### PR TITLE
SP-218/Fix: 인기 모집 공고 목록 조회 기능 수정

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/config/DataInitializer.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/config/DataInitializer.java
@@ -29,10 +29,10 @@ public class DataInitializer {
 						.name("프로젝트")
 						.build(),
 				Category.builder()
-						.name("코딩테스트")
+						.name("코딩 테스트")
 						.build(),
 				Category.builder()
-						.name("모의면접")
+						.name("모의 면접")
 						.build()
 		);
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/controller/RecruitmentController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/controller/RecruitmentController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -20,6 +21,7 @@ import com.ludo.study.studymatchingplatform.auth.common.IsAuthenticated;
 import com.ludo.study.studymatchingplatform.study.controller.dto.response.BaseApiResponse;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Applicant;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
+import com.ludo.study.studymatchingplatform.study.repository.dto.request.PopularRecruitmentCond;
 import com.ludo.study.studymatchingplatform.study.repository.dto.request.RecruitmentFindCond;
 import com.ludo.study.studymatchingplatform.study.repository.dto.request.RecruitmentFindCursor;
 import com.ludo.study.studymatchingplatform.study.service.PopularRecruitmentsFindService;
@@ -92,8 +94,10 @@ public class RecruitmentController {
 	}
 
 	@GetMapping("/recruitments/popular")
