### PR TITLE
SP-324/Fix: 스터디 지원 수락 / 거절 API 명세 수정 반영

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/study/controller/RecruitmentController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/controller/RecruitmentController.java
@@ -26,12 +26,9 @@ import com.ludo.study.studymatchingplatform.study.service.PopularRecruitmentsFin
 import com.ludo.study.studymatchingplatform.study.service.RecruitmentDetailsFindService;
 import com.ludo.study.studymatchingplatform.study.service.RecruitmentService;
 import com.ludo.study.studymatchingplatform.study.service.RecruitmentsFindService;
-import com.ludo.study.studymatchingplatform.study.service.StudyApplicantDecisionService;
 import com.ludo.study.studymatchingplatform.study.service.dto.request.ApplyRecruitmentRequest;
 import com.ludo.study.studymatchingplatform.study.service.dto.request.EditRecruitmentRequest;
-import com.ludo.study.studymatchingplatform.study.service.dto.request.StudyApplicantDecisionRequest;
 import com.ludo.study.studymatchingplatform.study.service.dto.request.WriteRecruitmentRequest;
-import com.ludo.study.studymatchingplatform.study.service.dto.response.ApplyAcceptResponse;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.ApplyRecruitmentResponse;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.DeleteRecruitmentResponse;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.EditRecruitmentResponse;
@@ -55,7 +52,6 @@ public class RecruitmentController {
 	private final RecruitmentsFindService recruitmentsFindService;
 	private final PopularRecruitmentsFindService popularRecruitmentsFindService;
 	private final RecruitmentService recruitmentService;
-	private final StudyApplicantDecisionService applicantDecisionService;
 
 	@GetMapping("/recruitments")
 	public ResponseEntity<BaseApiResponse<RecruitmentPreviewResponses>> readRecruitments(
@@ -129,35 +125,6 @@ public class RecruitmentController {
 			@AuthUser final User user) {
 		final Applicant applicant = recruitmentService.apply(user, recruitmentId, request);
 		return ResponseEntity.ok(BaseApiResponse.success("지원 성공", ApplyRecruitmentResponse.from(applicant)));
-	}
-
-	@IsAuthenticated
-	@PostMapping("/studies/{studyId}/recruitments/{recruitmentId}/apply-accept/{applicantUserId}")
-	public ResponseEntity<BaseApiResponse<ApplyAcceptResponse>> applicantAccept(@AuthUser final User user,
-																				@PathVariable final Long studyId,
-																				@PathVariable Long recruitmentId,
-																				@PathVariable Long applicantUserId) {
-
-		final StudyApplicantDecisionRequest studyApplicantDecisionRequest = new StudyApplicantDecisionRequest(studyId,
-				recruitmentId, applicantUserId);
-		ApplyAcceptResponse applyAcceptResponse = applicantDecisionService.applicantAccept(user,
-				studyApplicantDecisionRequest);
-
-		return ResponseEntity.ok(BaseApiResponse.success("지원자 수락 성공", applyAcceptResponse));
-	}
-
-	@IsAuthenticated
-	@PostMapping("/studies/{studyId}/recruitments/{recruitmentId}/apply-refuse/{applicantUserId}")
-	public ResponseEntity<BaseApiResponse<Void>> applicantRefuse(@AuthUser final User user,
-																 @PathVariable final Long studyId,
-																 @PathVariable Long recruitmentId,
-																 @PathVariable Long applicantUserId) {
-
-		final StudyApplicantDecisionRequest studyApplicantDecisionRequest = new StudyApplicantDecisionRequest(studyId,
-				recruitmentId, applicantUserId);
-		applicantDecisionService.applicantReject(user, studyApplicantDecisionRequest);
-
-		return ResponseEntity.ok(new BaseApiResponse<>(true, "지원자 거절 성공", null));
 	}
 
 	@DeleteMapping("/studies/{studyId}/recruitments")

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/controller/StudyController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/controller/StudyController.java
@@ -19,12 +19,14 @@ import com.ludo.study.studymatchingplatform.auth.common.IsAuthenticated;
 import com.ludo.study.studymatchingplatform.study.controller.dto.response.BaseApiResponse;
 import com.ludo.study.studymatchingplatform.study.domain.Study;
 import com.ludo.study.studymatchingplatform.study.domain.StudyStatus;
-import com.ludo.study.studymatchingplatform.study.service.RecruitmentDeleteService;
+import com.ludo.study.studymatchingplatform.study.service.StudyApplicantDecisionService;
 import com.ludo.study.studymatchingplatform.study.service.StudyCreateService;
 import com.ludo.study.studymatchingplatform.study.service.StudyFetchService;
 import com.ludo.study.studymatchingplatform.study.service.StudyService;
 import com.ludo.study.studymatchingplatform.study.service.StudyStatusService;
+import com.ludo.study.studymatchingplatform.study.service.dto.request.StudyApplicantDecisionRequest;
 import com.ludo.study.studymatchingplatform.study.service.dto.request.WriteStudyRequest;
+import com.ludo.study.studymatchingplatform.study.service.dto.response.ApplyAcceptResponse;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.StudyResponse;
 import com.ludo.study.studymatchingplatform.user.domain.User;
 
@@ -37,9 +39,9 @@ public class StudyController {
 
 	private final StudyCreateService studyCreateService;
 	private final StudyFetchService studyFetchService;
-	private final RecruitmentDeleteService recruitmentCreateService;
 	private final StudyStatusService studyStatusService;
 	private final StudyService studyService;
+	private final StudyApplicantDecisionService applicantDecisionService;
 
 	@IsAuthenticated
 	@PostMapping
@@ -76,6 +78,33 @@ public class StudyController {
 		final StudyResponse response = StudyResponse.from(study);
 
 		return ResponseEntity.ok(BaseApiResponse.success("스터디 조회가 완료되었습니다.", response));
+	}
+
+	@IsAuthenticated
+	@PostMapping("/{studyId}/apply-accept/{applicantUserId}")
+	public ResponseEntity<BaseApiResponse<ApplyAcceptResponse>> applicantAccept(@AuthUser final User user,
+																				@PathVariable final Long studyId,
+																				@PathVariable Long applicantUserId) {
+
+		final StudyApplicantDecisionRequest studyApplicantDecisionRequest = new StudyApplicantDecisionRequest(studyId,
+				applicantUserId);
+		ApplyAcceptResponse applyAcceptResponse = applicantDecisionService.applicantAccept(user,
+				studyApplicantDecisionRequest);
+
+		return ResponseEntity.ok(BaseApiResponse.success("지원자 수락 성공", applyAcceptResponse));
+	}
+
+	@IsAuthenticated
+	@PostMapping("/{studyId}/apply-refuse/{applicantUserId}")
+	public ResponseEntity<BaseApiResponse<Void>> applicantRefuse(@AuthUser final User user,
+																 @PathVariable final Long studyId,
+																 @PathVariable Long applicantUserId) {
+
+		final StudyApplicantDecisionRequest studyApplicantDecisionRequest = new StudyApplicantDecisionRequest(studyId,
+				applicantUserId);
+		applicantDecisionService.applicantReject(user, studyApplicantDecisionRequest);
+
+		return ResponseEntity.ok(new BaseApiResponse<>(true, "지원자 거절 성공", null));
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/Study.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/Study.java
@@ -168,23 +168,22 @@ public class Study extends BaseEntity {
 		}
 	}
 
-	public void acceptApplicant(final User owner, final User applicantUser, final Long recruitmentId) {
-		ensureAcceptApplicant(owner, applicantUser, recruitmentId);
+	public void acceptApplicant(final User owner, final User applicantUser) {
+		ensureAcceptApplicant(owner, applicantUser);
 		accept(applicantUser);
 		if (isMaxParticipantCount()) {
 			changeStatus(StudyStatus.RECRUITED);
 		}
 	}
 
-	public void rejectApplicant(final User owner, final User applicantUser, final Long recruitmentId) {
-		ensureRejectApplicant(owner, applicantUser, recruitmentId);
+	public void rejectApplicant(final User owner, final User applicantUser) {
+		ensureRejectApplicant(owner, applicantUser);
 		recruitment.rejectApplicant(applicantUser);
 	}
 
-	private void ensureRejectApplicant(final User owner, final User applicantUser, final Long recruitmentId) {
+	private void ensureRejectApplicant(final User owner, final User applicantUser) {
 		ensureCorrectOwner(owner);
 		ensureApplicantUserIsNotOwner(owner, applicantUser);
-		ensureCorrectRecruitment(recruitmentId);
 		recruitment.ensureCorrectApplicantUser(applicantUser);
 	}
 
@@ -194,12 +193,11 @@ public class Study extends BaseEntity {
 		}
 	}
 
-	private void ensureAcceptApplicant(final User owner, final User applicantUser, final Long recruitmentId) {
+	private void ensureAcceptApplicant(final User owner, final User applicantUser) {
 		ensureCorrectOwner(owner);
 		ensureApplicantUserIsNotOwner(owner, applicantUser);
 		ensureRecruiting();
 		ensureRemainParticipantLimit();
-		ensureCorrectRecruitment(recruitmentId);
 		recruitment.ensureCorrectApplicantUser(applicantUser);
 	}
 
@@ -215,12 +213,6 @@ public class Study extends BaseEntity {
 	private void ensureRemainParticipantLimit() {
 		if (Objects.equals(getParticipantCount(), participantLimit)) {
 			throw new IllegalStateException("남아있는 자리가 없습니다.");
-		}
-	}
-
-	private void ensureCorrectRecruitment(final Long recruitmentId) {
-		if (!this.recruitment.isIdEquals(recruitmentId)) {
-			throw new IllegalArgumentException("해당 스터디의 모집공고가 아닙니다.");
 		}
 	}
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/StudyApplicantDecisionService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/StudyApplicantDecisionService.java
@@ -6,7 +6,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.ludo.study.studymatchingplatform.study.domain.Participant;
 import com.ludo.study.studymatchingplatform.study.domain.Study;
 import com.ludo.study.studymatchingplatform.study.repository.ParticipantRepositoryImpl;
-import com.ludo.study.studymatchingplatform.study.repository.PositionRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.repository.StudyRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.service.dto.request.StudyApplicantDecisionRequest;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.ApplyAcceptResponse;
@@ -24,14 +23,13 @@ public class StudyApplicantDecisionService {
 	private final StudyRepositoryImpl studyRepository;
 	private final UserRepositoryImpl userRepository;
 	private final ParticipantRepositoryImpl participantRepository;
-	private final PositionRepositoryImpl positionRepository;
 
 	@Transactional
 	public ApplyAcceptResponse applicantAccept(final User owner, final StudyApplicantDecisionRequest request) {
 		final Study study = findStudy(request.studyId());
 		final User applicantUser = findUser(request.applicantUserId());
 
-		study.acceptApplicant(owner, applicantUser, request.recruitmentId());
+		study.acceptApplicant(owner, applicantUser);
 		Participant participant = findParticipant(study, applicantUser);
 
 		return ApplyAcceptResponse.from(participant);
@@ -42,7 +40,7 @@ public class StudyApplicantDecisionService {
 		final Study study = findStudy(request.studyId());
 		final User applicantUser = findUser(request.applicantUserId());
 
-		study.rejectApplicant(owner, applicantUser, request.recruitmentId());
+		study.rejectApplicant(owner, applicantUser);
 	}
 
 	private User findUser(final Long applicantUserId) {

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/request/StudyApplicantDecisionRequest.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/request/StudyApplicantDecisionRequest.java
@@ -2,7 +2,6 @@ package com.ludo.study.studymatchingplatform.study.service.dto.request;
 
 public record StudyApplicantDecisionRequest(
 		Long studyId,
-		Long recruitmentId,
 		Long applicantUserId
 ) {
 }

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/domain/StudyTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/domain/StudyTest.java
@@ -35,32 +35,8 @@ class StudyTest {
 			Recruitment recruitment = RecruitmentFixture.createRecruitment(study, "모집공고", "내용", 0, null, null);
 
 			// when then
-			assertThatThrownBy(() -> study.acceptApplicant(notOwner, applicant, recruitment.getId()))
+			assertThatThrownBy(() -> study.acceptApplicant(notOwner, applicant))
 					.hasMessageContaining("스터디 장이 아닙니다.");
-		}
-
-		/**
-		 * test scenario:
-		 * 스터디 지원자 수락 API -> /studies/{study-id}/recruitments/{recruitment-id}
-		 * 중 recruitment-id를 임의로 바꿔서 요청을 보내는 경우
-		 */
-		@Test
-		@DisplayName("[Exception] 다른 스터디 모집공고로 지원한 경우 예외 발생")
-		void otherRecruitment() {
-			// given
-			long otherRecruitmentId = 100;
-			User owner = UserFixture.createUser(Social.NAVER, "archa", "archa@naver.com");
-			User applicantUser = UserFixture.createUser(Social.NAVER, "applicant", "applicant@naver.com");
-
-			Study ownerStudy = StudyFixture.createStudy(owner, "스터디 A", 5, StudyStatus.RECRUITING);
-
-			Recruitment ownerStudyRecruitment = RecruitmentFixture.createRecruitment(ownerStudy, "모집공고", "내용", 0, null,
-					null);
-			ownerStudy.registerRecruitment(ownerStudyRecruitment);
-
-			// when, then
-			assertThatThrownBy(() -> ownerStudy.acceptApplicant(owner, applicantUser, otherRecruitmentId))
-					.hasMessage("해당 스터디의 모집공고가 아닙니다.");
 		}
 
 		@Test
@@ -78,7 +54,7 @@ class StudyTest {
 			}
 
 			// when then
-			assertThatThrownBy(() -> study.acceptApplicant(owner, applicantUser, null))
+			assertThatThrownBy(() -> study.acceptApplicant(owner, applicantUser))
 					.hasMessage("남아있는 자리가 없습니다.");
 		}
 
@@ -92,7 +68,7 @@ class StudyTest {
 			Study study = StudyFixture.createStudy(owner, "스터디 A", 5, studyStatus);
 
 			// when then
-			assertThatThrownBy(() -> study.acceptApplicant(owner, applicantUser, null))
+			assertThatThrownBy(() -> study.acceptApplicant(owner, applicantUser))
 					.hasMessage("현재 모집 중인 스터디가 아닙니다.");
 		}
 
@@ -107,7 +83,7 @@ class StudyTest {
 			User notApplicantUser = UserFixture.createUser(Social.NAVER, "other", "other@gmail.com");
 
 			// when then
-			assertThatThrownBy(() -> study.acceptApplicant(owner, notApplicantUser, recruitment.getId()))
+			assertThatThrownBy(() -> study.acceptApplicant(owner, notApplicantUser))
 					.hasMessage("지원자 목록에 존재하지 않는 사용자입니다.");
 		}
 
@@ -120,7 +96,7 @@ class StudyTest {
 			Recruitment recruitment = RecruitmentFixture.createRecruitment(study, "모집공고", "내용", 5, null, null);
 
 			// when then
-			assertThatThrownBy(() -> study.acceptApplicant(owner, owner, recruitment.getId()))
+			assertThatThrownBy(() -> study.acceptApplicant(owner, owner))
 					.hasMessage("스터디 장과 지원자가 같습니다.");
 		}
 
@@ -143,7 +119,7 @@ class StudyTest {
 			assertThat(recruitment.getApplicants().get(0).getApplicantStatus()).isEqualTo(ApplicantStatus.UNCHECKED);
 
 			// then
-			assertThatCode(() -> study.acceptApplicant(owner, applicantUser, recruitment.getId()))
+			assertThatCode(() -> study.acceptApplicant(owner, applicantUser))
 					.doesNotThrowAnyException();
 			assertThat(study.getParticipantCount()).isEqualTo(1);
 			assertThat(recruitment.getApplicants().get(0).getApplicantStatus()).isEqualTo(ApplicantStatus.ACCEPTED);
@@ -168,7 +144,7 @@ class StudyTest {
 				User user = UserFixture.createUser(Social.NAVER, "닉네임", "email@google.com");
 				Applicant applicant = Applicant.of(recruitment, user, PositionFixture.createPosition("백엔드"));
 				recruitment.addApplicant(applicant);
-				study.acceptApplicant(owner, user, recruitment.getId());
+				study.acceptApplicant(owner, user);
 			}
 
 			User applicantUser = UserFixture.createUser(Social.NAVER, "other", "other@gmail.com");
@@ -176,7 +152,7 @@ class StudyTest {
 			recruitment.addApplicant(applicant);
 
 			// when
-			study.acceptApplicant(owner, applicantUser, recruitment.getId());
+			study.acceptApplicant(owner, applicantUser);
 
 			// then
 			assertThatThrownBy(study::ensureRecruiting).hasMessage("현재 모집 중인 스터디가 아닙니다.");
@@ -199,27 +175,8 @@ class StudyTest {
 			study.addRecruitment(recruitment);
 
 			// when then
-			assertThatThrownBy(() -> study.rejectApplicant(notOwner, applicant, recruitment.getId()))
+			assertThatThrownBy(() -> study.rejectApplicant(notOwner, applicant))
 					.hasMessageContaining("스터디 장이 아닙니다.");
-		}
-
-		@Test
-		@DisplayName("[Exception] 다른 스터디 모집공고로 지원한 경우 예외 발생")
-		void otherRecruitment() {
-			// given
-			long otherRecruitmentId = 100;
-			User owner = UserFixture.createUser(Social.NAVER, "archa", "archa@naver.com");
-			User applicantUser = UserFixture.createUser(Social.NAVER, "applicant", "applicant@naver.com");
-
-			Study ownerStudy = StudyFixture.createStudy(owner, "스터디 A", 5, StudyStatus.RECRUITING);
-
-			Recruitment ownerStudyRecruitment = RecruitmentFixture.createRecruitment(ownerStudy, "모집공고", "내용", 0, null,
-					null);
-			ownerStudy.registerRecruitment(ownerStudyRecruitment);
-
-			// when, then
-			assertThatThrownBy(() -> ownerStudy.rejectApplicant(owner, applicantUser, otherRecruitmentId))
-					.hasMessage("해당 스터디의 모집공고가 아닙니다.");
 		}
 
 		@Test
@@ -233,7 +190,7 @@ class StudyTest {
 			User notApplicantUser = UserFixture.createUser(Social.NAVER, "other", "other@gmail.com");
 
 			// when then
-			assertThatThrownBy(() -> study.acceptApplicant(owner, notApplicantUser, recruitment.getId()))
+			assertThatThrownBy(() -> study.acceptApplicant(owner, notApplicantUser))
 					.hasMessage("지원자 목록에 존재하지 않는 사용자입니다.");
 		}
 
@@ -246,7 +203,7 @@ class StudyTest {
 			Recruitment recruitment = RecruitmentFixture.createRecruitment(study, "모집공고", "내용", 5, null, null);
 
 			// when then
-			assertThatThrownBy(() -> study.rejectApplicant(owner, owner, recruitment.getId()))
+			assertThatThrownBy(() -> study.rejectApplicant(owner, owner))
 					.hasMessage("스터디 장과 지원자가 같습니다.");
 		}
 
@@ -268,7 +225,7 @@ class StudyTest {
 			assertThat(recruitment.getApplicants().get(0).getApplicantStatus()).isEqualTo(ApplicantStatus.UNCHECKED);
 
 			// then
-			assertThatCode(() -> study.rejectApplicant(owner, applicantUser, recruitment.getId()))
+			assertThatCode(() -> study.rejectApplicant(owner, applicantUser))
 					.doesNotThrowAnyException();
 			assertThat(study.getParticipants()).isEmpty();
 			assertThat(recruitment.getApplicants()).isNotEmpty();

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/service/StudyApplicantDecisionServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/service/StudyApplicantDecisionServiceTest.java
@@ -96,7 +96,7 @@ class StudyApplicantDecisionServiceTest {
 
 		// when
 		StudyApplicantDecisionRequest studyApplicantDecisionRequest = new StudyApplicantDecisionRequest(study.getId(),
-				recruitment.getId(), other.getId());
+				other.getId());
 		ApplyAcceptResponse applyAcceptResponse = applicantDecisionService.applicantAccept(owner,
 				studyApplicantDecisionRequest);
 
@@ -135,7 +135,7 @@ class StudyApplicantDecisionServiceTest {
 
 		// when
 		StudyApplicantDecisionRequest studyApplicantDecisionRequest = new StudyApplicantDecisionRequest(study.getId(),
-				recruitment.getId(), other.getId());
+				other.getId());
 		applicantDecisionService.applicantReject(owner, studyApplicantDecisionRequest);
 
 		// then


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.
관련 PR: https://github.com/Ludo-SMP/ludo-backend/pull/30
- [x] https://github.com/Ludo-SMP/ludo-backend/issues/61

<br><br>

## 💡 이슈를 처리하면서 수정된 코드가 있어요.
### 도메인 비즈니스 로직의 메서드 시그니쳐가 변경되었어요.
**스터디 지원자 수락, 거절 메서드 시그니쳐** 변경사항은 다음과 같아요.
```java
// before
public void acceptApplicant(final User owner, final User applicantUser, final Long recruitmentId) {
}

public void rejectApplicant(final User owner, final User applicantUser, final Long recruitmentId) {
}
```

```java
// after
public void acceptApplicant(final User owner, final User applicantUser) {
}

public void rejectApplicant(final User owner, final User applicantUser) {
}
```

- **`Study` Domain 은 `Recruitment` Domain을 인스턴스 필드로 갖고있기 때문에** 사실 `Long recruitmentId` 는 필요 없어요.
- 구현을 하면서도 `Long recruitmentId` 존재에 어색함을 느꼈는데 이 문제가 해결 되었어요. @Hugh-KR 좋은 의견 감사합니다 👍


<br> <br>
### 불필요한 검증 메서드와 테스트를 제거했어요.
- 처음에 설계한 API명세는 `/api/studies/{study-id}/recruitments/{recruitment-id}/apply-accept/{applicantUserId}` 였기 때문에
- `recruitment-id`가 잘못된 값으로 보내지는 경우를 염두하기 위한 검증 기능이었어요.
```java
private void ensureCorrectRecruitment(final Long recruitmentId) {
	if (!this.recruitment.isIdEquals(recruitmentId)) {
		throw new IllegalArgumentException("해당 스터디의 모집공고가 아닙니다.");
	}
}
```

- 하지만 `/api/studies/{study-id}/apply-accept/{applicant-user-id}`로 API 명세가 수정되었기 때문에
- 해당 검증 로직을 제거했어요.
- 마찬가지로 관련된 테스트 코드를 제거했어요.


<br><br>

### ✅ 셀프 체크리스트

- [v] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [v] 커밋 메세지를 컨벤션에 맞추었습니다.
- [v] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [v] 변경 후 코드는 기존의 테스트를 통과합니다.
- [v] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [v] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
