### PR TITLE
feature: 모집 공고 수정 및 Recruitment 연결 테이블 관련 테스트

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/study/Participant.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/Participant.java
@@ -1,8 +1,6 @@
-package com.ludo.study.studymatchingplatform.study.domain;
+package com.ludo.study.studymatchingplatform.study;
 
-import static jakarta.persistence.FetchType.*;
-
-import java.util.Objects;
+import static jakarta.persistence.FetchType.LAZY;
 
 import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
 import com.ludo.study.studymatchingplatform.study.domain.id.ParticipantId;
@@ -47,34 +45,12 @@ public class Participant extends BaseEntity {
 	)
 	private User user;
 
-	@ManyToOne
-	@JoinColumn(name = "position_id")
-	private Position position;
-
-	public static Participant from(final Study study, final User user, final Position position) {
+	public static Participant from(final Study study, final User user) {
 		final Participant participant = new Participant();
 		participant.study = study;
 		participant.user = user;
-		participant.position = position;
+
 		return participant;
 	}
 
-	public String getRole() {
-		// TODO: Role spec not determined clearly
-		if (study.isOwner(this)) {
-			return "Owner";
-		}
-		return "Participant";
-	}
-
-	public boolean matchesUser(final User user) {
-		final boolean isMatchesUser = Objects.equals(this.user.getId(), user.getId());
-		return isMatchesUser && !isDeleted();
-	}
-
-	public void leave(final Study study) {
-		study.removeParticipant(this);
-		this.study = null;
-		this.softDelete();
-	}
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/recruitment/Recruitment.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/recruitment/Recruitment.java
@@ -1,24 +1,12 @@
 package com.ludo.study.studymatchingplatform.study.domain.recruitment;
 
-import static jakarta.persistence.FetchType.*;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
-
+import static jakarta.persistence.FetchType.LAZY;
 import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
 import com.ludo.study.studymatchingplatform.study.domain.Position;
 import com.ludo.study.studymatchingplatform.study.domain.Study;
-import com.ludo.study.studymatchingplatform.study.domain.recruitment.id.ApplicantId;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.id.RecruitmentStackId;
 import com.ludo.study.studymatchingplatform.study.domain.stack.Stack;
 import com.ludo.study.studymatchingplatform.user.domain.User;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -31,283 +19,316 @@ import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-import lombok.extern.slf4j.Slf4j;
 
 @Entity
 @Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@SQLDelete(sql = "UPDATE recruitment SET deleted_date_time = NOW() WHERE recruitment_id = ?")
-@SQLRestriction("deleted_date_time is null")
-@ToString(of = {"id", "title"}, callSuper = true)
-@Slf4j
+// @SQLDelete(sql = "UPDATE recruitment SET deleted_date_time = NOW() WHERE recruitment_id = ?")
+// @SQLRestriction("deleted_date_time is null")
 public class Recruitment extends BaseEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "recruitment_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recruitment_id")
+    private Long id;
 
-	@OneToOne(fetch = LAZY)
-	@JoinColumn(name = "study_id", nullable = false)
-	private Study study;
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "study_id", nullable = false)
+    private Study study;
 