-	public ResponseEntity<BaseApiResponse<PopularRecruitmentsResponse>> readPopularRecruitments() {
-		PopularRecruitmentsResponse popularRecruitments = popularRecruitmentsFindService.findPopularRecruitments();
+	public ResponseEntity<BaseApiResponse<PopularRecruitmentsResponse>> readPopularRecruitments(
+			@ModelAttribute PopularRecruitmentCond request) {
+		PopularRecruitmentsResponse popularRecruitments = popularRecruitmentsFindService.findPopularRecruitments(
+				request);
 
 		return ResponseEntity.ok(BaseApiResponse.success("인기 모집 공고 목록 조회 성공", popularRecruitments));
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/repository/dto/request/PopularRecruitmentCond.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/repository/dto/request/PopularRecruitmentCond.java
@@ -1,0 +1,6 @@
+package com.ludo.study.studymatchingplatform.study.repository.dto.request;
+
+public record PopularRecruitmentCond(
+		Integer count
+) {
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/repository/recruitment/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/repository/recruitment/RecruitmentRepositoryImpl.java
@@ -1,6 +1,5 @@
 package com.ludo.study.studymatchingplatform.study.repository.recruitment;
 
-import static com.ludo.study.studymatchingplatform.study.domain.QCategory.*;
 import static com.ludo.study.studymatchingplatform.study.domain.QStudy.*;
 import static com.ludo.study.studymatchingplatform.study.domain.recruitment.QRecruitment.*;
 import static com.ludo.study.studymatchingplatform.study.domain.recruitment.QRecruitmentPosition.*;
@@ -72,13 +71,12 @@ public class RecruitmentRepositoryImpl {
 		recruitmentJpaRepository.delete(recruitment);
 	}
 
-	public List<Recruitment> findPopularRecruitments(final String categoryName,
+	public List<Recruitment> findPopularRecruitments(final Long categoryId,
 													 final PopularRecruitmentCond cond) {
 		return q.select(recruitment)
 				.from(recruitment)
 				.join(recruitment.study, study)
-				.join(study.category, category)
-				.where(category.name.eq(categoryName))
+				.where(study.category.id.eq(categoryId))
 				.limit(cond.count())
 				.orderBy(recruitment.hits.desc())
 				.fetch();

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/repository/recruitment/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/repository/recruitment/RecruitmentRepositoryImpl.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Repository;
 
 import com.ludo.study.studymatchingplatform.study.domain.Way;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
+import com.ludo.study.studymatchingplatform.study.repository.dto.request.PopularRecruitmentCond;
 import com.ludo.study.studymatchingplatform.study.repository.dto.request.RecruitmentFindCond;
 import com.ludo.study.studymatchingplatform.study.repository.dto.request.RecruitmentFindCursor;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -71,13 +72,14 @@ public class RecruitmentRepositoryImpl {
 		recruitmentJpaRepository.delete(recruitment);
 	}
 
-	public List<Recruitment> findPopularRecruitments(final String categoryName) {
+	public List<Recruitment> findPopularRecruitments(final String categoryName,
+													 final PopularRecruitmentCond cond) {
 		return q.select(recruitment)
 				.from(recruitment)
 				.join(recruitment.study, study)
 				.join(study.category, category)
 				.where(category.name.eq(categoryName))
-				.limit(3)
+				.limit(cond.count())
 				.orderBy(recruitment.hits.desc())
 				.fetch();
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/PopularRecruitmentsFindService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/PopularRecruitmentsFindService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
+import com.ludo.study.studymatchingplatform.study.repository.dto.request.PopularRecruitmentCond;
 import com.ludo.study.studymatchingplatform.study.repository.recruitment.RecruitmentRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.service.dto.mapper.RecruitmentPreviewResponseMapper;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.PopularRecruitmentsResponse;
@@ -20,11 +21,11 @@ public class PopularRecruitmentsFindService {
 	private final RecruitmentPreviewResponseMapper recruitmentPreviewResponseMapper;
 
 	@Transactional
-	public PopularRecruitmentsResponse findPopularRecruitments() {
+	public PopularRecruitmentsResponse findPopularRecruitments(final PopularRecruitmentCond cond) {
 
-		List<Recruitment> popularCoding = recruitmentRepository.findPopularRecruitments("코딩 테스트");
-		List<Recruitment> popularInterview = recruitmentRepository.findPopularRecruitments("모의 면접");
-		List<Recruitment> popularProject = recruitmentRepository.findPopularRecruitments("프로젝트");
+		List<Recruitment> popularCoding = recruitmentRepository.findPopularRecruitments("코딩 테스트", cond);
+		List<Recruitment> popularInterview = recruitmentRepository.findPopularRecruitments("모의 면접", cond);
+		List<Recruitment> popularProject = recruitmentRepository.findPopularRecruitments("프로젝트", cond);
 
 		return new PopularRecruitmentsResponse(
 				recruitmentPreviewResponseMapper.mapBy(popularCoding),

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/PopularRecruitmentsFindService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/PopularRecruitmentsFindService.java
@@ -22,14 +22,14 @@ public class PopularRecruitmentsFindService {
 	@Transactional
 	public PopularRecruitmentsResponse findPopularRecruitments() {
 
-		List<Recruitment> popularCoding = recruitmentRepository.findPopularRecruitments("코딩테스트");
-		List<Recruitment> popularInterview = recruitmentRepository.findPopularRecruitments("모의면접");
+		List<Recruitment> popularCoding = recruitmentRepository.findPopularRecruitments("코딩 테스트");
+		List<Recruitment> popularInterview = recruitmentRepository.findPopularRecruitments("모의 면접");
 		List<Recruitment> popularProject = recruitmentRepository.findPopularRecruitments("프로젝트");
 
 		return new PopularRecruitmentsResponse(
-			recruitmentPreviewResponseMapper.mapBy(popularCoding),
-			recruitmentPreviewResponseMapper.mapBy(popularInterview),
-			recruitmentPreviewResponseMapper.mapBy(popularProject)
+				recruitmentPreviewResponseMapper.mapBy(popularCoding),
+				recruitmentPreviewResponseMapper.mapBy(popularInterview),
+				recruitmentPreviewResponseMapper.mapBy(popularProject)
 		);
 	}
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/PopularRecruitmentsFindService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/PopularRecruitmentsFindService.java
@@ -23,15 +23,27 @@ public class PopularRecruitmentsFindService {
 	@Transactional
 	public PopularRecruitmentsResponse findPopularRecruitments(final PopularRecruitmentCond cond) {
 
-		List<Recruitment> popularCoding = recruitmentRepository.findPopularRecruitments("코딩 테스트", cond);
-		List<Recruitment> popularInterview = recruitmentRepository.findPopularRecruitments("모의 면접", cond);
-		List<Recruitment> popularProject = recruitmentRepository.findPopularRecruitments("프로젝트", cond);
+		List<Recruitment> popularProject = findPopularProjects(cond);
+		List<Recruitment> popularCoding = findPopularCodingTests(cond);
+		List<Recruitment> popularInterview = findPopularInterviews(cond);
 
 		return new PopularRecruitmentsResponse(
 				recruitmentPreviewResponseMapper.mapBy(popularCoding),
 				recruitmentPreviewResponseMapper.mapBy(popularInterview),
 				recruitmentPreviewResponseMapper.mapBy(popularProject)
 		);
+	}
+
+	private List<Recruitment> findPopularProjects(final PopularRecruitmentCond cond) {
+		return recruitmentRepository.findPopularRecruitments(1L, cond);
+	}
+
+	private List<Recruitment> findPopularCodingTests(final PopularRecruitmentCond cond) {
+		return recruitmentRepository.findPopularRecruitments(2L, cond);
+	}
+
+	private List<Recruitment> findPopularInterviews(final PopularRecruitmentCond cond) {
+		return recruitmentRepository.findPopularRecruitments(3L, cond);
 	}
 
 }

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/fixture/CategoryFixture.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/fixture/CategoryFixture.java
@@ -5,8 +5,8 @@ import com.ludo.study.studymatchingplatform.study.domain.Category;
 public class CategoryFixture {
 
 	public static final String PROJECT = "프로젝트";
-	public static final String CODING_TEST = "코딩테스트";
-	public static final String INTERVIEW = "인터뷰";
+	public static final String CODING_TEST = "코딩 테스트";
+	public static final String INTERVIEW = "모의 면접";
 
 	public static Category createCategory(String name) {
 		return Category.builder()

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/service/PopularRecruitmentsFindServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/service/PopularRecruitmentsFindServiceTest.java
@@ -16,13 +16,7 @@ import com.ludo.study.studymatchingplatform.study.domain.Study;
 import com.ludo.study.studymatchingplatform.study.domain.StudyStatus;
 import com.ludo.study.studymatchingplatform.study.domain.Way;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
-import com.ludo.study.studymatchingplatform.study.domain.recruitment.RecruitmentStack;
-import com.ludo.study.studymatchingplatform.study.domain.stack.StackCategory;
-import com.ludo.study.studymatchingplatform.study.fixture.CategoryFixture;
 import com.ludo.study.studymatchingplatform.study.fixture.RecruitmentFixture;
-import com.ludo.study.studymatchingplatform.study.fixture.RecruitmentStackFixture;
-import com.ludo.study.studymatchingplatform.study.fixture.StackCategoryFixture;
-import com.ludo.study.studymatchingplatform.study.fixture.StackFixture;
 import com.ludo.study.studymatchingplatform.study.fixture.StudyFixture;
 import com.ludo.study.studymatchingplatform.study.fixture.UserFixture;
 import com.ludo.study.studymatchingplatform.study.repository.CategoryRepositoryImpl;
@@ -61,18 +55,11 @@ class PopularRecruitmentsFindServiceTest {
 	@BeforeEach
 	void init() {
 		User user = UserFixture.createUser(Social.GOOGLE, "아카", "hihi@google.com");
-		Category project = CategoryFixture.createCategory(CategoryFixture.PROJECT);
-		Category algorithm = CategoryFixture.createCategory(CategoryFixture.CODING_TEST);
-		Category interview = CategoryFixture.createCategory(CategoryFixture.INTERVIEW);
+		Category project = categoryRepository.findByName("프로젝트").get();
+		Category algorithm = categoryRepository.findByName("코딩 테스트").get();
+		Category interview = categoryRepository.findByName("모의 면접").get();
 
-		StackCategory backend = StackCategoryFixture.createStackCategory("백엔드");
-		RecruitmentStack spring = RecruitmentStackFixture.createRecruitmentStack(
-				StackFixture.createStack("spring", backend)
-		);
 		userRepository.save(user);
-		categoryRepository.save(project);
-		categoryRepository.save(algorithm);
-		categoryRepository.save(interview);
 
 		Study studyA = StudyFixture.createStudy(StudyStatus.RECRUITING, "스터디A", Way.ONLINE, project, user, 5, 5,
 				Platform.GATHER);

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/service/PopularRecruitmentsFindServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/service/PopularRecruitmentsFindServiceTest.java
@@ -27,6 +27,7 @@ import com.ludo.study.studymatchingplatform.study.fixture.StudyFixture;
 import com.ludo.study.studymatchingplatform.study.fixture.UserFixture;
 import com.ludo.study.studymatchingplatform.study.repository.CategoryRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.repository.StudyRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.dto.request.PopularRecruitmentCond;
 import com.ludo.study.studymatchingplatform.study.repository.recruitment.RecruitmentRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.service.dto.mapper.RecruitmentPreviewResponseMapper;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.PopularRecruitmentsResponse;
@@ -60,9 +61,9 @@ class PopularRecruitmentsFindServiceTest {
 	@BeforeEach
 	void init() {
 		User user = UserFixture.createUser(Social.GOOGLE, "아카", "hihi@google.com");
-		Category project = CategoryFixture.createCategory("프로젝트");
-		Category algorithm = CategoryFixture.createCategory("코딩테스트");
-		Category interview = CategoryFixture.createCategory("모의면접");
+		Category project = CategoryFixture.createCategory(CategoryFixture.PROJECT);
+		Category algorithm = CategoryFixture.createCategory(CategoryFixture.CODING_TEST);
+		Category interview = CategoryFixture.createCategory(CategoryFixture.INTERVIEW);
 
 		StackCategory backend = StackCategoryFixture.createStackCategory("백엔드");
 		RecruitmentStack spring = RecruitmentStackFixture.createRecruitmentStack(
@@ -121,21 +122,23 @@ class PopularRecruitmentsFindServiceTest {
 
 	@Test
 	void 인기있는_프로젝트_모집공고_조회() {
-		PopularRecruitmentsResponse result = popularRecruitmentsFindService.findPopularRecruitments();
+		PopularRecruitmentCond request = new PopularRecruitmentCond(6);
+		PopularRecruitmentsResponse result = popularRecruitmentsFindService.findPopularRecruitments(request);
 		List<RecruitmentPreviewResponse> popularProjectRecruitments = result.popularProjectRecruitments();
 
 		assertThat(popularProjectRecruitments)
 				.size()
-				.isLessThanOrEqualTo(3);
+				.isLessThanOrEqualTo(6);
 
 		assertThat(popularProjectRecruitments)
 				.extracting("title")
-				.containsExactly("모집공고C", "모집공고B", "모집공고A");
+				.containsExactly("모집공고C", "모집공고B", "모집공고A", "모집공고D");
 	}
 
 	@Test
 	void 인기있는_코딩테스트_모집공고_조회() {
-		PopularRecruitmentsResponse result = popularRecruitmentsFindService.findPopularRecruitments();
+		PopularRecruitmentCond request = new PopularRecruitmentCond(6);
+		PopularRecruitmentsResponse result = popularRecruitmentsFindService.findPopularRecruitments(request);
 		List<RecruitmentPreviewResponse> popularCodingRecruitments = result.popularCodingRecruitments();
 
 		assertThat(popularCodingRecruitments)
@@ -149,7 +152,8 @@ class PopularRecruitmentsFindServiceTest {
 
 	@Test
 	void 인기있는_모의면접_모집공고_조회() {
-		PopularRecruitmentsResponse result = popularRecruitmentsFindService.findPopularRecruitments();
+		PopularRecruitmentCond request = new PopularRecruitmentCond(6);
+		PopularRecruitmentsResponse result = popularRecruitmentsFindService.findPopularRecruitments(request);
 		List<RecruitmentPreviewResponse> popularInterviewRecruitments = result.popularInterviewRecruitments();
 
 		assertThat(popularInterviewRecruitments)


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.
- [x] 인기 모집 공고 목록 중 `코딩 테스트 모집 공고`, `모의 면접 모집 공고` 데이터가 조회되지 않는 이슈 해결
- https://github.com/Ludo-SMP/ludo-backend/issues/65
- [x] 카테고리 이름을 비교해서 조회하는 로직을 카테고리 아이디로 비교해서 조회하는 로직으로 수정
- [x] API 요청값에 count가 추가됨에 따라 `PopularRecruitmentCond` DTO 를 사용하도록 수정

<br><br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.
### 변경된 컬럼 내용에 맞도록 코드를 수정했어요.
- 코딩테스트 → 코딩 테스트
- 모의면접 → 모의 면접
```java
@Transactional
public PopularRecruitmentsResponse findPopularRecruitments(final PopularRecruitmentCond cond) {

	List<Recruitment> popularCoding = recruitmentRepository.findPopularRecruitments("코딩 테스트", cond);
	List<Recruitment> popularInterview = recruitmentRepository.findPopularRecruitments("모의 면접", cond);
	List<Recruitment> popularProject = recruitmentRepository.findPopularRecruitments("프로젝트", cond);

	return new PopularRecruitmentsResponse(
			recruitmentPreviewResponseMapper.mapBy(popularCoding),
			recruitmentPreviewResponseMapper.mapBy(popularInterview),
			recruitmentPreviewResponseMapper.mapBy(popularProject)
	);
}
```
하지만 **데이터 컬럼 내용이 바뀔 때마다 코드 수정이 이루어져야하는 단점**이 있어요. 이렇게 구현한 이유는 아래 논의 사항에 설명했어요.

<br> <br>
### 인기 모집 공고 목록 조회 API가 수정되었어요.
원래 결정되었던 인기 모집 공고 목록 디자인이
<img width="504" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/68291395/de417a64-ce5e-4f9c-b54d-0fb2a4179667">


다음과 같이 변경되면서
<img width="490" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/68291395/72e94837-9d72-448c-bfe7-9eae77c50ebb">

**limit 개수에 대한 코드 수정이 불가피했어요.**
```java
public List<Recruitment> findPopularRecruitments(final String categoryName,
										 final PopularRecruitmentCond cond) {
	return q.select(recruitment)
			.from(recruitment)
			.join(recruitment.study, study)
			.join(study.category, category)
			.where(category.name.eq(categoryName))
			.limit(6) // 수정 불가피
			.orderBy(recruitment.hits.desc())
			.fetch();
}
```

매 번 요구사항이 변경될 때 마다 코드 수정이 발생되는 상황이라, 유연하게 대처하기 위해 API를 아래와 같이 수정했고 그에 맞게 구현 로직을 수정했어요. (프론트엔드 분과 사전 논의를 마친 상태에요)
```
// before
/api/recruitments/popular

// after
/api/recruitments/popular?count=6
```


<br><br>

## 💡 논의할 사항이 있어요.
### "코딩 테스트", "모의 면접", "프로젝트" 하드 코딩 문제
`인기 모집 공고 목록 조회` API response 응답은 아래와 같아요.
```
{
  "data": {
    "popularCodingRecruitments": [
       {
         "id": number,
         "title": string,
         "category": string,
         // 생략
       }
    ],
    "popularInterviewRecruitments": [
       {
         "id": number,
         "title": string,
         "category": string,
         // 생략
       }
    ],
    "popularProjectRecruitments": [
       {
         "id": number,
         "title": string,
         "category": string,
         // 생략
       }
    ]
  }
```

`popularCodingRecruitments` → `코딩 테스트`
`popularInterviewRecruitments` → `모의 면접`
`popularProjectRecruitments` → `프로젝트`
각 **popularXXX 에 맞는 응답값을 넣어주기 위해선 하드코딩이 불가피**했어요.

<br><br>
**방안1. categoryId로 조회**
아래와 같이 categoryId 로 조회한다고 해도 모집 공고 Id를 하드코딩 하는 것은 마찬가지이며, Id가 어떤 카테고리인지 기억해야하는 문제도 있어요.
```java
@Transactional
public PopularRecruitmentsResponse findPopularRecruitments(final PopularRecruitmentCond cond) {
        // "코딩 테스트" : 1
        // "모의 면접" : 2
        // "프로젝트" : 3
	List<Recruitment> popularCoding = recruitmentRepository.findPopularRecruitments(1, cond);
	List<Recruitment> popularInterview = recruitmentRepository.findPopularRecruitments(2, cond);
	List<Recruitment> popularProject = recruitmentRepository.findPopularRecruitments(3, cond);

	return new PopularRecruitmentsResponse(
			recruitmentPreviewResponseMapper.mapBy(popularCoding),
			recruitmentPreviewResponseMapper.mapBy(popularInterview),
			recruitmentPreviewResponseMapper.mapBy(popularProject)
	);
}
```


<br> <br>
Id가 어떤 카테고리인지 기억하지 않도록 구현할 순 있지만 마찬가지로 "코딩 테스트" 문자열로 하드코딩해야 함은 마찬가지에요.
```java
List<Recruitment> recruitments = recruitmentRepository.findPopularRecruitments(1, cond);

List<Recruitment> popularCodingTestRecruitments = new ArrayList<>();
for (recruitment: recruitments) {
    if (recruitment.getStudy().getCategory().getName().equals("코딩 테스트") {
            popularCodingTestRecruitments.add(recruitment);
    }
}
```

<br> <br>
**각 스터디 카테고리 별로 조회수 기준 6개씩 조회**를 만족하는 더 좋은 쿼리도 떠오르지 않는 상황이에요.
```java
// 현재 코드
// repository
public List<Recruitment> findPopularRecruitments(final String categoryName,
										 final PopularRecruitmentCond cond) {
	return q.select(recruitment)
			.from(recruitment)
			.join(recruitment.study, study)
			.join(study.category, category)
			.where(category.name.eq(categoryName))
			.limit(cond.count())
			.orderBy(recruitment.hits.desc())
			.fetch();
}
```

<br> <br>
스터디 카테고리를 Enum으로 관리하자니, 스터디 카테고리 엔티티와 의미가 중복되는 느낌이 있어요.
```java
enum TempCategory {
        CODING_TEST("코딩 테스트"),
        PROJECT("프로젝트"),
        INTERVIEW("모의 면접")
}

// 현재
@Entity
class Category {

    	@Id
	@GeneratedValue(strategy = GenerationType.IDENTITY)
	@Column(name = "category_id")
	private Long id;
    // something
}

```


**이 부분에 대해서 피드백 남겨주시면 좋을 것 같아요 🤔🤔🤔**



<br><br>

### ✅ 셀프 체크리스트

- [v] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [v] 커밋 메세지를 컨벤션에 맞추었습니다.
- [v] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [v] 변경 후 코드는 기존의 테스트를 통과합니다.
- [v] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [v] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
