### PR TITLE
Sp 213/Refactor: 스터디 생성시 항목 추가

### DIFF
--- a/.idea/modules/com.ludo.study.study-matching-platform.main.iml
+++ b/.idea/modules/com.ludo.study.study-matching-platform.main.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="CheckStyle-IDEA-Module" serialisationVersion="2">
+    <option name="activeLocationsIds" />
+  </component>
+  <component name="SonarLintModuleSettings">
+    <option name="uniqueId" value="3aabc05e-7d6e-4b20-9f9c-a35bed2adcc5" />
+  </component>
+</module>

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/Platform.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/Platform.java
@@ -1,0 +1,8 @@
+package com.ludo.study.studymatchingplatform.study.domain;
+
+public enum Platform {
+
+	GATHER,
+	GOOGLE_MEAT
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/Study.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/Study.java
@@ -53,6 +53,10 @@ public class Study extends BaseEntity {
 	@JoinColumn(name = "owner_id", nullable = false)
 	private User owner;
 
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, columnDefinition = "char(20)")
+	private Platform platform;
+
 	@Column(nullable = false, length = 50)
 	private String title;
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/StudyCreateService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/StudyCreateService.java
@@ -25,7 +25,7 @@ public class StudyCreateService {
 	@Transactional
 	public Study create(final WriteStudyRequest request, final User user) {
 		final Category category = findCategoryById(request.categoryId());
-		final Study study = request.toStudy(user, category);
+		final Study study = request.toStudy(user, category, request.platform());
 		studyRepository.save(study);
 		participantService.add(study, user);
 		return study;

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/request/WriteStudyRequest.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/request/WriteStudyRequest.java
@@ -3,6 +3,7 @@ package com.ludo.study.studymatchingplatform.study.service.dto.request;
 import java.time.LocalDateTime;
 
 import com.ludo.study.studymatchingplatform.study.domain.Category;
+import com.ludo.study.studymatchingplatform.study.domain.Platform;
 import com.ludo.study.studymatchingplatform.study.domain.Study;
 import com.ludo.study.studymatchingplatform.study.domain.StudyStatus;
 import com.ludo.study.studymatchingplatform.study.domain.Way;
@@ -15,19 +16,22 @@ public record WriteStudyRequest(
 
 		String title,
 		Long categoryId,
+		Long positionId,
 		Way way,
+		Platform platform,
 		Integer participantLimit,
 		LocalDateTime startDateTime,
 		LocalDateTime endDateTime
 
 ) {
 
-	public Study toStudy(final User owner, final Category category) {
+	public Study toStudy(final User owner, final Category category, final Platform platform) {
 		return Study.builder()
 				.status(StudyStatus.RECRUITING)
 				.title(title)
 				.category(category)
 				.owner(owner)
+				.platform(platform)
 				.way(way)
 				.participantLimit(participantLimit)
 				.startDateTime(startDateTime)

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/WriteStudyResponse.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/WriteStudyResponse.java
@@ -3,6 +3,7 @@ package com.ludo.study.studymatchingplatform.study.service.dto.response;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.ludo.study.studymatchingplatform.study.domain.Platform;
 import com.ludo.study.studymatchingplatform.study.domain.Study;
 import com.ludo.study.studymatchingplatform.study.domain.StudyStatus;
 import com.ludo.study.studymatchingplatform.study.domain.Way;
@@ -18,6 +19,7 @@ public record WriteStudyResponse(
 		CategoryResponse category,
 		UserResponse owner,
 		String title,
+		Platform platform,
 		List<ParticipantResponse> participants,
 		Way way,
 		Integer participantLimit,
@@ -41,6 +43,7 @@ public record WriteStudyResponse(
 				.category(category)
 				.owner(owner)
 				.title(study.getTitle())
+				.platform(study.getPlatform())
 				.participants(participants)
 				.way(study.getWay())
 				.participantLimit(study.getParticipantLimit())

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/service/CreateStudyServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/service/CreateStudyServiceTest.java
@@ -1,0 +1,74 @@
+package com.ludo.study.studymatchingplatform.study.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.ludo.study.studymatchingplatform.study.domain.Category;
+import com.ludo.study.studymatchingplatform.study.domain.Platform;
+import com.ludo.study.studymatchingplatform.study.domain.Study;
+import com.ludo.study.studymatchingplatform.study.domain.StudyStatus;
+import com.ludo.study.studymatchingplatform.study.domain.Way;
+import com.ludo.study.studymatchingplatform.study.fixture.CategoryFixture;
+import com.ludo.study.studymatchingplatform.study.repository.CategoryRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.service.dto.request.WriteStudyRequest;
+import com.ludo.study.studymatchingplatform.user.domain.Social;
+import com.ludo.study.studymatchingplatform.user.domain.User;
+import com.ludo.study.studymatchingplatform.user.repository.UserRepositoryImpl;
+
+@SpringBootTest
+class CreateStudyServiceTest {
+
+	@Autowired
+	private UserRepositoryImpl userRepository;
+
+	@Autowired
+	private CategoryRepositoryImpl categoryRepository;
+
+	@Autowired
+	private StudyCreateService studyCreateService;
+
+	@Test
+	void 사용자는_스터디를_생성할_수_있어야_한다() {
+		// given
+		final User owner = userRepository.save(
+				User.builder()
+						.nickname("owner")
+						.email("aaa@kakao.com")
+						.social(Social.KAKAO)
+						.build());
+
+		final Category category = categoryRepository.save(
+				CategoryFixture.createCategory("category1"));
+
+		final WriteStudyRequest request = WriteStudyRequest.builder()
+				.title("create study test.")
+				.categoryId(category.getId())
+				.way(Way.ONLINE)
+				.platform(Platform.GATHER)
+				.participantLimit(3)
+				.startDateTime(LocalDateTime.now())
+				.endDateTime(LocalDateTime.now().plusMonths(3))
+				.build();
+
+		// when
+		final Study study = studyCreateService.create(request, owner);
+
+		// then
+		assertThat(study.getTitle()).isEqualTo("create study test.");
+		assertThat(study.getOwner().getId()).isEqualTo(owner.getId());
+		assertThat(study.getCategory().getId()).isEqualTo(1);
+		assertThat(study.getWay()).isEqualTo(Way.ONLINE);
+		assertThat(study.getStatus()).isEqualTo(StudyStatus.RECRUITING);
+		assertThat(study.getPlatform()).isEqualTo(Platform.GATHER);
+		assertThat(study.getParticipantLimit()).isEqualTo(3);
+		assertThat(study.getParticipantCount()).isEqualTo(1);
+		assertThat(study.getParticipants().size()).isEqualTo(1);
+		assertThat(study.getRecruitment()).isNull();
+	}
+
+}


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 스터디 생성시 요청 / 응답 항목 추가했습니다.
- 스터디 생성에 대한 테스트 케이스를 작성했습니다.

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.
```java
@Builder
public record WriteStudyRequest(

		String title,
		Long categoryId,
		Long positionId, // mypage API PR과 통합되면 정상 작동 합니다.
		Way way,
		Platform platform,
		Integer participantLimit,
		LocalDateTime startDateTime,
		LocalDateTime endDateTime

) {

@Builder
public record WriteStudyResponse(

		Long id,
		StudyStatus status,
		CategoryResponse category,
		UserResponse owner,
		String title,
		Platform platform,
		List<ParticipantResponse> participants,
		Way way,
		Integer participantLimit,
		Integer participantCount,
		LocalDateTime startDateTime,
		LocalDateTime endDateTime

) {
```

- **Way와 같은 맥락이라고 생각하여 Enum으로 구현했습니다.**
```java
@Entity
@Getter
@SuperBuilder
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@AllArgsConstructor
public class Study extends BaseEntity {

	@Id
	@GeneratedValue(strategy = GenerationType.IDENTITY)
	@Column(name = "study_id")
	private Long id;

	@Enumerated(EnumType.STRING)
	@Column(nullable = false, columnDefinition = "char(10)")
	private StudyStatus status;

	@ManyToOne(fetch = LAZY)
	@JoinColumn(name = "category_id", nullable = false)
	private Category category;

	@ManyToOne(fetch = LAZY)
	@JoinColumn(name = "owner_id", nullable = false)
	private User owner;

	@Enumerated(EnumType.STRING)
	@Column(nullable = false, columnDefinition = "char(20)")
	private Platform platform;
```

<br><br>

### ✅ 셀프 체크리스트

- [X] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [X] 커밋 메세지를 컨벤션에 맞추었습니다.
- [X] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [X] 변경 후 코드는 기존의 테스트를 통과합니다.
- [X] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [X] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