-	@OneToMany(fetch = LAZY, mappedBy = "recruitment", cascade = CascadeType.ALL, orphanRemoval = true)
-	@Builder.Default
-	private List<Applicant> applicants = new ArrayList<>();
+    @OneToMany(fetch = LAZY, mappedBy = "recruitment", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Applicant> applicants = new ArrayList<>();
 
-	@OneToMany(fetch = LAZY, mappedBy = "recruitment", cascade = CascadeType.ALL, orphanRemoval = true)
-	@Builder.Default
-	private List<RecruitmentStack> recruitmentStacks = new ArrayList<>();
+    @OneToMany(fetch = LAZY, mappedBy = "recruitment", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<RecruitmentStack> recruitmentStacks = new ArrayList<>();
 
-	@OneToMany(fetch = LAZY, mappedBy = "recruitment", cascade = CascadeType.ALL, orphanRemoval = true)
-	@Builder.Default
-	private List<RecruitmentPosition> recruitmentPositions = new ArrayList<>();
+    @OneToMany(fetch = LAZY, mappedBy = "recruitment", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<RecruitmentPosition> recruitmentPositions = new ArrayList<>();
 
-	@Column(nullable = false, length = 2048)
-	@Size(max = 2048)
-	private String callUrl;
+    @Column(nullable = false, length = 2048)
+    @Size(max = 2048)
+    private String callUrl;
 
-	@Column(nullable = false, length = 50)
-	@Size(max = 50)
-	private String title;
+    @Column(nullable = false, length = 50)
+    @Size(max = 50)
+    private String title;
 
-	@Column(nullable = false, length = 2000)
-	@Size(max = 2000)
-	private String content;
+    @Column(nullable = false, length = 2000)
+    @Size(max = 2000)
+    private String content;
 
-	@Column(nullable = false)
-	@PositiveOrZero
-	@Builder.Default
-	private int hits = 0;
+    @Column(nullable = false)
+    @PositiveOrZero
+    @Builder.Default
+    private int hits = 0;
 
-	@Column(nullable = false)
-	@FutureOrPresent
-	private LocalDateTime recruitmentEndDateTime;
+    @Column(nullable = false)
+    @FutureOrPresent
+    private LocalDateTime recruitmentEndDateTime;
 
-	@Column(nullable = false)
-	@PositiveOrZero
-	private int recruitmentLimit;
+    @Column(nullable = false)
+    @PositiveOrZero
+    private int recruitmentLimit;
 
-	public static Recruitment of(
-			final String title,
-			final String content,
-			final String callUrl,
-			final int hits,
-			final int recruitmentLimit,
-			final LocalDateTime recruitmentEndDateTime,
-			final Study study
-	) {
-		return Recruitment.builder()
-				.title(title)
-				.content(content)
-				.callUrl(callUrl)
-				.hits(hits)
-				.recruitmentLimit(recruitmentLimit)
-				.recruitmentEndDateTime(recruitmentEndDateTime)
-				.study(study)
-				.build();
-	}
+    public static Recruitment of(
+        final String title,
+        final String content,
+        final String callUrl,
+        final int hits,
+        final int recruitmentLimit,
+        final LocalDateTime recruitmentEndDateTime,
+        final Study study
+    ) {
+        return Recruitment.builder()
+            .title(title)
+            .content(content)
+            .callUrl(callUrl)
+            .hits(hits)
+            .recruitmentLimit(recruitmentLimit)
+            .recruitmentEndDateTime(recruitmentEndDateTime)
+            .study(study)
+            .build();
+    }
 
-	@Deprecated
-	public void connectToStudy(Study study) {
-		this.study = study;
-	}
+    @Deprecated
+    public void connectToStudy(Study study) {
+        this.study = study;
+    }
 
-	/***
-	 *
-	 * @param recruitmentStack
-	 * 어플리케이션 레벨에서 데이터 정합성 유지
-	 */
-	public void addRecruitmentStack(RecruitmentStack recruitmentStack) {
-		this.recruitmentStacks
-				.add(recruitmentStack);
-	}
+    /***
+     *
+     * @param recruitmentStack
+     * 어플리케이션 레벨에서 데이터 정합성 유지
+     */
+    public void addRecruitmentStack(RecruitmentStack recruitmentStack) {
+        this.recruitmentStacks
+            .add(recruitmentStack);
+    }
 
-	public void addPosition(RecruitmentPosition recruitmentPosition) {
-		this.recruitmentPositions
-				.add(recruitmentPosition);
-	}
+    public void addPosition(RecruitmentPosition recruitmentPosition) {
+        this.recruitmentPositions
+            .add(recruitmentPosition);
+    }
 
-	public void upHit() {
-		hits++;
-	}
+    public void upHit() {
+        hits++;
+    }
 
-	public List<String> getStackNames() {
-		return recruitmentStacks.stream()
-				.map(recruitmentStack -> recruitmentStack.getStack().getName())
-				.toList();
-	}
+    public List<String> getStackNames() {
+        return recruitmentStacks.stream()
+            .map(recruitmentStack -> recruitmentStack.getStack().getName())
+            .toList();
+    }
 
-	public List<String> getPositionNames() {
-		return recruitmentPositions.stream()
-				.map(recruitmentPosition -> recruitmentPosition.getPosition().getName())
-				.toList();
-	}
+    public List<String> getPositionNames() {
+        return recruitmentPositions.stream()
+            .map(recruitmentPosition -> recruitmentPosition.getPosition().getName())
+            .toList();
+    }
 
-	public void addRecruitmentStacks(final List<RecruitmentStack> recruitmentStacks) {
-		this.recruitmentStacks.addAll(recruitmentStacks);
-	}
+    public void addRecruitmentStacks(final List<RecruitmentStack> recruitmentStacks) {
+        this.recruitmentStacks.addAll(recruitmentStacks);
+    }
 
-	public void addRecruitmentPositions(final List<RecruitmentPosition> recruitmentPositions) {
-		this.recruitmentPositions.addAll(recruitmentPositions);
-	}
+    public void addRecruitmentPositions(final List<RecruitmentPosition> recruitmentPositions) {
+        this.recruitmentPositions.addAll(recruitmentPositions);
+    }
 
-	public void edit(
-			final String title,
-			final String content,
-			final String callUrl,
-			final Integer recruitmentLimit,
-			final LocalDateTime recruitmentEndDateTime
-	) {
-		if (title != null) {
-			this.title = title;
-		}
-		if (content != null) {
-			this.content = content;
-		}
-		if (callUrl != null) {
-			this.callUrl = callUrl;
-		}
-		if (recruitmentLimit != null) {
-			this.recruitmentLimit = recruitmentLimit;
-		}
-		if (recruitmentEndDateTime != null) {
-			this.recruitmentEndDateTime = recruitmentEndDateTime;
-		}
-	}
+    public void edit(
+        final String title,
+        final String content,
+        final String callUrl,
+        final Integer recruitmentLimit,
+        final LocalDateTime recruitmentEndDateTime
+    ) {
+        if (title != null) {
+            this.title = title;
+        }
+        if (content != null) {
+            this.content = content;
+        }
+        if (callUrl != null) {
+            this.callUrl = callUrl;
+        }
+        if (recruitmentLimit != null) {
+            this.recruitmentLimit = recruitmentLimit;
+        }
+        if (recruitmentEndDateTime != null) {
+            this.recruitmentEndDateTime = recruitmentEndDateTime;
+        }
+    }
 
-	public Optional<RecruitmentStack> getRecruitmentStack(final Stack stack) {
-		return recruitmentStacks.stream()
-				.filter(r -> r.getStack().equals(stack))
-				.findFirst();
-	}
+    public Optional<RecruitmentStack> getRecruitmentStack(final Stack stack) {
+        return recruitmentStacks.stream()
+            .filter(r -> r.getStack().equals(stack))
+            .findFirst();
+    }
 
-	public Optional<RecruitmentPosition> getRecruitmentPosition(final Position position) {
-		return recruitmentPositions.stream()
-				.filter(r -> r.getPosition().equals(position))
-				.findFirst();
-	}
+    public Optional<RecruitmentPosition> getRecruitmentPosition(final Position position) {
+        return recruitmentPositions.stream()
+            .filter(r -> r.getPosition().equals(position))
+            .findFirst();
+    }
 
-	public void removeRecruitmentStack(final RecruitmentStack recruitmentStack) {
-		recruitmentStacks.remove(recruitmentStack);
-	}
+    public void removeRecruitmentStack(final RecruitmentStack recruitmentStack) {
+        recruitmentStacks.remove(recruitmentStack);
+    }
 
-	public void removeRecruitmentPosition(final RecruitmentPosition recruitmentPosition) {
-		recruitmentPositions.remove(recruitmentPosition);
-	}
+    public void removeRecruitmentPosition(final RecruitmentPosition recruitmentPosition) {
+        recruitmentPositions.remove(recruitmentPosition);
+    }
 
-	public boolean hasStacks(final Stack stack) {
-		return recruitmentStacks.stream()
-				.anyMatch(r -> r.getStack().equals(stack));
-	}
+    public boolean hasStacks(final Stack stack) {
+        return recruitmentStacks.stream()
+            .anyMatch(r -> r.getStack().equals(stack));
+    }
 
-	public boolean hasPosition(final Position position) {
-		return recruitmentPositions.stream()
-				.anyMatch(r -> r.getPosition().equals(position));
-	}
+    public boolean hasPosition(final Position position) {
+        return recruitmentPositions.stream()
+            .anyMatch(r -> r.getPosition().equals(position));
+    }
 
-	public void ensureEditable(final User user) {
-		if (!isOwner(user)) {
-			throw new IllegalArgumentException("모집 공고를 작성할 권한이 없습니다.");
-		}
-	}
+    public void ensureEditable(final User user) {
+        if (!isOwner(user)) {
+            throw new IllegalArgumentException("모집 공고를 작성할 권한이 없습니다.");
+        }
+    }
 
-	public void ensureApplicable(final User user) {
-		if (study.isOwner(user)) {
-			throw new IllegalArgumentException("스터디장은 자신의 스터디에 지원할 수 없습니다.");
-		}
-		applicants.stream()
-				.filter(a -> a.equals(user))
-				.findFirst()
-				.ifPresent(Applicant::ensureApplicable);
-	}
+    public void ensureApplicable(final User user) {
+        if (study.isOwner(user)) {
+            throw new IllegalArgumentException("스터디장은 자신의 스터디에 지원할 수 없습니다.");
+        }
+        applicants.stream()
+            .filter(a -> a.equals(user))
+            .findFirst()
+            .ifPresent(Applicant::ensureApplicable);
+    }
 
-	public Optional<Applicant> findApplicant(final User user) {
-		return applicants.stream()
-				.filter(a -> a.getUser().equals(user))
-				.findFirst();
-	}
+    public Optional<Applicant> findApplicant(final User user) {
+        return applicants.stream()
+            .filter(a -> a.getUser().equals(user))
+            .findFirst();
+    }
 
-	public boolean isOwner(final User user) {
-		return study.isOwner(user);
-	}
+    public boolean isOwner(final User user) {
+        return study.isOwner(user);
+    }
 
-	/** helper method */
-	public void addApplicant(final Applicant applicant) {
-		applicant.connectToRecruitment(this);
-		applicants.add(applicant);
-	}
+    public void addApplicant(final Applicant applicant) {
+        applicant.connectToRecruitment(this);
+        applicants.add(applicant);
+    }
 
-	public void ensureRecruiting() {
-		study.ensureRecruiting();
-	}
+    public void ensureRecruiting() {
+        study.ensureRecruiting();
+    }
 
-	public void updateStacks(final Set<Stack> nextStacks) {
-	}
+    public void updateStacks(final Set<Stack> nextStacks) {
+    }
 
-	public List<Stack> getAddedRecruitmentStacks(final Set<Stack> nextStacks) {
-		final List<Stack> stacks = getStacks();
+    public List<Stack> getAddedStacks(final Set<Stack> nextStacks) {
+        final List<Stack> stacks = getStacks();
 
-		return nextStacks.stream()
-				.filter(nextStack -> !stacks.contains(nextStack))
-				.toList();
-	}
+        return nextStacks.stream()
+            .filter(nextStack -> !stacks.contains(nextStack))
+            .toList();
+    }
 
-	public List<Stack> getRemovedRecruitmentStacks(final Set<Stack> nextStacks) {
-		final List<Stack> prevStacks = getStacks();
+    // public List<Stack> getRemovedRecruitmentStackIds(final Set<Stack> nextStacks) {
+    // 	final List<Stack> prevStacks = getStacks();
+    //
+    // 	final List<Stack> removedStacks = prevStacks.stream()
+    // 			.filter(nextStacks::contains)
+    // 			.toList();
+    //
+    // 	return recruitmentStacks.stream()
+    // 			.filter(recruitmentStack -> removedStacks.contains(recruitmentStack.getStack()))
+    // 			.map(RecruitmentStack::getId)
+    // 			.toList();
+    // }
 
-		return prevStacks.stream()
-				.filter(nextStacks::contains)
-				.toList();
-	}
+    public List<RecruitmentStackId> getRemovedRecruitmentStackIds(final Set<Stack> nextStacks) {
+        final List<Stack> prevStacks = getStacks();
 
-	public List<Stack> getStacks() {
-		return recruitmentStacks.stream()
-				.map(RecruitmentStack::getStack)
-				.toList();
-	}
+        final List<Stack> removedStacks = prevStacks.stream()
+            .filter(nextStacks::contains)
+            .toList();
 
-	public void ensureCorrectApplicantUser(final User applicantUser) {
-		if (!containsApplicantUser(applicantUser)) {
-			throw new IllegalStateException("지원자 목록에 존재하지 않는 사용자입니다.");
-		}
-	}
+        return recruitmentStacks.stream()
+            .filter(recruitmentStack -> removedStacks.contains(recruitmentStack.getStack()))
+            .map(RecruitmentStack::getId)
+            .toList();
+    }
 
-	private boolean containsApplicantUser(final User applicantUser) {
-		return applicants.stream()
-				.anyMatch(applicant -> applicant.getUser().equals(applicantUser));
-	}
+    public List<Stack> getStacks() {
+        return recruitmentStacks.stream()
+            .map(RecruitmentStack::getStack)
+            .toList();
+    }
 
-	public void acceptApplicant(final User applicantUser) {
-		final Applicant applicant = getApplicant(applicantUser);
-		applicant.changeStatus(ApplicantStatus.ACCEPTED);
-	}
+    public void removeRecruitmentStacksNotIn(final Set<Stack> nextStacks) {
+        final List<Stack> prevStacks = getStacks();
 
-	public void rejectApplicant(final User applicantUser) {
-		final Applicant applicant = getApplicant(applicantUser);
-		applicant.changeStatus(ApplicantStatus.REJECTED);
-	}
+        for (final Stack prevStack : prevStacks) {
+            if (!nextStacks.contains(prevStack)) {
+                recruitmentStacks.removeIf(recruitmentStack -> recruitmentStack.hasStack(prevStack));
+            }
+        }
+    }
 
-	public Applicant getApplicant(final User applicantUser) {
-		ApplicantId applicantId = new ApplicantId(id, applicantUser.getId());
+    public List<Position> getAddedPositions(final Set<Position> nextPositions) {
+        final List<Position> prevPositions = getPositions();
 
-		return applicants.stream()
-				.filter(applicant -> applicant.getId().equals(applicantId))
-				.findFirst()
-				.orElseThrow(() -> new IllegalStateException("지원하지 않은 사용자입니다."));
-	}
+        return nextPositions.stream()
+            .filter(nextPosition -> !prevPositions.contains(nextPosition))
+            .toList();
+    }
 
-	public boolean isIdEquals(final Long recruitmentId) {
-		return Objects.equals(this.id, recruitmentId);
-	}
+    private List<Position> getPositions() {
+        return recruitmentPositions.stream()
+            .map(RecruitmentPosition::getPosition)
+            .toList();
+    }
 
+    public void removeRecruitmentPositionsNotIn(final Set<Position> nextPositions) {
+        final List<Position> prevPositions = getPositions();
+
+        for (final Position prevPosition : prevPositions) {
+            if (!nextPositions.contains(prevPosition)) {
+                recruitmentPositions.removeIf(recruitmentPosition -> recruitmentPosition.hasPosition(prevPosition));
+            }
+        }
+    }
+
+    public void validateDuplicateStacks(final List<Stack> stacks) {
+        final boolean isDuplicateStack = this.recruitmentStacks.stream()
+            .anyMatch(r -> stacks.contains(r.getStack()));
+        if (isDuplicateStack) {
+            throw new IllegalArgumentException("이미 존재하는 스택입니다.");
+        }
+    }
+
+    public void validateDuplicatePositions(final List<Position> positions) {
+        final boolean isDuplicatePosition = this.recruitmentPositions.stream()
+            .anyMatch(r -> positions.contains(r.getPosition()));
+        if (isDuplicatePosition) {
+            throw new IllegalArgumentException("이미 존재하는 포지션입니다.");
+        }
+    }
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/recruitment/RecruitmentPosition.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/recruitment/RecruitmentPosition.java
@@ -57,4 +57,7 @@ public class RecruitmentPosition extends BaseEntity {
 		this.recruitment.addPosition(this);
 	}
 
+	public boolean hasPosition(final Position position) {
+		return this.position.equals(position);
+	}
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/RecruitmentPositionService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/RecruitmentPositionService.java
@@ -1,34 +1,44 @@
 package com.ludo.study.studymatchingplatform.study.service;
 
-import java.util.List;
-import java.util.Set;
-
-import org.springframework.stereotype.Service;
-
 import com.ludo.study.studymatchingplatform.study.domain.Position;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.RecruitmentPosition;
+import com.ludo.study.studymatchingplatform.study.repository.PositionRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.repository.recruitment.RecruitmentPositionRepositoryImpl;
-
+import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class RecruitmentPositionService {
 
-	private final PositionService positionService;
-	private final RecruitmentPositionRepositoryImpl recruitmentPositionRepository;
+    private final PositionService positionService;
+    private final RecruitmentPositionRepositoryImpl recruitmentPositionRepository;
+    private final PositionRepositoryImpl positionRepository;
 
-	public void addMany(final Recruitment recruitment, final Set<Long> positionIds) {
-		final List<Position> positions = positionService.findAllByIdsOrThrow(positionIds);
+    public void addMany(final Recruitment recruitment, final Set<Long> positionIds) {
+        final List<Position> positions = positionService.findAllByIdsOrThrow(positionIds);
+        addRecruitmentPositionsIn(recruitment, positions);
+    }
 
-		final List<RecruitmentPosition> recruitmentPositions = positions.stream()
-				.map(position -> RecruitmentPosition.from(recruitment, position))
-				.toList();
+    public void update(final Recruitment recruitment, final Set<Long> positionIds) {
 
-		recruitment.addRecruitmentPositions(recruitmentPositionRepository.saveAll(recruitmentPositions));
-	}
+        final Set<Position> nextPositions = positionRepository.findByIdIn(positionIds);
+        final List<Position> addedPositions = recruitment.getAddedPositions(nextPositions);
 
-	public void update(Recruitment recruitment, Set<Long> positionIds) {
-	}
+        addRecruitmentPositionsIn(recruitment, addedPositions);
+        recruitment.removeRecruitmentPositionsNotIn(nextPositions);
+    }
+
+    private void addRecruitmentPositionsIn(final Recruitment recruitment, final List<Position> positions) {
+        recruitment.validateDuplicatePositions(positions);
+
+        final List<RecruitmentPosition> recruitmentPositions = positions.stream()
+            .map(position -> RecruitmentPosition.from(recruitment, position))
+            .toList();
+
+        recruitment.addRecruitmentPositions(recruitmentPositionRepository.saveAll(recruitmentPositions));
+    }
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/RecruitmentService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/RecruitmentService.java
@@ -1,18 +1,10 @@
 package com.ludo.study.studymatchingplatform.study.service;
 
-import java.util.Optional;
-import java.util.Set;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.ludo.study.studymatchingplatform.study.domain.Position;
 import com.ludo.study.studymatchingplatform.study.domain.Study;
 import com.ludo.study.studymatchingplatform.study.domain.StudyStatus;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Applicant;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.ApplicantStatus;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
-import com.ludo.study.studymatchingplatform.study.domain.stack.Stack;
 import com.ludo.study.studymatchingplatform.study.repository.PositionRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.repository.StudyRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.repository.recruitment.ApplicantRepositoryImpl;
@@ -20,133 +12,103 @@ import com.ludo.study.studymatchingplatform.study.repository.recruitment.Recruit
 import com.ludo.study.studymatchingplatform.study.repository.recruitment.RecruitmentRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.repository.recruitment.RecruitmentStackRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.repository.stack.StackRepositoryImpl;
-import com.ludo.study.studymatchingplatform.study.service.dto.request.ApplyRecruitmentRequest;
-import com.ludo.study.studymatchingplatform.study.service.dto.request.EditRecruitmentRequest;
-import com.ludo.study.studymatchingplatform.study.service.dto.request.WriteRecruitmentRequest;
+import com.ludo.study.studymatchingplatform.study.service.dto.EditRecruitmentRequest;
+import com.ludo.study.studymatchingplatform.study.service.dto.WriteRecruitmentRequest;
 import com.ludo.study.studymatchingplatform.user.domain.User;
-
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class RecruitmentService {
 
-	private final RecruitmentRepositoryImpl recruitmentRepository;
-	private final StudyRepositoryImpl studyRepository;
-	private final RecruitmentStackRepositoryImpl recruitmentStackRepository;
-	private final RecruitmentStackService recruitmentStackService;
-	private final RecruitmentPositionRepositoryImpl recruitmentPositionRepository;
-	private final RecruitmentPositionService recruitmentPositionService;
-	private final StackRepositoryImpl stackRepository;
-	private final PositionRepositoryImpl positionRepository;
-	private final ApplicantRepositoryImpl applicantRepository;
+    private final RecruitmentRepositoryImpl recruitmentRepository;
+    private final StudyRepositoryImpl studyRepository;
+    private final RecruitmentStackRepositoryImpl recruitmentStackRepository;
+    private final RecruitmentStackService recruitmentStackService;
+    private final RecruitmentPositionRepositoryImpl recruitmentPositionRepository;
+    private final RecruitmentPositionService recruitmentPositionService;
+    private final StackRepositoryImpl stackRepository;
+    private final PositionRepositoryImpl positionRepository;
+    private final ApplicantRepositoryImpl applicantRepository;
 
-	@Transactional
-	public Recruitment write(final User user, final WriteRecruitmentRequest request) {
-		final Study study = studyRepository.findByIdWithRecruitment(request.getStudyId())
-				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디입니다."));
+    @Transactional
+    public Recruitment write(final User user, final WriteRecruitmentRequest request) {
+        final Study study = studyRepository.findByIdWithRecruitment(request.getStudyId())
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디입니다."));
 
-		study.ensureRecruitmentWritableBy(user);
+        study.ensureRecruitmentWritableBy(user);
 
-		final Recruitment recruitment = request.toRecruitment(study);
-		recruitmentRepository.save(recruitment);
+        final Recruitment recruitment = request.toRecruitment(study);
+        recruitmentRepository.save(recruitment);
 
-		recruitmentStackService.addMany(recruitment, request.getStackIds());
-		recruitmentPositionService.addMany(recruitment, request.getPositionIds());
+        recruitmentStackService.addMany(recruitment, request.getStackIds());
+        recruitmentPositionService.addMany(recruitment, request.getPositionIds());
+        study.registerRecruitment(recruitment);
 
-		return recruitment;
-	}
+        return recruitment;
+    }
 
-	public Recruitment edit(final User user, final Long recruitmentId, final EditRecruitmentRequest request) {
-		final Recruitment recruitment = recruitmentRepository.findByIdWithStudy(recruitmentId)
-				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 모집 공고입니다."));
+    public Recruitment edit(final User user, final Long recruitmentId, final EditRecruitmentRequest request) {
+        final Recruitment recruitment = recruitmentRepository.findByIdWithStudy(recruitmentId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 모집 공고입니다."));
 
-		recruitment.ensureEditable(user);
+        recruitment.ensureEditable(user);
 
-		recruitmentStackService.update(recruitment, request.getStackIds());
-		recruitmentPositionService.update(recruitment, request.getPositionIds());
+        recruitmentStackService.update(recruitment, request.getStackIds());
+        recruitmentPositionService.update(recruitment, request.getPositionIds());
 
-		final Set<Stack> nextStacks = stackRepository.findByIdIn(request.getStackIds());
-		final Set<Position> nextPositions = positionRepository.findByIdIn(request.getPositionIds());
+        recruitment.edit(
+            request.getTitle(),
+            request.getContent(),
+            request.getCallUrl(),
+            request.getRecruitmentLimit(),
+            request.getRecruitmentEndDateTime()
+        );
 
-		for (final Stack stack : nextStacks) {
-			recruitment.getRecruitmentStack(stack)
-					.ifPresent(recruitmentStack -> {
-						recruitment.removeRecruitmentStack(recruitmentStack);
-						recruitmentStackRepository.deleteById(recruitmentStack.getId());
-					});
-		}
+        return recruitment;
+    }
 
-		for (final Position position : nextPositions) {
-			recruitment.getRecruitmentPosition(position)
-					.ifPresent(recruitmentPosition -> {
-						recruitment.removeRecruitmentPosition(recruitmentPosition);
-						recruitmentPositionRepository.deleteById(recruitmentPosition.getId());
-					});
-		}
+    public Applicant apply(final User user, final long recruitmentId) {
+        final Recruitment recruitment = recruitmentRepository.findByIdWithStudy(recruitmentId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 모집 공고입니다."));
+        recruitment.ensureRecruiting();
 
-		recruitment.edit(
-				request.getTitle(),
-				request.getContent(),
-				request.getCallUrl(),
-				request.getRecruitmentLimit(),
-				request.getRecruitmentEndDateTime()
-		);
+        final Optional<Applicant> applicant = recruitment.findApplicant(user);
 
-		return recruitment;
-	}
+        if (applicant.isEmpty()) {
+            final Applicant newApplicant = Applicant.of(recruitment, user);
+            applicantRepository.save(newApplicant);
+            final Applicant savedApplicant = applicantRepository.save(newApplicant);
+            recruitment.addApplicant(savedApplicant);
 
-	public Applicant apply(final User user,
-						   final long recruitmentId,
-						   final ApplyRecruitmentRequest request) {
-		final Recruitment recruitment = recruitmentRepository.findByIdWithStudy(recruitmentId)
-				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디 입니다."));
-		recruitment.ensureRecruiting();
+            return savedApplicant;
+        } else {
+            final Applicant reapplicant = applicant.get();
+            reapplicant.ensureApplicable();
+            reapplicant.reapply();
 
-		final Optional<Applicant> applicant = recruitment.findApplicant(user);
-		final Position position = positionRepository.findById(request.positionId());
-		if (applicant.isEmpty()) {
-			final Applicant newApplicant = Applicant.of(recruitment, user, position);
-			applicantRepository.save(newApplicant);
-			final Applicant savedApplicant = applicantRepository.save(newApplicant);
-			recruitment.addApplicant(savedApplicant);
+            return reapplicant;
+        }
 
-			return savedApplicant;
-		} else {
-			final Applicant reapplicant = applicant.get();
-			reapplicant.ensureApplicable();
-			reapplicant.reapply();
+    }
 
-			return reapplicant;
-		}
+    public Applicant cancel(final User user, final long recruitmentId) {
+        final Recruitment recruitment = recruitmentRepository.findByIdWithStudy(recruitmentId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 모집 공고입니다."));
+        recruitment.ensureRecruiting();
 
-	}
+        final Applicant applicant = recruitment.findApplicant(user)
+            .orElseThrow(() -> new IllegalArgumentException("지원한 적 없는 모집 공고입니다."));
 
-	public Applicant cancel(final User user, final long recruitmentId) {
-		final Recruitment recruitment = recruitmentRepository.findByIdWithStudy(recruitmentId)
-				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 모집 공고입니다."));
-		recruitment.ensureRecruiting();
+        final StudyStatus studyStatus = recruitment.getStudy().getStatus();
+        applicant.ensureCancellable(studyStatus);
+        applicant.changeStatus(ApplicantStatus.CANCELLED);
 
-		final Applicant applicant = recruitment.findApplicant(user)
-				.orElseThrow(() -> new IllegalArgumentException("지원한 적 없는 모집 공고입니다."));
-
-		final StudyStatus studyStatus = recruitment.getStudy().getStatus();
-		applicant.ensureCancellable(studyStatus);
-		applicant.changeStatus(ApplicantStatus.CANCELLED);
-
-		return applicant;
-	}
-
-	public void delete(final User user, final Long studyId) {
-		final Study study = studyRepository.findByIdWithRecruitment(studyId)
-				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디 입니다."));
-
-		study.ensureRecruitmentDeletable(user);
-
-		final Recruitment recruitment = study.getRecruitment();
-
-		recruitmentRepository.delete(recruitment);
-	}
+        return applicant;
+    }
 
 }

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/service/RecruitmentPositionServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/service/RecruitmentPositionServiceTest.java
@@ -1,0 +1,309 @@
+package com.ludo.study.studymatchingplatform.study.service;
+
+package com.ludo.study.studymatchingplatform.study.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import com.ludo.study.studymatchingplatform.study.domain.Category;
+import com.ludo.study.studymatchingplatform.study.domain.Position;
+import com.ludo.study.studymatchingplatform.study.domain.Study;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.RecruitmentPosition;
+import com.ludo.study.studymatchingplatform.study.fixture.CategoryFixture;
+import com.ludo.study.studymatchingplatform.study.fixture.PositionFixture;
+import com.ludo.study.studymatchingplatform.study.fixture.StudyFixture;
+import com.ludo.study.studymatchingplatform.study.repository.CategoryRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.PositionRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.StudyRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.service.dto.WriteRecruitmentRequest;
+import com.ludo.study.studymatchingplatform.user.domain.Social;
+import com.ludo.study.studymatchingplatform.user.domain.User;
+import com.ludo.study.studymatchingplatform.user.repository.UserRepositoryImpl;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class RecruitmentPositionServiceTest {
+
+	@Autowired
+	private StudyRepositoryImpl studyRepository;
+
+	@Autowired
+	private UserRepositoryImpl userRepository;
+
+	@Autowired
+	private CategoryRepositoryImpl categoryRepository;
+
+	@Autowired
+	private PositionRepositoryImpl positionRepository;
+
+	@Autowired
+	private RecruitmentService recruitmentService;
+
+	@Autowired
+	private RecruitmentPositionService recruitmentPositionService;
+
+	@DisplayName("모집 공고에 등록하지 않은 포지션을 추가할 수 있다.")
+	@Test
+	void createRecruitmentPositionSuccess() {
+
+		// given
+		final User owner = userRepository.save(
+				User.builder()
+						.nickname("owner")
+						.email("a@aa.aa")
+						.social(Social.KAKAO)
+						.build());
+
+		final Category category = categoryRepository.save(
+				CategoryFixture.createCategory("category1"));
+
+		final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+						"study",
+						category,
+						owner,
+						4
+				)
+		);
+
+		final WriteRecruitmentRequest request = WriteRecruitmentRequest.builder()
+				.studyId(study.getId())
+				.title("recruitment")
+				.content("I want to study")
+				.stackIds(Set.of())
+				.positionIds(Set.of())
+				.recruitmentLimit(4)
+				.callUrl("x.com")
+				.recruitmentEndDateTime(LocalDateTime.now().plusMonths(3))
+				.build();
+
+		final Recruitment recruitment = recruitmentService.write(owner, request);
+
+		final Position position1 = positionRepository.save(PositionFixture.createPosition("position1"));
+		final Position position2 = positionRepository.save(PositionFixture.createPosition("position2"));
+		final Position position3 = positionRepository.save(PositionFixture.createPosition("position3"));
+
+		// when
+		recruitmentPositionService.addMany(recruitment,
+				Set.of(position1.getId(), position2.getId(), position3.getId()));
+		final List<RecruitmentPosition> recruitmentPositions = recruitment.getRecruitmentPositions();
+
+		// then
+		assertThat(recruitmentPositions).hasSize(3);
+		assertThat(recruitmentPositions).extracting("position")
+				.containsAll(List.of(position1, position2, position3));
+
+	}
+
+	@DisplayName("모집 공고에 이미 등록된 포지션을 중복해서 추가하면 예외 발생")
+	@Test
+	void createRecruitmentPositionFailure() {
+
+		// given
+		final User owner = userRepository.save(
+				User.builder()
+						.nickname("owner")
+						.email("a@aa.aa")
+						.social(Social.KAKAO)
+						.build());
+
+		final Category category = categoryRepository.save(
+				CategoryFixture.createCategory("category1"));
+
+		final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+						"study",
+						category,
+						owner,
+						4
+				)
+		);
+
+		final Position position1 = positionRepository.save(PositionFixture.createPosition("position1"));
+
+
+		final WriteRecruitmentRequest request = WriteRecruitmentRequest.builder()
+				.studyId(study.getId())
+				.title("recruitment")
+				.content("I want to study")
+				.stackIds(Set.of())
+				.positionIds(Set.of(position1.getId()))
+				.recruitmentLimit(4)
+				.callUrl("x.com")
+				.recruitmentEndDateTime(LocalDateTime.now().plusMonths(3))
+				.build();
+
+		final Recruitment recruitment = recruitmentService.write(owner, request);
+
+		// when
+		// then
+		assertThatThrownBy(
+				() -> recruitmentPositionService.addMany(recruitment,
+						Set.of(position1.getId())))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("이미 존재하는 포지션입니다.");
+
+	}
+
+
+	@DisplayName("update 시, 모집 공고에 등록되지 않은 스택을 전달하면 추가된다.")
+	@Test
+	void updateRecruitmentStackSuccess1() {
+
+		// given
+		final User owner = userRepository.save(
+				User.builder()
+						.nickname("owner")
+						.email("a@aa.aa")
+						.social(Social.KAKAO)
+						.build());
+
+		final Category category = categoryRepository.save(
+				CategoryFixture.createCategory("category1"));
+
+		final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+						"study",
+						category,
+						owner,
+						4
+				)
+		);
+
+		final Position position1 = positionRepository.save(PositionFixture.createPosition("position1"));
+		final Position position2 = positionRepository.save(PositionFixture.createPosition("position2"));
+		final Position position3 = positionRepository.save(PositionFixture.createPosition("position3"));
+
+		final WriteRecruitmentRequest request = WriteRecruitmentRequest.builder()
+				.studyId(study.getId())
+				.title("recruitment")
+				.content("I want to study")
+				.stackIds(Set.of())
+				.positionIds(Set.of())
+				.recruitmentLimit(4)
+				.callUrl("x.com")
+				.recruitmentEndDateTime(LocalDateTime.now().plusMonths(3))
+				.build();
+
+		final Recruitment recruitment = recruitmentService.write(owner, request);
+
+		// when
+		recruitmentPositionService.update(recruitment, Set.of(position1.getId(), position2.getId(), position3.getId()));
+		final List<RecruitmentPosition> recruitmentPositions = recruitment.getRecruitmentPositions();
+
+		// then
+		assertThat(recruitmentPositions).hasSize(3);
+		assertThat(recruitmentPositions).extracting("position")
+				.containsAll(List.of(position1, position2, position3));
+
+	}
+
+	@DisplayName("update 시, 모집 공고에 등록된 포지션을 전달하지 않으면 제거된다.")
+	@Test
+	void updateRecruitmentPositionSuccess2() {
+
+		// given
+		final User owner = userRepository.save(
+				User.builder()
+						.nickname("owner")
+						.email("a@aa.aa")
+						.social(Social.KAKAO)
+						.build());
+
+		final Category category = categoryRepository.save(
+				CategoryFixture.createCategory("category1"));
+
+		final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+						"study",
+						category,
+						owner,
+						4
+				)
+		);
+
+		final Position position1 = positionRepository.save(PositionFixture.createPosition("position1"));
+		final Position position2 = positionRepository.save(PositionFixture.createPosition("position2"));
+		final Position position3 = positionRepository.save(PositionFixture.createPosition("position3"));
+
+		final WriteRecruitmentRequest request = WriteRecruitmentRequest.builder()
+				.studyId(study.getId())
+				.title("recruitment")
+				.content("I want to study")
+				.stackIds(Set.of())
+				.positionIds(Set.of(position1.getId(), position2.getId(), position3.getId()))
+				.recruitmentLimit(4)
+				.callUrl("x.com")
+				.recruitmentEndDateTime(LocalDateTime.now().plusMonths(3))
+				.build();
+
+		final Recruitment recruitment = recruitmentService.write(owner, request);
+
+		// when
+		recruitmentPositionService.update(recruitment, Set.of());
+		final List<RecruitmentPosition> recruitmentPositions = recruitment.getRecruitmentPositions();
+
+		// then
+		assertThat(recruitmentPositions).hasSize(0);
+
+	}
+
+	@DisplayName("update 시, 모집 공고에 등록된 포지션을 전달하면 아무런 변화도 일어나지 않는다.")
+	@Test
+	void updateRecruitmentPositionSuccess3() {
+
+		// given
+		final User owner = userRepository.save(
+				User.builder()
+						.nickname("owner")
+						.email("a@aa.aa")
+						.social(Social.KAKAO)
+						.build());
+
+		final Category category = categoryRepository.save(
+				CategoryFixture.createCategory("category1"));
+
+		final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+						"study",
+						category,
+						owner,
+						4
+				)
+		);
+
+		final Position position1 = positionRepository.save(PositionFixture.createPosition("position1"));
+
+
+		final WriteRecruitmentRequest request = WriteRecruitmentRequest.builder()
+				.studyId(study.getId())
+				.title("recruitment")
+				.content("I want to study")
+				.stackIds(Set.of())
+				.positionIds(Set.of(position1.getId()))
+				.recruitmentLimit(4)
+				.callUrl("x.com")
+				.recruitmentEndDateTime(LocalDateTime.now().plusMonths(3))
+				.build();
+
+		final Recruitment recruitment = recruitmentService.write(owner, request);
+
+		// when
+		recruitmentPositionService.update(recruitment, Set.of(position1.getId()));
+		final List<RecruitmentPosition> recruitmentPositions = recruitment.getRecruitmentPositions();
+
+		// then
+		assertThat(recruitmentPositions).hasSize(1);
+		assertThat(recruitmentPositions).extracting("position")
+				.containsAll(List.of(position1));
+
+	}
+}

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/service/RecruitmentServiceTestBakup.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/service/RecruitmentServiceTestBakup.java
@@ -1,10 +1,10 @@
 package com.ludo.study.studymatchingplatform.study.service;
 
