### PR TITLE
hotfix: Route Logout Handler

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/common/AuthController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/common/AuthController.java
@@ -2,6 +2,7 @@ package com.ludo.study.studymatchingplatform.auth.common;
 
 import java.io.IOException;
 
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
@@ -17,6 +18,7 @@ public class AuthController {
 
 	private final Redirection redirection;
 
+	@PostMapping("/auth/logout")
 	public void logout(final HttpServletResponse response) throws IOException {
 		cookieProvider.clearAuthCookie(response);
 		redirection.to("/", response);


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

인증/인가 수단이 Cookie로 완전히 정해지기 전에 임시로 작성해두어 `logout` 핸들러가 실제 경로와 Mapping 되어 있지 않았습니다.

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

```java
@PostMapping("/auth/logout")
public void logout(final HttpServletResponse response) throws IOException {
    cookieProvider.clearAuthCookie(response);
    redirection.to("/", response);
}
```

`logout` Handler를 `PostMapping`으로 실제 경로와 매핑하였습니다.
추가된 코드는 `@PostMapping("/auth/logout")` 한 줄입니다.