### PR TITLE
SP-357/Feat: 소셜 회원가입 시 중복되지 않는 기본 닉네임 부여

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/google/service/GoogleSignUpService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/google/service/GoogleSignUpService.java
@@ -25,10 +25,7 @@ public class GoogleSignUpService {
 
 		validateAlreadySignUp(userInfo);
 
-		final User user = userInfo.toUser();
-		userRepository.save(user);
-
-		return user;
+		return signup(userInfo);
 	}
 
 	private void validateAlreadySignUp(final GoogleUserInfo userInfo) {
@@ -36,6 +33,12 @@ public class GoogleSignUpService {
 				.ifPresent(user -> {
 					throw new IllegalArgumentException("이미 가입되어 있는 회원입니다.");
 				});
+	}
+
+	private User signup(final GoogleUserInfo userInfo) {
+		final User user = userRepository.save(userInfo.toUser());
+		user.setInitialDefaultNickname();
+		return user;
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/kakao/service/KakaoSignUpService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/kakao/service/KakaoSignUpService.java
@@ -31,9 +31,7 @@ public class KakaoSignUpService {
 
 		validateAlreadySignUp(kakaoUserProfileDto);
 
-		User user = kakaoUserProfileDto.toUser();
-		userRepository.save(user);
-		return user;
+		return sinup(kakaoUserProfileDto);
 	}
 
 	private void validateAlreadySignUp(final KakaoUserProfileDto userInfo) {
@@ -41,6 +39,12 @@ public class KakaoSignUpService {
 				.ifPresent(user -> {
 					throw new IllegalArgumentException("이미 가입되어 있는 회원입니다.");
 				});
+	}
+
+	private User sinup(KakaoUserProfileDto kakaoUserProfileDto) {
+		User user = userRepository.save(kakaoUserProfileDto.toUser());
+		user.setInitialDefaultNickname();
+		return user;
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/naver/service/NaverSignUpService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/naver/service/NaverSignUpService.java
@@ -38,8 +38,8 @@ public class NaverSignUpService {
 	}
 
 	private void signup(final UserProfile userProfile) {
-		User user = userProfile.toUser();
-		userRepository.save(user);
+		User user = userRepository.save(userProfile.toUser());
+		user.setInitialDefaultNickname();
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/domain/User.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/domain/User.java
@@ -1,6 +1,7 @@
 package com.ludo.study.studymatchingplatform.user.domain;
 
 import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
+import com.ludo.study.studymatchingplatform.user.domain.exception.UserExceptionMessage;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -26,6 +27,9 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 public class User extends BaseEntity {
 
+	public static final String DEFAULT_NICKNAME_PREFIX = "스따-디 %d";
+	public static final Long DEFAULT_NICKNAME_ID = 716L;
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "user_id")
@@ -47,6 +51,17 @@ public class User extends BaseEntity {
 		this.social = social;
 		this.nickname = nickname;
 		this.email = email;
+	}
+
+	public void setInitialDefaultNickname() {
+		validateInitDefaultNickname();
+		this.nickname = String.format(DEFAULT_NICKNAME_PREFIX, DEFAULT_NICKNAME_ID + id);
+	}
+
+	private void validateInitDefaultNickname() {
+		if (this.id == null) {
+			throw new IllegalArgumentException(UserExceptionMessage.INIT_DEFAULT_NICKNAME.getMessage());
+		}
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/domain/exception/UserExceptionMessage.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/domain/exception/UserExceptionMessage.java
@@ -1,0 +1,16 @@
+package com.ludo.study.studymatchingplatform.user.domain.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum UserExceptionMessage {
+
+	INIT_DEFAULT_NICKNAME("초기 닉네임은 id가 존재해야 합니다.");
+
+	private final String message;
+
+	UserExceptionMessage(String message) {
+		this.message = message;
+	}
+
+}

--- a/src/test/java/com/ludo/study/studymatchingplatform/user/domain/UserTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/user/domain/UserTest.java
@@ -1,0 +1,32 @@
+package com.ludo.study.studymatchingplatform.user.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ludo.study.studymatchingplatform.study.fixture.UserFixture;
+import com.ludo.study.studymatchingplatform.user.domain.exception.UserExceptionMessage;
+
+class UserTest {
+
+	@Test
+	@DisplayName("[Success] 사용자 초기 닉네임 설정 성공")
+	void initDefaultNickname() {
+		User user = UserFixture.createUserWithId(1L, Social.NAVER, "archa", "archa@naver.com");
+		user.setInitialDefaultNickname();
+
+		assertThat(user.getNickname())
+				.isEqualTo(String.format(User.DEFAULT_NICKNAME_PREFIX, User.DEFAULT_NICKNAME_ID + 1L));
+	}
+
+	@Test
+	@DisplayName("[Exception] 사용자 아이디가 없을 경우 초기 닉네임 설정 실패")
+	void useridIsNull() {
+		User user = UserFixture.createUser(Social.NAVER, "archa", "archa@naver.com");
+
+		assertThatThrownBy(user::setInitialDefaultNickname)
+				.hasMessage(UserExceptionMessage.INIT_DEFAULT_NICKNAME.getMessage());
+	}
+
+}


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.
- [x] 사용자 기본 닉네임 설정 기능
- [x] 사용자 기본 닉네임 설정 가능 여부 검증 기능
- [x] 회원가입 서비스 계층에 사용자 기본 닉네임 설정 호출 로직 추가


<br><br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.
### 기본 닉네임 설정에 대한 도메인 비즈니스 로직을 추가했어요.
```java
public class User {
	public static final String DEFAULT_NICKNAME_PREFIX = "스따-디 %d";
	public static final Long DEFAULT_NICKNAME_ID = 716L;

	public void setInitialDefaultNickname() {
		validateInitDefaultNickname();
		this.nickname = String.format(DEFAULT_NICKNAME_PREFIX, DEFAULT_NICKNAME_ID + id);
	}

	private void validateInitDefaultNickname() {
		if (this.id == null) {
			throw new IllegalArgumentException(UserExceptionMessage.INIT_DEFAULT_NICKNAME.getMessage());
		}
	}
}
```
- 기본 닉네임 설정 시, 아이디 값이 존재해야 한다는 **비즈니스 요구사항을 도메인 로직 코드로 반영**하고자 했어요.
- `setInitialDefaultNickname` 을 **호출할 때 마다, `String.format`을 호출**해야 하는 점이 아쉬움으로 남았어요.
- `DEFAULT_NICKNAME_PREFIX`, `DEFAULT_NICKNAME_ID` 상수를 User Domain Entity에서 관리하는게 적합한 구조인지 애매하다는 판단이 들어요. 별도의 **Config Enum 으로 관리**하면 좋을 듯 싶은데, 피드백 주시면 반영해볼게요.

<br> <br>
### 테스트는 도메인 단위 테스트로 진행했어요.
현재 서비스 계층은 **외부 API (Naver, Google, Kakao OAuth Server)에 의존적으로 구현되어 있기 때문에** 테스트가 어려워요.
아래의 naverSignup 메서드를 보면, OAuth Server에 액세스 토큰 및 프로필 요청이 수행된 후에야 회원가입이 완료되기 때문이에요.
```java
@Transactional
public SignupResponse naverSignUp(final String authorizationCode) {
	final NaverOAuthToken oAuthToken = naverOAuthTokenRequestService.createOAuthToken(authorizationCode); // naverOAuth에 토큰을 요청하는 로직
	final UserProfile userProfile = naverProfileRequestService.createNaverProfile(oAuthToken); // naverOAuth에 프로필을 요청하는 로직

	validateAlreadySignUp(userProfile);
	signup(userProfile);

	return new SignupResponse(true, "회원가입을 완료했습니다.");
}
```

이를 해결할 수 있는 방법이 없는건 아니에요.
방법1. `NaverOAuthTokenRequestService`와 `NaverProfileRequestService` 클래스를 **인터페이스로 분리** 하면 테스트하기 용이한 코드로 개선할 수 있어요.

방법2. `signup`만 수행하는 클래스로 분리해서 해당 클래스를 테스트하는 방법이에요.
```java
// ex
public class SignupClass {

    public void signup(UserProfile userProfile) {
        // something
    }

}

```
하지만 현재 OAuth 구현 로직은 리팩터링할 사안이 남아있기 때문에, 추상화 및 구조적 변경을 최소화하고 현재 구조를 유지하고자 했어요. (방법 1 혹은 방법 2에 대해 피드백 주시면 반영할 수는 있어요 🙂)



결과적으로 서비스 계층은 아래와 같이 `User.setInitialDefaultNickname` 호출 로직만 추가되었기 때문에
```java
private void signup(final UserProfile userProfile) {
	User user = userRepository.save(userProfile.toUser());
	user.setInitialDefaultNickname();
}
```

해당 도메인 단위 테스트만 진행해도 괜찮을 것으로 판단했어요.
```java
@Test
@DisplayName("[Success] 사용자 초기 닉네임 설정 성공")
void initDefaultNickname() {
	User user = UserFixture.createUserWithId(1L, Social.NAVER, "archa", "archa@naver.com");
	user.setInitialDefaultNickname();
	assertThat(user.getNickname())
		.isEqualTo(String.format(User.DEFAULT_NICKNAME_PREFIX, User.DEFAULT_NICKNAME_ID + 1L));
}

@Test
@DisplayName("[Exception] 사용자 아이디가 없을 경우 초기 닉네임 설정 실패")
void useridIsNull() {
	User user = UserFixture.createUser(Social.NAVER, "archa", "archa@naver.com");
		assertThatThrownBy(user::setInitialDefaultNickname)
			.hasMessage(UserExceptionMessage.INIT_DEFAULT_NICKNAME.getMessage());
}
```

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