-import static org.assertj.core.api.Assertions.*;
-
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +19,8 @@ import com.ludo.study.studymatchingplatform.study.domain.StudyStatus;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Applicant;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.ApplicantStatus;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.RecruitmentPosition;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.RecruitmentStack;
 import com.ludo.study.studymatchingplatform.study.domain.stack.Stack;
 import com.ludo.study.studymatchingplatform.study.domain.stack.StackCategory;
 import com.ludo.study.studymatchingplatform.study.fixture.CategoryFixture;
@@ -27,6 +29,7 @@ import com.ludo.study.studymatchingplatform.study.fixture.RecruitmentFixture;
 import com.ludo.study.studymatchingplatform.study.fixture.StackCategoryFixture;
 import com.ludo.study.studymatchingplatform.study.fixture.StackFixture;
 import com.ludo.study.studymatchingplatform.study.fixture.StudyFixture;
+import com.ludo.study.studymatchingplatform.study.fixture.UserFixture;
 import com.ludo.study.studymatchingplatform.study.repository.CategoryRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.repository.PositionRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.repository.StudyRepositoryImpl;
@@ -39,6 +42,8 @@ import com.ludo.study.studymatchingplatform.study.service.dto.request.WriteRecru
 import com.ludo.study.studymatchingplatform.user.domain.Social;
 import com.ludo.study.studymatchingplatform.user.domain.User;
 import com.ludo.study.studymatchingplatform.user.repository.UserRepositoryImpl;
