### PR TITLE
Hotfix: 지원자 수락 서비스 계층 반환 타입 변경으로 인한 기존 테스트 컴파일 오류 해결

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/study/repository/CategoryRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/repository/CategoryRepositoryImpl.java
@@ -1,10 +1,13 @@
 package com.ludo.study.studymatchingplatform.study.repository;
 
+import static com.ludo.study.studymatchingplatform.study.domain.QCategory.*;
+
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
 import com.ludo.study.studymatchingplatform.study.domain.Category;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 public class CategoryRepositoryImpl {
 
 	private final CategoryJpaRepository categoryJpaRepository;
+	private final JPAQueryFactory q;
 
 	public Category save(Category category) {
 		categoryJpaRepository.save(category);
@@ -21,6 +25,14 @@ public class CategoryRepositoryImpl {
 
 	public Optional<Category> findById(final Long categoryId) {
 		return categoryJpaRepository.findById(categoryId);
+	}
+
+	public Optional<Category> findByName(final String name) {
+		return Optional.ofNullable(
+				q.select(category)
+						.from(category)
+						.where(category.name.eq(name))
+						.fetchOne());
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/repository/PositionRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/repository/PositionRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.ludo.study.studymatchingplatform.study.repository;
 import static com.ludo.study.studymatchingplatform.study.domain.QPosition.*;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.springframework.stereotype.Repository;
@@ -34,6 +35,14 @@ public class PositionRepositoryImpl {
 		return q.selectFrom(position)
 				.where(position.id.eq(id))
 				.fetchOne();
+	}
+
+	public Optional<Position> findByName(final String name) {
+		return Optional.ofNullable(
+				q.select(position)
+						.from(position)
+						.where(position.name.eq(name))
+						.fetchOne());
 	}
 
 	public Position save(final Position position) {


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

- 최신화 된 main 브랜치에서 기존 테스트가 컴파일 오류 발생하는 문제가 있어요.
```java
// before
@Transactional
public ParticipantResponse applicantAccept(final User owner, final StudyApplicantDecisionRequest request) {
	final Study study = findStudy(request.studyId());
	final User applicantUser = findUser(request.applicantUserId());

	study.acceptApplicant(owner, applicantUser, request.recruitmentId());
	Participant participant = findParticipant(study, applicantUser);

	return Participant.from(participant);
}

// after
@Transactional
public ApplyAcceptResponse applicantAccept(final User owner, final StudyApplicantDecisionRequest request) {
	final Study study = findStudy(request.studyId());
	final User applicantUser = findUser(request.applicantUserId());

	study.acceptApplicant(owner, applicantUser, request.recruitmentId());
	Participant participant = findParticipant(study, applicantUser);

	return ApplyAcceptResponse.from(participant);
}
```
- 위와 같이 서비스 계층의 반환 타입이 `ParticipantResponse` → `ApplyAcceptResponse` 으로 변경됨으로 인해

```java
@Test
@Transactional
@DisplayName("[Success] 스터디 지원자 거절 성공")
void applicantRejectTest() {
	ApplyAcceptResponse response = service.applicantAccept(...);

        // before
        assertParticipantResponse(response, ...); // 컴파일 에러 (Type mismatch)
  
        // after
        assertParticipantResponse(response, ...);
}

// before (compile error)
assertParticipantResponse(ParticipantResponse response, ...)
// after
assertApplyAcceptResponse(ApplyAcceptResponse response, ...)
```
- participantResponse 를 테스트하는 로직에서 컴파일 오류가 발생하고 있어요.
- ApplyAcceptResponse 를 테스트하도록 테스트 코드를 수정했어요.

<br><br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.
- 지원자 수락 API Response에 추가된 항목인  
<img width="427" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/68291395/28a1b8f2-2feb-44c7-87cd-2d966e62a03e">

- Role, Position에 대한 테스트 로직을 추가했어요.
```java
	private void assertApplyAcceptResponse(ApplyAcceptResponse applyAcceptResponse, User other) {
		assertThat(applyAcceptResponse.participant().nickname()).isEqualTo("other");
		assertThat(applyAcceptResponse.participant().email()).isEqualTo("other@gmail.com");
		assertThat(applyAcceptResponse.participant().id()).isEqualTo(other.getId());
		assertThat(applyAcceptResponse.participant().role()).isEqualTo(Role.MEMBER); // 추가
		assertThat(applyAcceptResponse.participant().position().getName()).isEqualTo(POSITION_NAME); // 추가
	}
```

<br><br>

## ✅ 셀프 체크리스트

- [v] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (hotfix → dev)
- [v] 커밋 메세지를 컨벤션에 맞추었습니다.
- [v] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [v] 변경 후 코드는 기존의 테스트를 통과합니다.
- [v] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [v] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
