### PR TITLE
SP-349/Feat: 회원 탈퇴 기능 추가

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/common/entity/BaseEntity.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/entity/BaseEntity.java
@@ -36,4 +36,7 @@ public abstract class BaseEntity {
 		return deletedDateTime != null;
 	}
 
+	public void softDelete() {
+		deletedDateTime = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/controller/UserController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/controller/UserController.java
@@ -1,0 +1,35 @@
+package com.ludo.study.studymatchingplatform.user.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ludo.study.studymatchingplatform.auth.common.AuthUser;
+import com.ludo.study.studymatchingplatform.auth.common.Redirection;
+import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
+import com.ludo.study.studymatchingplatform.user.domain.User;
+import com.ludo.study.studymatchingplatform.user.service.UserService;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+	private final UserService userService;
+
+	private final CookieProvider cookieProvider;
+
+	private final Redirection redirection;
+
+	@DeleteMapping("/users/deactivate")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void withdraw(@AuthUser User user, final HttpServletResponse response) {
+		userService.withdraw(user);
+		cookieProvider.clearAuthCookie(response);
+		redirection.to("/", response);
+	}
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/service/UserService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/service/UserService.java
@@ -1,0 +1,32 @@
+package com.ludo.study.studymatchingplatform.user.service;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.ludo.study.studymatchingplatform.study.service.exception.NotFoundException;
+import com.ludo.study.studymatchingplatform.user.domain.User;
+import com.ludo.study.studymatchingplatform.user.repository.UserRepositoryImpl;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserService {
+
+	private final UserRepositoryImpl userRepository;
+
+	public void withdraw(final User user) {
+
+		final User foundUser = userRepository.findById(user.getId())
+				.orElseThrow(() -> new NotFoundException("가입되지 않은 회원입니다."));
+
+		if (foundUser.isDeleted()) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT, "비활성화 된 회원입니다. 복구하시려면 해당 계정으로 다시 회원 가입을 시도해주세요.");
+		}
+
+		user.softDelete();
+	}
+}


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

회원 탈퇴 기능을 추가하였습니다.

현재 구현된 코드의 정책은 다음과 같습니다.

1. 회원 탈퇴는 기본적으로 soft delete로 진행한다.
2. 회원 탈퇴된 계정은 실제 DB에서 제거되는 것이 아니며, **정해진 기간**동안 사용자의 의향에 따라 복구가 가능하다.
3. 이미 탈퇴한 계정으로 탈퇴를 시도하는 경우
-> 복구가 불가능하기 때문에 404 NotFound
4. 비활성화 된 계정으로 탈퇴를 시도하는 경우
-> 이미 soft delete 처리된 계정에 대한 충돌이므로, 회원 가입을 재시도 하여 계정을 복구하라는 오류와 함께 409 Conflict
5. 탈퇴 성공 시
-204 NoContent -> res body가 없는 성공이므로. 향후 응답 공통 템플릿이 완성되면 변경 가능성O