### PR TITLE
SP-350/Feat: 사용자 닉네임 변경

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/user/controller/UserController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/controller/UserController.java
@@ -15,9 +15,8 @@ import com.ludo.study.studymatchingplatform.auth.common.AuthUser;
 import com.ludo.study.studymatchingplatform.auth.common.Redirection;
 import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
 import com.ludo.study.studymatchingplatform.study.controller.dto.BaseApiResponse;
+import com.ludo.study.studymatchingplatform.study.service.exception.BusinessException;
 import com.ludo.study.studymatchingplatform.user.domain.User;
-import com.ludo.study.studymatchingplatform.user.domain.exception.CurrentNicknameEqualsException;
-import com.ludo.study.studymatchingplatform.user.domain.exception.DuplicateNicknameException;
 import com.ludo.study.studymatchingplatform.user.service.ChangeNicknameService;
 import com.ludo.study.studymatchingplatform.user.service.UserService;
 import com.ludo.study.studymatchingplatform.user.service.dto.request.ChangeUserNicknameRequest;
@@ -25,6 +24,7 @@ import com.ludo.study.studymatchingplatform.user.service.dto.response.ChangeUser
 import com.ludo.study.studymatchingplatform.user.service.dto.response.UserResponse;
 
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -56,18 +56,14 @@ public class UserController {
 
 	@PostMapping("/users/me/nickname")
 	public ResponseEntity<BaseApiResponse<ChangeUserNicknameResponse>> changeNickname(@AuthUser final User user,
-																					  @RequestBody final ChangeUserNicknameRequest changeNickname) {
+																					  @RequestBody @Valid final ChangeUserNicknameRequest changeNickname) {
 
 		try {
 			final ChangeUserNicknameResponse response = changeNicknameService.changeUserNickname(user,
 					changeNickname.changeNickname());
 
 			return ResponseEntity.ok(BaseApiResponse.success("닉네임 변경 성공", response));
-		} catch (CurrentNicknameEqualsException e) {
-
-			return ResponseEntity.status(HttpStatus.CONFLICT)
-					.body(BaseApiResponse.fail(e.getMessage(), null));
-		} catch (DuplicateNicknameException e) {
+		} catch (BusinessException e) {
 
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 					.body(BaseApiResponse.fail(e.getMessage(), null));

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/domain/User.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/domain/User.java
@@ -1,6 +1,7 @@
 package com.ludo.study.studymatchingplatform.user.domain;
 
 import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
+import com.ludo.study.studymatchingplatform.user.service.exception.CurrentNicknameEqualsException;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,6 +18,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
 
 @Entity
 @Table(name = "`user`")
@@ -24,6 +26,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Slf4j
 public class User extends BaseEntity {
 
 	@Id
@@ -47,6 +50,17 @@ public class User extends BaseEntity {
 		this.social = social;
 		this.nickname = nickname;
 		this.email = email;
+	}
+
+	public void changeNickname(final String nickname) {
+		validateNotEqualsCurrentNickname(nickname);
+		this.nickname = nickname;
+	}
+
+	public void validateNotEqualsCurrentNickname(final String nickname) {
+		if (this.nickname.equals(nickname)) {
+			throw new CurrentNicknameEqualsException();
+		}
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/domain/User.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/domain/User.java
@@ -1,7 +1,7 @@
 package com.ludo.study.studymatchingplatform.user.domain;
 
 import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
-import com.ludo.study.studymatchingplatform.user.service.exception.CurrentNicknameEqualsException;
+import com.ludo.study.studymatchingplatform.user.domain.exception.CurrentNicknameEqualsException;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/domain/User.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/domain/User.java
@@ -1,7 +1,6 @@
 package com.ludo.study.studymatchingplatform.user.domain;
 
 import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
-import com.ludo.study.studymatchingplatform.user.domain.exception.CurrentNicknameEqualsException;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -53,14 +52,11 @@ public class User extends BaseEntity {
 	}
 
 	public void changeNickname(final String nickname) {
-		validateNotEqualsCurrentNickname(nickname);
 		this.nickname = nickname;
 	}
 
-	public void validateNotEqualsCurrentNickname(final String nickname) {
-		if (this.nickname.equals(nickname)) {
-			throw new CurrentNicknameEqualsException();
-		}
+	public boolean equalsNickname(final String nickname) {
+		return this.nickname.equals(nickname);
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/domain/exception/CurrentNicknameEqualsException.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/domain/exception/CurrentNicknameEqualsException.java
@@ -1,0 +1,11 @@
+package com.ludo.study.studymatchingplatform.user.domain.exception;
+
+public class CurrentNicknameEqualsException extends RuntimeException {
+
+	public static final String MESSAGE = "현재 닉네임과 동일한 닉네임입니다.";
+
+	public CurrentNicknameEqualsException() {
+		super(MESSAGE);
+	}
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/domain/exception/CurrentNicknameEqualsException.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/domain/exception/CurrentNicknameEqualsException.java
@@ -1,6 +1,8 @@
 package com.ludo.study.studymatchingplatform.user.domain.exception;
 
-public class CurrentNicknameEqualsException extends RuntimeException {
+import com.ludo.study.studymatchingplatform.study.service.exception.BusinessException;
+
+public class CurrentNicknameEqualsException extends BusinessException {
 
 	public static final String MESSAGE = "현재 닉네임과 동일한 닉네임입니다.";
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/domain/exception/DuplicateNicknameException.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/domain/exception/DuplicateNicknameException.java
@@ -1,6 +1,8 @@
 package com.ludo.study.studymatchingplatform.user.domain.exception;
 
-public class DuplicateNicknameException extends RuntimeException {
+import com.ludo.study.studymatchingplatform.study.service.exception.BusinessException;
+
+public class DuplicateNicknameException extends BusinessException {
 
 	public static final String MESSAGE = "이미 존재하는 닉네임입니다.";
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/domain/exception/DuplicateNicknameException.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/domain/exception/DuplicateNicknameException.java
@@ -1,0 +1,10 @@
+package com.ludo.study.studymatchingplatform.user.domain.exception;
+
+public class DuplicateNicknameException extends RuntimeException {
+
+	public static final String MESSAGE = "이미 존재하는 닉네임입니다.";
+
+	public DuplicateNicknameException() {
+		super(MESSAGE);
+	}
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/repository/UserRepositoryImpl.java
@@ -57,4 +57,15 @@ public class UserRepositoryImpl {
 		return userJpaRepository.findById(id)
 				.orElseThrow(() -> new AuthenticationException("로그인 되지 않은 사용자입니다."));
 	}
+
+	public boolean existsByNickname(final String nickname) {
+		Long userId = q.select(user.id)
+				.from(user)
+				.where(user.nickname.eq(nickname))
+				.limit(1L)
+				.fetchOne();
+
+		return userId != null;
+	}
+
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/service/ChangeNicknameService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/service/ChangeNicknameService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ludo.study.studymatchingplatform.user.domain.User;
+import com.ludo.study.studymatchingplatform.user.domain.exception.CurrentNicknameEqualsException;
 import com.ludo.study.studymatchingplatform.user.domain.exception.DuplicateNicknameException;
 import com.ludo.study.studymatchingplatform.user.repository.UserRepositoryImpl;
 import com.ludo.study.studymatchingplatform.user.service.dto.response.ChangeUserNicknameResponse;
@@ -20,11 +21,21 @@ public class ChangeNicknameService {
 
 	@Transactional
 	public ChangeUserNicknameResponse changeUserNickname(final User user, final String changeNickname) {
-		user.validateNotEqualsCurrentNickname(changeNickname);
-		validateDuplicateNickname(changeNickname);
+		validateChangeNickname(user, changeNickname);
 		user.changeNickname(changeNickname);
 
 		return new ChangeUserNicknameResponse(user);
+	}
+
+	private void validateChangeNickname(final User user, final String nickname) {
+		validateNotEqualsCurrentNickname(user, nickname);
+		validateDuplicateNickname(nickname);
+	}
+
+	private void validateNotEqualsCurrentNickname(final User user, final String nickname) {
+		if (user.equalsNickname(nickname)) {
+			throw new CurrentNicknameEqualsException();
+		}
 	}
 
 	private void validateDuplicateNickname(final String nickname) {

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/service/ChangeNicknameService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/service/ChangeNicknameService.java
@@ -1,0 +1,35 @@
+package com.ludo.study.studymatchingplatform.user.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ludo.study.studymatchingplatform.user.domain.User;
+import com.ludo.study.studymatchingplatform.user.repository.UserRepositoryImpl;
+import com.ludo.study.studymatchingplatform.user.service.dto.response.ChangeUserNicknameResponse;
+import com.ludo.study.studymatchingplatform.user.service.exception.DuplicateNicknameException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ChangeNicknameService {
+
+	private final UserRepositoryImpl userRepository;
+
+	@Transactional
+	public ChangeUserNicknameResponse changeUserNickname(final User user, final String changeNickname) {
+		user.validateNotEqualsCurrentNickname(changeNickname);
+		validateDuplicateNickname(changeNickname);
+		user.changeNickname(changeNickname);
+
+		return new ChangeUserNicknameResponse(user);
+	}
+
+	private void validateDuplicateNickname(final String nickname) {
+		if (userRepository.existsByNickname(nickname)) {
+			throw new DuplicateNicknameException();
+		}
+	}
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/service/ChangeNicknameService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/service/ChangeNicknameService.java
@@ -4,9 +4,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ludo.study.studymatchingplatform.user.domain.User;
+import com.ludo.study.studymatchingplatform.user.domain.exception.DuplicateNicknameException;
 import com.ludo.study.studymatchingplatform.user.repository.UserRepositoryImpl;
 import com.ludo.study.studymatchingplatform.user.service.dto.response.ChangeUserNicknameResponse;
-import com.ludo.study.studymatchingplatform.user.service.exception.DuplicateNicknameException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/service/dto/request/ChangeUserNicknameRequest.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/service/dto/request/ChangeUserNicknameRequest.java
@@ -3,11 +3,13 @@ package com.ludo.study.studymatchingplatform.user.service.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 public record ChangeUserNicknameRequest(
 		@NotBlank
 		@NotEmpty
 		@Pattern(regexp = "^\\S(.*\\S)?$", message = "맨 앞, 맨 뒤는 공백일 수 없습니다.")
+		@Size(min = 1, max = 20)
 		String changeNickname
 ) {
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/service/dto/request/ChangeUserNicknameRequest.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/service/dto/request/ChangeUserNicknameRequest.java
@@ -1,4 +1,13 @@
 package com.ludo.study.studymatchingplatform.user.service.dto.request;
 
-public record ChangeUserNicknameRequest(String changeNickname) {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+
+public record ChangeUserNicknameRequest(
+		@NotBlank
+		@NotEmpty
+		@Pattern(regexp = "^\\S(.*\\S)?$", message = "맨 앞, 맨 뒤는 공백일 수 없습니다.")
+		String changeNickname
+) {
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/service/dto/request/ChangeUserNicknameRequest.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/service/dto/request/ChangeUserNicknameRequest.java
@@ -1,0 +1,4 @@
+package com.ludo.study.studymatchingplatform.user.service.dto.request;
+
+public record ChangeUserNicknameRequest(String changeNickname) {
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/service/dto/response/ChangeUserNicknameResponse.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/service/dto/response/ChangeUserNicknameResponse.java
@@ -1,0 +1,18 @@
+package com.ludo.study.studymatchingplatform.user.service.dto.response;
+
+import com.ludo.study.studymatchingplatform.user.domain.User;
+
+public record ChangeUserNicknameResponse(
+		UserResponse user
+) {
+
+	public record UserResponse(
+			Long id, String nickname
+	) {
+	}
+
+	public ChangeUserNicknameResponse(final User user) {
+		this(new UserResponse(user.getId(), user.getNickname()));
+	}
+}
+

--- a/src/test/java/com/ludo/study/studymatchingplatform/user/service/ChangeNicknameServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/user/service/ChangeNicknameServiceTest.java
@@ -1,0 +1,92 @@
+package com.ludo.study.studymatchingplatform.user.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ludo.study.studymatchingplatform.study.fixture.UserFixture;
+import com.ludo.study.studymatchingplatform.user.domain.Social;
+import com.ludo.study.studymatchingplatform.user.domain.User;
+import com.ludo.study.studymatchingplatform.user.repository.UserRepositoryImpl;
+import com.ludo.study.studymatchingplatform.user.service.dto.response.ChangeUserNicknameResponse;
+
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+
+@SpringBootTest
+@Slf4j
+class ChangeNicknameServiceTest {
+
+	@Autowired
+	ChangeNicknameService changeNicknameService;
+
+	@Autowired
+	UserRepositoryImpl userRepository;
+
+	@Autowired
+	EntityManager em;
+
+	@Test
+	@DisplayName("[Success] 존재하지 않는 닉네임이면 닉네임 변경 성공")
+	@Transactional
+	void changeNickname() {
+		// given
+		User user = userRepository.save(
+				UserFixture.createUser(Social.NAVER, "archa", "archa@naver.com")
+		);
+		String changeNickname = "루도";
+
+		// when
+		ChangeUserNicknameResponse response = changeNicknameService.changeUserNickname(user,
+				changeNickname);
+
+		// then
+		Optional<User> findOptionalUser = userRepository.findById(user.getId());
+		assertThat(findOptionalUser).isPresent();
+
+		User findUser = findOptionalUser.get();
+		assertThat(findUser.getNickname()).isEqualTo(changeNickname);
+		assertThat(response.user().nickname()).isEqualTo(changeNickname);
+	}
+
+	@Test
+	@DisplayName("[Exception] 현재 닉네임과 동일한 닉네임이면 예외 발생")
+	@Transactional
+	void equalsCurrentNickname() {
+		// given
+		User user = userRepository.save(
+				UserFixture.createUser(Social.NAVER, "archa", "archa@naver.com"));
+
+		// when, then
+		assertThatThrownBy(() -> changeNicknameService.changeUserNickname(user, "archa"))
+				.hasMessageContaining("현재 닉네임과 동일한 닉네임입니다.");
+	}
+
+	@Test
+	@DisplayName("[Exception] 존재하는 닉네임이면 예외 발생")
+	@Transactional
+	void existNickname() {
+		// given
+		User user = userRepository.save(
+				UserFixture.createUser(Social.NAVER, "archa", "archa@naver.com")
+		);
+		User other = userRepository.save(
+				UserFixture.createUser(Social.NAVER, "other", "archa@naver.com")
+		);
+		String changeNickname = "other";
+
+		userRepository.save(user);
+		userRepository.save(other);
+
+		// when, then
+		assertThatThrownBy(() -> changeNicknameService.changeUserNickname(user, changeNickname))
+				.hasMessageContaining("이미 존재하는 닉네임입니다.");
+	}
+
+}


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

- [x] 현재 닉네임과 동일여부 검증 기능
- [x] 중복 닉네임 여부 검증 기능
- [x] 닉네임 변경 기능 

<br><br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.
### 1. 도메인 요구사항을 코드로 반영하고자 했어요.
**닉네임 변경 시, 현재 닉네임으로는 변경할 수 없다** 라는 **도메인 요구사항을 코드로 명시**하기 위해
아래와 같이 changeNickname 메서드 내부에 검증 로직을 포함시켰어요.
```java
// User Domain Entity
public void changeNickname(final String nickname) {
	validateNotEqualsCurrentNickname(nickname);
	this.nickname = nickname;
}
```

<br><br>
### 2. DB I/O를 최소화하기 위해 `현재 닉네임과 동일여부 검증`을 먼저 확인하도록 했어요.
```java
// Service
@Transactional
public ChangeUserNicknameResponse changeUserNickname(final User user, final String changeNickname) {
	user.validateNotEqualsCurrentNickname(changeNickname); // 현재 닉네임과 동일여부 검증
	validateDuplicateNickname(changeNickname); //  중복 닉네임 검증
	user.changeNickname(changeNickname);

	return new ChangeUserNicknameResponse(user);
}

private void validateDuplicateNickname(final String nickname) {
	if (userRepository.existsByNickname(nickname)) { // repository 호출 → DB I/O 발생
		throw new DuplicateNicknameException();
	}
}
```
```java
// User Domain Entity
public void validateNotEqualsCurrentNickname(final String nickname) {
	if (this.nickname.equals(nickname)) {
		throw new CurrentNicknameEqualsException();
	}
}
```

<br><br>
### 3. 닉네임 변경 기능은 JPA Dirty Checking을 활용했어요.
repository 에서 queryDsl을 활용해 `update set` 을 사용할 수도 있지만, JPA를 사용하는 시점에서 해당 기능들을 이용하는 것이 좋다고 판단했어요.

```
1, 2, 3번 항목이 맞물려서 `현재 닉네임과 동일 여부 검증`을 2 번 수행하고 있어요. 이 부분이 개인적으로 아쉬워서 피드백 받으면 좋을 것 같아요.
```

<br><br>
### 4. `Custom Exception` 클래스가 추가되었어요.
닉네임 변경 실패 케이스는 다음과 같아요.
1. 현재 닉네임으로 변경 시도
2. 중복 닉네임으로 변경 시도

각 실패 케이스에 대해 프론트엔드 측에서 보여줘야 할 메시지가 달라요.
1. "현재 닉네임과 동일한 닉네임입니다."
2. "이미 존재하는 닉네임입니다."

두 실패 케이스 모두 `400 Status`로 내려줄 경우 프론트엔드 측에서 구분하기 어려울 것이라 생각들었어요.
프론트분과 논의한 결과 1번 실패 케이스는 `409 (Conflict) Status`로 응답을 내려주는게 적합하다는 결론이 내려졌어요.
결과적으로 **각 예외에 대해 Http Status를 구분하여 응답으로 내려주기 위해** Custom Exception을 도입했어요.
(1번 케이스의 경우 프론트에서 방어 로직이 존재하지만, postman 등 javascript를 거치지 않고 요청을 보낼 수 있기 때문에 백엔드 측에서도 방어로직이 필요하다 판단했어요.)

```java
public class DuplicateNicknameException extends RuntimeException {

	public static final String MESSAGE = "이미 존재하는 닉네임입니다.";

	public DuplicateNicknameException() {
		super(MESSAGE);
	}
}
```

```java
public class CurrentNicknameEqualsException extends RuntimeException {

	public static final String MESSAGE = "현재 닉네임과 동일한 닉네임입니다.";

	public CurrentNicknameEqualsException() {
		super(MESSAGE);
	}
}
```

CustomException 클래스의 패키지 위치는 `domain/exception` 으로 두었어요.
`service/exception` 처럼 서비스 하위에 둘까 고민했지만, domain 에서 해당 예외를 throw 하는 과정에서 `domain ←→ service` 순환 참조가 발생하기 때문에 도메인 하위에 위치해두었어요.

---

3월 6일 (수) 코드 리뷰 반영 및 추가사항
### 1. 도메인 검증 로직을 서비스 계층에 응집시켰어요.
비즈니스 요구사항을 Domain 객체에 코드로 반영하는 스타일을 선호하지만, 현재는 그 방법이 어려운 상태에요.
닉네임 중복 여부 검증을 위해선 레포지토리를 거쳐야하기 때문이에요.
따라서 서비스 계층에 검증 로직을 모두 위치시키는 방법으로 코드를 수정했어요.
```java
public class ChangeNicknameService {

	private final UserRepositoryImpl userRepository;

	@Transactional
	public ChangeUserNicknameResponse changeUserNickname(final User user, final String changeNickname) {
		validateChangeNickname(user, changeNickname);
		user.changeNickname(changeNickname);

		return new ChangeUserNicknameResponse(user);
	}

	private void validateChangeNickname(final User user, final String nickname) {
		validateNotEqualsCurrentNickname(user, nickname);
		validateDuplicateNickname(nickname);
	}

	private void validateNotEqualsCurrentNickname(final User user, final String nickname) {
		if (user.equalsNickname(nickname)) {
			throw new CurrentNicknameEqualsException();
		}
	}

	private void validateDuplicateNickname(final String nickname) {
		if (userRepository.existsByNickname(nickname)) {
			throw new DuplicateNicknameException();
		}
	}
}

```

<br> <br>
### 현재 닉네임과 동일한 닉네임 예외에 대한 Http Status 409를 400으로 통일시켰어요.
닉네임 변경에 대한 예외 사항은 아래로 확립되었어요.
1. 빈 문자열 X
2. 공백 문자열 X
3. 맨 앞/뒤 공백 문자열 X
4. 길이 1 ~ 20 글자
5. 현재 닉네임과 동일한 닉네임 X
6. 중복된 닉네임 X

생각보다 닉네임 변경 실패 케이스 예외가 많아서 각 케이스에 따라 Http Status를 분류하여 내려주는 것은 부적합하다 판단했어요.
(Http Status로 표현할 수 있는 정도가 한정되어 있기 때문이에요)
따라서 Http Status 400으로 통일성있게 응답을 내려주고, 세부 예외 메시지로 분류하는 것이 적합하다 판단했어요.

<br> <br>

### Bean Validation을 추가했어요
1. 빈 문자열 X
2. 공백 문자열 X
3. 맨 앞/뒤 공백 문자열 X
4. 길이 1 ~ 20 글자
를 검증하기 위해 RequestDTO에 Bean Validation을 추가했어요.

```java
// resuetDTO
public record ChangeUserNicknameRequest(
		@NotBlank
		@NotEmpty
		@Pattern(regexp = "^\\S(.*\\S)?$", message = "맨 앞, 맨 뒤는 공백일 수 없습니다.")
                @Size(min = 1, max = 20)
		String changeNickname
) {
}

```

```java
// controller
@PostMapping("/users/me/nickname")
public ResponseEntity<BaseApiResponse<ChangeUserNicknameResponse>> changeNickname(@AuthUser final User user, @RequestBody @Valid final ChangeUserNicknameRequest changeNickname) {
```



<br> <br>

### Custom Exception 이 Business Exception 을 상속하도록 했어요.
상속하지 않는다면 컨트롤러는 아래와 같이 구현돼요.
```java
@PostMapping("/users/me/nickname")
public ResponseEntity<BaseApiResponse<ChangeUserNicknameResponse>> changeNickname(@AuthUser final User user,
																					  @RequestBody @Valid final ChangeUserNicknameRequest changeNickname) {

	try {
		final ChangeUserNicknameResponse response = changeNicknameService.changeUserNickname(user,
				changeNickname.changeNickname());
			return ResponseEntity.ok(BaseApiResponse.success("닉네임 변경 성공", response));
	} catch (DuplicateNicknameException e) {
			return ResponseEntity.status(HttpStatus.BAD_REQUEST)
				.body(BaseApiResponse.fail(e.getMessage(), null));
	} catch (CurrentNicknameEqualsException e) {
			return ResponseEntity.status(HttpStatus.BAD_REQUEST)
				.body(BaseApiResponse.fail(e.getMessage(), null));
	}
}
```

- RuntimeException을 catch 하는 것처럼 **넓은 범위의 Exception을 catch** 하는 것은 지양해야하는 방법이에요.
- 하지만 현재 프로젝트에서 만들어둔 **Business Exception은 범위가 한정**되어 있고,
- 세부 예외를 catch해도 **수행하는 행위 (Http Status 400 설정, body에 데이터 추가)가 같기 때문에**
- 아래와 같이 구현했어요.

```java
@PostMapping("/users/me/nickname")
public ResponseEntity<BaseApiResponse<ChangeUserNicknameResponse>> changeNickname(@AuthUser final User user,
																					  @RequestBody @Valid final ChangeUserNicknameRequest changeNickname) {

	try {
		final ChangeUserNicknameResponse response = changeNicknameService.changeUserNickname(user,
				changeNickname.changeNickname());
			return ResponseEntity.ok(BaseApiResponse.success("닉네임 변경 성공", response));
	} catch (BusinessException e) {
			return ResponseEntity.status(HttpStatus.BAD_REQUEST)
				.body(BaseApiResponse.fail(e.getMessage(), null));
	}
}
```



<br><br>

## 💡 필요한 후속작업이 있어요.
### Custom Exception 들을 정리할 필요가 있어 보여요.
- Custom Exception 계층 구조를 논의 후 컨벤션 룰로 설정하면 좋을 것 같아요.

### Exception 핸들링에 대한 전역 처리가 필요해요.
```java
	@PostMapping("/users/me/nickname")
	public ResponseEntity<BaseApiResponse<ChangeUserNicknameResponse>> changeNickname(@AuthUser final User user,
																					  @RequestBody final ChangeUserNicknameRequest changeNickname) {

		try {
			final ChangeUserNicknameResponse response = changeNicknameService.changeUserNickname(user,
					changeNickname.changeNickname());

			return ResponseEntity.ok(BaseApiResponse.success("닉네임 변경 성공", response));
		} catch (CurrentNicknameEqualsException e) {

			return ResponseEntity.status(HttpStatus.CONFLICT)
					.body(BaseApiResponse.fail(e.getMessage(), null));
		} catch (DuplicateNicknameException e) {

			return ResponseEntity.status(HttpStatus.BAD_REQUEST)
					.body(BaseApiResponse.fail(e.getMessage(), null));
		}
	}
```
- 위의 컨트롤러 클래스는 `Exception`을 핸들링하기 위한 코드들이 많아요. 모든 컨트롤러에서 위와 같이 핸들링하면, 불필요한 중복 작업이 된다고 생각해요.
- 현재 Domain, Service 계층에서 뱉고 있는 여러 Custom Exception, 기본 Exception 들을 어떻게 핸들링해야 좋을지 다양한 논의가 필요해요.

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