+
+import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 @Transactional

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/service/RecruitmentsFindServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/service/RecruitmentsFindServiceTest.java
@@ -1,10 +1,12 @@
 package com.ludo.study.studymatchingplatform.study.service;
 
-import static org.assertj.core.api.Assertions.*;
-
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,8 +19,10 @@ import com.ludo.study.studymatchingplatform.study.domain.Way;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.RecruitmentStack;
 import com.ludo.study.studymatchingplatform.study.fixture.CategoryFixture;
+import com.ludo.study.studymatchingplatform.study.fixture.PositionFixture;
 import com.ludo.study.studymatchingplatform.study.fixture.RecruitmentFixture;
 import com.ludo.study.studymatchingplatform.study.fixture.RecruitmentStackFixture;
+import com.ludo.study.studymatchingplatform.study.fixture.StackCategoryFixture;
 import com.ludo.study.studymatchingplatform.study.fixture.StackFixture;
 import com.ludo.study.studymatchingplatform.study.fixture.StudyFixture;
 import com.ludo.study.studymatchingplatform.study.fixture.UserFixture;
@@ -29,6 +33,8 @@ import com.ludo.study.studymatchingplatform.study.service.dto.response.Recruitme
 import com.ludo.study.studymatchingplatform.user.domain.Social;
 import com.ludo.study.studymatchingplatform.user.domain.User;
 import com.ludo.study.studymatchingplatform.user.repository.UserRepositoryImpl;
+
+import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 class RecruitmentsFindServiceTest {
@@ -148,5 +154,961 @@ class RecruitmentsFindServiceTest {
 		Recruitment recruitment = RecruitmentFixture.createRecruitment(study, recruitmentTitle, "내용", 1, "call",
 				spring);
 		recruitmentRepository.save(recruitment);
+	}
+
+	@SpringBootTest
+	@Transactional
+	static
+	class RecruitmentServiceTestBakup {
+
+		@Autowired
+		private UserRepositoryImpl userRepository;
+
+		@Autowired
+		private CategoryRepositoryImpl categoryRepository;
+
+		@Autowired
+		private StudyRepositoryImpl studyRepository;
+
+		@Autowired
+		private PositionRepositoryImpl positionRepository;
+
+		@Autowired
+		private StackRepositoryImpl stackRepository;
+
+		@Autowired
+		private StackCategoryRepositoryImpl stackCategoryRepository;
+
+		@Autowired
+		private RecruitmentRepositoryImpl recruitmentRepository;
+
+		@Autowired
+		private RecruitmentService recruitmentService;
+
+		@DisplayName("스터디장은 모집 공고를 작성할 수 있다")
+		@Test
+		void writeRecruitment() {
+
+			// given
+			final User owner = userRepository.save(
+				User.builder()
+					.nickname("owner")
+					.email("a@aa.aa")
+					.social(Social.KAKAO)
+					.build());
+
+			final Category category = categoryRepository.save(
+				CategoryFixture.createCategory("category1"));
+
+			final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+					"study",
+					category,
+					owner,
+					4
+				)
+			);
+			final StackCategory stackCategory = stackCategoryRepository.save(
+				StackCategoryFixture.createStackCategory("stackCategory")
+			);
+
+			final Stack stack = stackRepository.save(
+				StackFixture.createStack("stack", stackCategory)
+			);
+			final Position position = positionRepository.save(
+				PositionFixture.createPosition("position")
+			);
+
+			final WriteRecruitmentRequest request = WriteRecruitmentRequest.builder()
+				.studyId(study.getId())
+				.title("recruitment")
+				.content("I want to study")
+				.stackIds(Set.of(stack.getId()))
+				.positionIds(Set.of(position.getId()))
+				.recruitmentLimit(4)
+				.callUrl("x.com")
+				.recruitmentEndDateTime(LocalDateTime.now().plusMonths(3))
+				.build();
+
+			// when
+			final Recruitment recruitment = recruitmentService.write(owner, request);
+
+			// then
+			Assertions.assertThat(recruitment.getTitle()).isEqualTo("recruitment");
+			Assertions.assertThat(recruitment.getContent()).isEqualTo("I want to study");
+			Assertions.assertThat(recruitment.getCallUrl()).isEqualTo("x.com");
+
+		}
+
+		@DisplayName("스터디장이 아니면 모집 공고를 작성할 수 없다")
+		@Test
+		void writeRecruitmentFailure() {
+
+			// given
+			final User owner = userRepository.save(
+				User.builder()
+					.nickname("owner")
+					.email("a@aa.aa")
+					.social(Social.KAKAO)
+					.build());
+			final User user = userRepository.save(
+				User.builder()
+					.nickname("user")
+					.email("b@bb.bb")
+					.social(Social.KAKAO)
+					.build());
+
+			final Category category = categoryRepository.save(
+				CategoryFixture.createCategory("category1"));
+
+			final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+					"study",
+					category,
+					owner,
+					4
+				)
+			);
+			final StackCategory stackCategory = stackCategoryRepository.save(
+				StackCategoryFixture.createStackCategory("stackCategory")
+			);
+
+			final Stack stack = stackRepository.save(
+				StackFixture.createStack("stack", stackCategory)
+			);
+			final Position position = positionRepository.save(
+				PositionFixture.createPosition("position")
+			);
+
+			final WriteRecruitmentRequest request = WriteRecruitmentRequest.builder()
+				.studyId(study.getId())
+				.title("recruitment")
+				.content("I want to study")
+				.stackIds(Set.of(stack.getId()))
+				.positionIds(Set.of(position.getId()))
+				.recruitmentLimit(4)
+				.callUrl("x.com")
+				.recruitmentEndDateTime(LocalDateTime.now().plusMonths(3))
+				.build();
+
+			// when
+			// then
+			assertThatThrownBy(() ->
+				recruitmentService.write(user, request))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("모집 공고를 작성할 권한이 없습니다.");
+		}
+
+		@DisplayName("스터디에 이미 작성된 모집 공고가 존재 하면 모집 공고를 작성할 수 없다")
+		@Test
+		void writeDuplicateRecruitmentFailure() {
+
+			// given
+			final User owner = userRepository.save(
+				User.builder()
+					.nickname("owner")
+					.email("a@aa.aa")
+					.social(Social.KAKAO)
+					.build());
+			final Category category = categoryRepository.save(
+				CategoryFixture.createCategory("category1"));
+
+			final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+					"study",
+					category,
+					owner,
+					4
+				)
+			);
+			final StackCategory stackCategory = stackCategoryRepository.save(
+				StackCategoryFixture.createStackCategory("stackCategory")
+			);
+
+			final Stack stack = stackRepository.save(
+				StackFixture.createStack("stack", stackCategory)
+			);
+			final Position position = positionRepository.save(
+				PositionFixture.createPosition("position")
+			);
+
+			final WriteRecruitmentRequest request = WriteRecruitmentRequest.builder()
+				.studyId(study.getId())
+				.title("recruitment")
+				.content("I want to study")
+				.stackIds(Set.of(stack.getId()))
+				.positionIds(Set.of(position.getId()))
+				.recruitmentLimit(4)
+				.callUrl("x.com")
+				.recruitmentEndDateTime(LocalDateTime.now().plusMonths(3))
+				.build();
+
+			final Recruitment recruitment = recruitmentService.write(owner, request);
+			study.registerRecruitment(recruitment);
+
+			// when
+			// then
+			assertThatThrownBy(() ->
+				recruitmentService.write(owner, request))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("이미 작성된 모집 공고가 존재합니다.");
+		}
+
+		@DisplayName("스터디가 존재하지 않으면 모집 공고를 작성할 수 없다")
+		@Test
+		void writeRecruitmentFailureWithoutStudy() {
+
+			// given
+			final User owner = userRepository.save(
+				User.builder()
+					.nickname("owner")
+					.email("a@aa.aa")
+					.social(Social.KAKAO)
+					.build());
+
+			final StackCategory stackCategory = stackCategoryRepository.save(
+				StackCategoryFixture.createStackCategory("stackCategory")
+			);
+
+			final Stack stack = stackRepository.save(
+				StackFixture.createStack("stack", stackCategory)
+			);
+			final Position position = positionRepository.save(
+				PositionFixture.createPosition("position")
+			);
+
+			final WriteRecruitmentRequest request = WriteRecruitmentRequest.builder()
+				.studyId(2147483647L)
+				.title("recruitment")
+				.content("I want to study")
+				.stackIds(Set.of(stack.getId()))
+				.positionIds(Set.of(position.getId()))
+				.recruitmentLimit(4)
+				.callUrl("x.com")
+				.recruitmentEndDateTime(LocalDateTime.now().plusMonths(3))
+				.build();
+
+			// when
+			// then
+			assertThatThrownBy(() ->
+				recruitmentService.write(owner, request))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("존재하지 않는 스터디입니다.");
+		}
+
+		@DisplayName("스터디에 지원한 적 없는 사용자는 스터디에 지원할 수 있다")
+		@Test
+		void applyRecruitment() {
+
+			// given
+			final User owner = userRepository.save(
+				User.builder()
+					.nickname("owner")
+					.email("a@aa.aa")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final User applier = userRepository.save(
+				User.builder()
+					.nickname("applier")
+					.email("b@bb.bb")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final Category category = categoryRepository.save(
+
+				CategoryFixture.createCategory("category1"));
+
+			final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+					"study",
+					category,
+					owner,
+					4
+				)
+			);
+			final Recruitment recruitment = recruitmentRepository.save(
+				RecruitmentFixture.createRecruitmentWithoutStacksAndPositions(
+					study,
+					"recruitment",
+					"content",
+					"callUrl",
+					LocalDateTime.now().plusDays(5)
+				)
+			);
+			study.registerRecruitment(recruitment);
+
+			// when
+			final Applicant applicant = recruitmentService.apply(applier, recruitment.getId());
+
+			// then
+			Assertions.assertThat(applicant.getUser()).isEqualTo(applier);
+		}
+
+		@DisplayName("이미 지원한 모집 공고에 지원할 수 없다")
+		@Test
+		void applyRecruitmentFailIfAlreadyApplied() {
+
+			// given
+			final User owner = userRepository.save(
+				User.builder()
+					.nickname("owner")
+					.email("a@aa.aa")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final User applier = userRepository.save(
+				User.builder()
+					.nickname("applier")
+					.email("b@bb.bb")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final Category category = categoryRepository.save(
+
+				CategoryFixture.createCategory("category1"));
+
+			final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+					"study",
+					category,
+					owner,
+					4
+				)
+			);
+			final Recruitment recruitment = recruitmentRepository.save(
+				RecruitmentFixture.createRecruitmentWithoutStacksAndPositions(
+					study,
+					"recruitment",
+					"content",
+					"callUrl",
+					LocalDateTime.now().plusDays(5)
+				)
+			);
+			study.registerRecruitment(recruitment);
+			recruitmentService.apply(applier, recruitment.getId());
+
+			// when
+			// then
+			assertThatThrownBy(() -> recruitmentService.apply(applier, recruitment.getId()))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("이미 지원한 모집 공고입니다.");
+		}
+
+		@DisplayName("모집 중이 아닌 스터디의 모집 공고에 지원할 수 없다")
+		@Test
+		void applyRecruitmentFailIfNotRecruiting() {
+
+			// given
+			final User owner = userRepository.save(
+				User.builder()
+					.nickname("owner")
+					.email("a@aa.aa")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final User applier = userRepository.save(
+				User.builder()
+					.nickname("applier")
+					.email("b@bb.bb")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final Category category = categoryRepository.save(
+
+				CategoryFixture.createCategory("category1"));
+
+			final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+					"study",
+					category,
+					owner,
+					4
+				)
+			);
+			final Recruitment recruitment = recruitmentRepository.save(
+				RecruitmentFixture.createRecruitmentWithoutStacksAndPositions(
+					study,
+					"recruitment",
+					"content",
+					"callUrl",
+					LocalDateTime.now().plusDays(5)
+				)
+			);
+			study.registerRecruitment(recruitment);
+
+			// when
+			// then
+			study.changeStatus(StudyStatus.RECRUITED);
+			assertThatThrownBy(() -> recruitmentService.apply(applier, recruitment.getId()))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessage("현재 모집 중인 스터디가 아닙니다.");
+
+			study.changeStatus(StudyStatus.PROGRESS);
+			assertThatThrownBy(() -> recruitmentService.apply(applier, recruitment.getId()))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessage("현재 모집 중인 스터디가 아닙니다.");
+
+			study.changeStatus(StudyStatus.COMPLETED);
+			assertThatThrownBy(() -> recruitmentService.apply(applier, recruitment.getId()))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessage("현재 모집 중인 스터디가 아닙니다.");
+		}
+
+		@DisplayName("지원 취소한 모집 공고에 다시 지원할 수 있다")
+		@Test
+		void applyRecruitmentIfCancelled() {
+
+			// given
+			final User owner = userRepository.save(
+				User.builder()
+					.nickname("owner")
+					.email("a@aa.aa")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final User applier = userRepository.save(
+				User.builder()
+					.nickname("applier")
+					.email("b@bb.bb")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final Category category = categoryRepository.save(
+
+				CategoryFixture.createCategory("category1"));
+
+			final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+					"study",
+					category,
+					owner,
+					4
+				)
+			);
+			final Recruitment recruitment = recruitmentRepository.save(
+				RecruitmentFixture.createRecruitmentWithoutStacksAndPositions(
+					study,
+					"recruitment",
+					"content",
+					"callUrl",
+					LocalDateTime.now().plusDays(5)
+				)
+			);
+			study.registerRecruitment(recruitment);
+			recruitmentService.apply(applier, recruitment.getId());
+			recruitmentService.cancel(applier, recruitment.getId());
+
+			// when
+			// then
+			recruitmentService.apply(applier, recruitment.getId());
+		}
+
+		@DisplayName("지원 취소 상태가 아닌 경우, 모집 공고에 다시 지원할 수 없다")
+		@Test
+		void applyRecruitmentIfNotCancelled() {
+
+			// given
+			final User owner = userRepository.save(
+				User.builder()
+					.nickname("owner")
+					.email("a@aa.aa")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final User applier = userRepository.save(
+				User.builder()
+					.nickname("applier")
+					.email("b@bb.bb")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final Category category = categoryRepository.save(
+
+				CategoryFixture.createCategory("category1"));
+
+			final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+					"study",
+					category,
+					owner,
+					4
+				)
+			);
+			final Recruitment recruitment = recruitmentRepository.save(
+				RecruitmentFixture.createRecruitmentWithoutStacksAndPositions(
+					study,
+					"recruitment",
+					"content",
+					"callUrl",
+					LocalDateTime.now().plusDays(5)
+				)
+			);
+			study.registerRecruitment(recruitment);
+			final Applicant applicant = recruitmentService.apply(applier, recruitment.getId());
+
+			// when
+			// then
+			applicant.changeStatus(ApplicantStatus.ACCEPTED);
+			assertThatThrownBy(() -> recruitmentService.apply(applier, recruitment.getId()))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("이미 수락된 모집 공고입니다.");
+
+			applicant.changeStatus(ApplicantStatus.REJECTED);
+			assertThatThrownBy(() -> recruitmentService.apply(applier, recruitment.getId()))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("이미 거절된 모집 공고입니다.");
+
+		}
+
+		@DisplayName("모집 공고 지원 후 UNCHECKED 상태인 경우 지원 취소 가능")
+		@Test
+		void cancelApplicant() {
+
+			// given
+			final User owner = userRepository.save(
+				User.builder()
+					.nickname("owner")
+					.email("a@aa.aa")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final User applier = userRepository.save(
+				User.builder()
+					.nickname("applier")
+					.email("b@bb.bb")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final Category category = categoryRepository.save(
+
+				CategoryFixture.createCategory("category1"));
+
+			final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+					"study",
+					category,
+					owner,
+					4
+				)
+			);
+			final Recruitment recruitment = recruitmentRepository.save(
+				RecruitmentFixture.createRecruitmentWithoutStacksAndPositions(
+					study,
+					"recruitment",
+					"content",
+					"callUrl",
+					LocalDateTime.now().plusDays(5)
+				)
+			);
+			study.registerRecruitment(recruitment);
+			final Applicant applicant = recruitmentService.apply(applier, recruitment.getId());
+
+			// when
+			// then
+			applicant.changeStatus(ApplicantStatus.UNCHECKED);
+			final Applicant cancelledApplier = recruitmentService.cancel(applier, recruitment.getId());
+
+			Assertions.assertThat(cancelledApplier.getApplicantStatus()).isEqualTo(ApplicantStatus.CANCELLED);
+
+		}
+
+		@DisplayName("모집 공고 지원 후 ACCEPTED 상태이며, 스터디가 모집 중인 경우 지원 취소 가능")
+		@Test
+		void cancelFailureIfAcceptedAndRecruiting() {
+
+			// given
+			final User owner = userRepository.save(
+				User.builder()
+					.nickname("owner")
+					.email("a@aa.aa")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final User applier = userRepository.save(
+				User.builder()
+					.nickname("applier")
+					.email("b@bb.bb")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final Category category = categoryRepository.save(
+
+				CategoryFixture.createCategory("category1"));
+
+			final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+					"study",
+					category,
+					owner,
+					4
+				)
+			);
+			final Recruitment recruitment = recruitmentRepository.save(
+				RecruitmentFixture.createRecruitmentWithoutStacksAndPositions(
+					study,
+					"recruitment",
+					"content",
+					"callUrl",
+					LocalDateTime.now().plusDays(5)
+				)
+			);
+			study.registerRecruitment(recruitment);
+			study.changeStatus(StudyStatus.RECRUITING);
+
+			final Applicant applicant = recruitmentService.apply(applier, recruitment.getId());
+
+			// when
+			// then
+			applicant.changeStatus(ApplicantStatus.ACCEPTED);
+			final Applicant cancelledApplier = recruitmentService.cancel(applier, recruitment.getId());
+
+			Assertions.assertThat(cancelledApplier.getApplicantStatus()).isEqualTo(ApplicantStatus.CANCELLED);
+
+		}
+
+		@DisplayName("모집 중이 아닌 스터디의 모집 공고는 취소할 수 없다.")
+		@Test
+		void cancelFailureIfNotRecruiting() {
+
+			// given
+			final User owner = userRepository.save(
+				User.builder()
+					.nickname("owner")
+					.email("a@aa.aa")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final User applier = userRepository.save(
+				User.builder()
+					.nickname("applier")
+					.email("b@bb.bb")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final Category category = categoryRepository.save(
+
+				CategoryFixture.createCategory("category1"));
+
+			final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+					"study",
+					category,
+					owner,
+					4
+				)
+			);
+			final Recruitment recruitment = recruitmentRepository.save(
+				RecruitmentFixture.createRecruitmentWithoutStacksAndPositions(
+					study,
+					"recruitment",
+					"content",
+					"callUrl",
+					LocalDateTime.now().plusDays(5)
+				)
+			);
+			study.registerRecruitment(recruitment);
+			final Applicant applicant = recruitmentService.apply(applier, recruitment.getId());
+
+			study.changeStatus(StudyStatus.RECRUITED);
+
+			// when
+			// then
+			applicant.changeStatus(ApplicantStatus.UNCHECKED);
+			assertThatThrownBy(() -> recruitmentService.apply(applier, recruitment.getId()))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessage("현재 모집 중인 스터디가 아닙니다.");
+
+			applicant.changeStatus(ApplicantStatus.CANCELLED);
+			assertThatThrownBy(() -> recruitmentService.apply(applier, recruitment.getId()))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessage("현재 모집 중인 스터디가 아닙니다.");
+
+			applicant.changeStatus(ApplicantStatus.REJECTED);
+			assertThatThrownBy(() -> recruitmentService.apply(applier, recruitment.getId()))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessage("현재 모집 중인 스터디가 아닙니다.");
+
+			applicant.changeStatus(ApplicantStatus.REMOVED);
+			assertThatThrownBy(() -> recruitmentService.apply(applier, recruitment.getId()))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessage("현재 모집 중인 스터디가 아닙니다.");
+
+			applicant.changeStatus(ApplicantStatus.ACCEPTED);
+			assertThatThrownBy(() -> recruitmentService.apply(applier, recruitment.getId()))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessage("현재 모집 중인 스터디가 아닙니다.");
+
+		}
+
+		@DisplayName("거절된 모집 공고는 지원 취소할 수 없다.")
+		@Test
+		void cancelFailureIfAlreadyRejected() {
+
+			// given
+			final User owner = userRepository.save(
+				User.builder()
+					.nickname("owner")
+					.email("a@aa.aa")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final User applier = userRepository.save(
+				User.builder()
+					.nickname("applier")
+					.email("b@bb.bb")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final Category category = categoryRepository.save(
+
+				CategoryFixture.createCategory("category1"));
+
+			final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+					"study",
+					category,
+					owner,
+					4
+				)
+			);
+			final Recruitment recruitment = recruitmentRepository.save(
+				RecruitmentFixture.createRecruitmentWithoutStacksAndPositions(
+					study,
+					"recruitment",
+					"content",
+					"callUrl",
+					LocalDateTime.now().plusDays(5)
+				)
+			);
+			study.registerRecruitment(recruitment);
+			final Applicant applicant = recruitmentService.apply(applier, recruitment.getId());
+
+			// when
+			// then
+			applicant.changeStatus(ApplicantStatus.REJECTED);
+			assertThatThrownBy(() -> recruitmentService.apply(applier, recruitment.getId()))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("이미 거절된 모집 공고입니다.");
+
+		}
+
+		@DisplayName("스터디장은 모집 공고를 수정할 수 있다.")
+		@Test
+		void editRecruitmentSuccess() {
+
+			// given
+			final User owner = userRepository.save(
+				User.builder()
+					.nickname("owner")
+					.email("a@aa.aa")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final Category category = categoryRepository.save(
+
+				CategoryFixture.createCategory("category1"));
+
+			final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+					"study",
+					category,
+					owner,
+					4
+				)
+			);
+			final Recruitment recruitment = recruitmentRepository.save(
+				RecruitmentFixture.createRecruitmentWithoutStacksAndPositions(
+					study,
+					"recruitment",
+					"content",
+					"callUrl",
+					LocalDateTime.now().plusDays(5)
+				)
+			);
+			study.registerRecruitment(recruitment);
+
+			// when
+			// then
+			final LocalDateTime editedRecruitmentEndDateTime = LocalDateTime.now().plusDays(5);
+			final EditRecruitmentRequest request = EditRecruitmentRequest.builder()
+				.title("edited text")
+				// .content("edited content")
+				.callUrl("edited callUrl")
+				.recruitmentEndDateTime(editedRecruitmentEndDateTime)
+				.build();
+			final Recruitment editedRecruitment = recruitmentService.edit(owner, recruitment.getId(), request);
+
+			// edited states
+			Assertions.assertThat(editedRecruitment.getTitle()).isEqualTo("edited text");
+			Assertions.assertThat(editedRecruitment.getCallUrl()).isEqualTo("edited callUrl");
+			Assertions.assertThat(editedRecruitment.getRecruitmentEndDateTime()).isEqualTo(editedRecruitmentEndDateTime);
+
+			// same as prev states
+			Assertions.assertThat(editedRecruitment.getId()).isEqualTo(recruitment.getId());
+			Assertions.assertThat(editedRecruitment.getContent()).isEqualTo(recruitment.getContent());
+			Assertions.assertThat(editedRecruitment.getHits()).isEqualTo(recruitment.getHits());
+		}
+
+		@DisplayName("스터디장이 아니면 모집 공고를 수정할 수 없다.")
+		@Test
+		void editRecruitmentFailure() {
+
+			// given
+			final User owner = userRepository.save(
+				User.builder()
+					.nickname("owner")
+					.email("a@aa.aa")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final User user = userRepository.save(
+				User.builder()
+					.nickname("user")
+					.email("b@bb.bb")
+					.social(Social.KAKAO)
+					.build()
+			);
+			final Category category = categoryRepository.save(
+
+				CategoryFixture.createCategory("category1"));
+
+			final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+					"study",
+					category,
+					owner,
+					4
+				)
+			);
+			final Recruitment recruitment = recruitmentRepository.save(
+				RecruitmentFixture.createRecruitmentWithoutStacksAndPositions(
+					study,
+					"recruitment",
+					"content",
+					"callUrl",
+					LocalDateTime.now().plusDays(5)
+				)
+			);
+			study.registerRecruitment(recruitment);
+
+			// when
+			// then
+			final LocalDateTime editedRecruitmentEndDateTime = LocalDateTime.now().plusDays(5);
+			final EditRecruitmentRequest request = EditRecruitmentRequest.builder()
+				.title("edited text")
+				.content("edited content")
+				.callUrl("edited callUrl")
+				.recruitmentEndDateTime(editedRecruitmentEndDateTime)
+				.build();
+
+			assertThatThrownBy(() -> recruitmentService.edit(user, recruitment.getId(), request))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("모집 공고를 작성할 권한이 없습니다.");
+
+		}
+
+		@DisplayName("존재하지 않는 모집 공고는 수정할 수 없다.")
+		@Test
+		void editRecruitmentFailureIfNotExists() {
+
+			// given
+			final User owner = userRepository.save(
+				User.builder()
+					.nickname("owner")
+					.email("a@aa.aa")
+					.social(Social.KAKAO)
+					.build()
+			);
+
+			final LocalDateTime editedRecruitmentEndDateTime = LocalDateTime.now().plusDays(5);
+			final EditRecruitmentRequest request = EditRecruitmentRequest.builder()
+				.title("edited text")
+				.content("edited content")
+				.callUrl("edited callUrl")
+				.recruitmentEndDateTime(editedRecruitmentEndDateTime)
+				.build();
+
+			final Long invalidRecruitmentId = Long.MIN_VALUE;
+			// when
+			// then
+			assertThatThrownBy(() -> recruitmentService.edit(owner, invalidRecruitmentId, request))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("존재하지 않는 모집 공고입니다.");
+
+		}
+
+		@DisplayName("")
+		@Test
+		void updateRecruitmentStackSuccess3() {
+
+			// given
+			final User owner = userRepository.save(
+				User.builder()
+					.nickname("owner")
+					.email("a@aa.aa")
+					.social(Social.KAKAO)
+					.build());
+
+			final Category category = categoryRepository.save(
+				CategoryFixture.createCategory("category1"));
+
+			final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+					"study",
+					category,
+					owner,
+					4
+				)
+			);
+			final StackCategory stackCategory = stackCategoryRepository.save(
+				StackCategoryFixture.createStackCategory("stackCategory")
+			);
+
+			final Stack stack1 = stackRepository.save(
+				StackFixture.createStack("stack1", stackCategory)
+			);
+			final Stack stack2 = stackRepository.save(
+				StackFixture.createStack("stack2", stackCategory)
+			);
+			final Stack stack3 = stackRepository.save(
+				StackFixture.createStack("stack3", stackCategory)
+			);
+			final Position position = positionRepository.save(
+				PositionFixture.createPosition("position")
+			);
+			final Recruitment recruitment = recruitmentRepository.save(
+				RecruitmentFixture.createRecruitmentWithoutStacksAndPositions(
+					study,
+					"recruitment",
+					"content",
+					"callUrl",
+					LocalDateTime.now().plusDays(5)
+				)
+			);
+			study.registerRecruitment(recruitment);
+
+			final EditRecruitmentRequest request = EditRecruitmentRequest.builder()
+				.title("recruitment")
+				.content("I want to study")
+				.stackIds(Set.of(stack1.getId()))
+				.positionIds(Set.of(position.getId()))
+				.recruitmentLimit(4)
+				.callUrl("x.com")
+				.recruitmentEndDateTime(LocalDateTime.now().plusMonths(3))
+				.build();
+
+			// when
+			recruitmentService.edit(owner, recruitment.getId(), request);
+			final List<RecruitmentStack> recruitmentStacks = recruitment.getRecruitmentStacks();
+
+			// then
+			Assertions.assertThat(recruitmentStacks).hasSize(1);
+			Assertions.assertThat(recruitmentStacks).extracting("stack")
+				.containsAll(List.of(stack1));
+
+		}
+
+
 	}
 }


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

모집 공고 수정에 대한 API 작성

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

모집 공고 수정 시 입력된 Position, Stack에 따라 Link table이 제거 or 추가되어야 합니다.

이를 위해 다음과 같은 서비스가 추가되었습니다.

`RecruitmentStackService`도 거의 비슷하므로 생략합니다.

```java
public class RecruitmentPositionService {

// ...
    public void addMany(final Recruitment recruitment, final Set<Long> positionIds) {
        final List<Position> positions = positionService.findAllByIdsOrThrow(positionIds);
        addRecruitmentPositionsIn(recruitment, positions);
    }

    public void update(final Recruitment recruitment, final Set<Long> positionIds) {

        final Set<Position> nextPositions = positionRepository.findByIdIn(positionIds);
        final List<Position> addedPositions = recruitment.getAddedPositions(nextPositions);

        addRecruitmentPositionsIn(recruitment, addedPositions);
        recruitment.removeRecruitmentPositionsNotIn(nextPositions);
    }

    private void addRecruitmentPositionsIn(final Recruitment recruitment, final List<Position> positions) {
        recruitment.validateDuplicatePositions(positions);

        final List<RecruitmentPosition> recruitmentPositions = positions.stream()
            .map(position -> RecruitmentPosition.from(recruitment, position))
            .toList();

        recruitment.addRecruitmentPositions(recruitmentPositionRepository.saveAll(recruitmentPositions));
    }

// ...
```


추가된 포지션은 `recruitment.getAddedPositions`에 의해 비교되어 기존 `recruitment.recruitmentPositions`에 존재하지 않았으나 새로운 `EditRecruitmentRequest`에 추가된 `Position`들이 반환되고 이를 토대로 새로운 `RecruitmentPosition`을 생성합니다.


```

```java
// Recruitment

    public List<Position> getAddedPositions(final Set<Position> nextPositions) {
        final List<Position> prevPositions = getPositions();

        return nextPositions.stream()
            .filter(nextPosition -> !prevPositions.contains(nextPosition))
            .toList();
    }

    public void removeRecruitmentPositionsNotIn(final Set<Position> nextPositions) {
        final List<Position> prevPositions = getPositions();

        for (final Position prevPosition : prevPositions) {
            if (!nextPositions.contains(prevPosition)) {
                recruitmentPositions.removeIf(recruitmentPosition -> recruitmentPosition.hasPosition(prevPosition));
            }
        }
    }
```

반대로 `removeRecruitmentPositionsNotIn`에 의해 `recruitment.recruitmentPositions`에 존재하였으나, 새로운 `EditRecruitmentRequest`에 존재하지 않는 `Position`에 대응되는 `RecruitmentPosition`들이 제거되며 이후 `commit` 시점에 변경 감지에 의해 제거됩니다.

요구 사항이 추가되어 제거된 `RecruitmentPosition`을 보존하고 싶을 경우 변경 감지가 아닌 상태 변경에 의존하도록 추후 코드를 변경하는 작업이 이어지면 되겠습니다.

최종적으로 Service에서 실행되는 로직은 다음과 같으며, `ensureEditable`은 panic을 발생시켜 Spring의 `ExceptionHandlerException`에서 `IllegalArgumentException` 처리합니다.

추후 Custom 오류를 만들고 `@ExceptionHandler` 및 `@ControllerAdvice`를 구현하는 등의 예외 처리를 고도화 하는 작업이 수반될 수 있겠습니다.

```java
// RecruitmentService.java
    public Recruitment edit(final User user, final Long recruitmentId, final EditRecruitmentRequest request) {
        final Recruitment recruitment = recruitmentRepository.findByIdWithStudy(recruitmentId)
            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 모집 공고입니다."));

        recruitment.ensureEditable(user);

        recruitmentStackService.update(recruitment, request.getStackIds());
        recruitmentPositionService.update(recruitment, request.getPositionIds());

        recruitment.edit(
            request.getTitle(),
            request.getContent(),
            request.getCallUrl(),
            request.getRecruitmentLimit(),
            request.getRecruitmentEndDateTime()
        );

        return recruitment;
    }
```



<br><br>

### 💡 필요한 후속작업이 있어요.

잃어버린 테스트 코드 찾기 or 재작성

### ✅ 셀프 체크리스트

- [O] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [O] 커밋 메세지를 컨벤션에 맞추었습니다.
- [X] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [?] 변경 후 코드는 기존의 테스트를 통과합니다.
- [O] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [X] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
