### PR TITLE
SP-373/Refactor: Controller Response 일반화 및 문서화

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/common/AuthController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/common/AuthController.java
@@ -2,11 +2,16 @@ package com.ludo.study.studymatchingplatform.auth.common;
 
 import java.io.IOException;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -19,7 +24,10 @@ public class AuthController {
 	private final Redirection redirection;
 
 	@PostMapping("/auth/logout")
-	public void logout(final HttpServletResponse response) throws IOException {
+	@Operation(description = "현재 사용자 로그 아웃")
+	@ApiResponse(description = "로그 아웃", responseCode = "302")
+	@ResponseStatus(HttpStatus.FOUND)
+	public void logout(@Parameter(hidden = true) final HttpServletResponse response) throws IOException {
 		cookieProvider.clearAuthCookie(response);
 		redirection.to("/", response);
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/common/advice/CommonResponse.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/advice/CommonResponse.java
@@ -1,0 +1,30 @@
+package com.ludo.study.studymatchingplatform.common.advice;
+
+import java.util.Map;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+public final class CommonResponse {
+
+	private final boolean ok;
+	private final String message;
+	private final Object data;
+
+	public static CommonResponse success(final String nestedFieldName, final Object data) {
+		final Map<String, Object> nestedData = Map.of(nestedFieldName, data);
+		return new CommonResponse(true, null, nestedData);
+	}
+
+	public static CommonResponse success(final Object data) {
+		return new CommonResponse(true, null, data);
+	}
+
+	public static CommonResponse error(final String message) {
+		return new CommonResponse(false, message, null);
+	}
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/common/advice/CommonResponseAdvice.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/advice/CommonResponseAdvice.java
@@ -1,0 +1,55 @@
+package com.ludo.study.studymatchingplatform.common.advice;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+import com.ludo.study.studymatchingplatform.common.annotation.DataFieldName;
+
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+
+@Component
+@RestControllerAdvice
+@RequiredArgsConstructor
+public final class CommonResponseAdvice implements ResponseBodyAdvice<Object> {
+
+	@Override
+	public boolean supports(final MethodParameter returnType,
+							final Class<? extends HttpMessageConverter<?>> converterType) {
+		return converterType.isAssignableFrom(MappingJackson2HttpMessageConverter.class);
+	}
+
+	@SneakyThrows
+	@Override
+	public Object beforeBodyWrite(Object body, final MethodParameter returnType,
+								  final MediaType selectedContentType,
+								  final Class<? extends HttpMessageConverter<?>> selectedConverterType,
+								  final ServerHttpRequest request, final ServerHttpResponse response) {
+		if (isApi(request) && isOk(body)) {
+			final DataFieldName annotation = returnType.getMethodAnnotation(DataFieldName.class);
+			body = (annotation != null && body instanceof String) ? CommonResponse.success(annotation.value(), body) :
+					CommonResponse.success(body);
+		}
+		return body;
+	}
+
+	private boolean isApi(final ServerHttpRequest request) {
+		return request.getURI().getPath().startsWith("/api");
+	}
+
+	private boolean isOk(final Object body) {
+		if (CommonResponse.class.isAssignableFrom(body.getClass())) {
+			final CommonResponse resp = (CommonResponse)body;
+			return resp.isOk();
+		}
+		return true;
+	}
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/common/advice/CommonResponseAdvice.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/advice/CommonResponseAdvice.java
@@ -1,6 +1,7 @@
 package com.ludo.study.studymatchingplatform.common.advice;
 
 import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -41,6 +42,9 @@ public final class CommonResponseAdvice implements ResponseBodyAdvice<Object> {
 	}
 
 	private boolean isApi(final ServerHttpRequest request) {
+		if(request.getHeaders().containsKey(HttpHeaders.LOCATION)) {
+			return false;
+		}
 		return request.getURI().getPath().startsWith("/api");
 	}
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/common/annotation/DataFieldName.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/annotation/DataFieldName.java
@@ -1,0 +1,12 @@
+package com.ludo.study.studymatchingplatform.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DataFieldName {
+	String value() default "";
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.ludo.study.studymatchingplatform.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.ludo.study.studymatchingplatform.common.advice.CommonResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestControllerAdvice
+@Component
+@RequiredArgsConstructor
+public final class GlobalExceptionHandler {
+
+	@ExceptionHandler(value = Exception.class)
+	public ResponseEntity<CommonResponse> handleException(Exception e) {
+		final CommonResponse resp = CommonResponse.error(e.getMessage());
+		return new ResponseEntity<>(resp, HttpStatus.CONFLICT);
+	}
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/controller/RecruitmentController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/controller/RecruitmentController.java
@@ -3,7 +3,6 @@ package com.ludo.study.studymatchingplatform.study.controller;
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -18,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.ludo.study.studymatchingplatform.auth.common.AuthUser;
 import com.ludo.study.studymatchingplatform.auth.common.IsAuthenticated;
-import com.ludo.study.studymatchingplatform.study.controller.dto.response.BaseApiResponse;
+import com.ludo.study.studymatchingplatform.common.annotation.DataFieldName;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Applicant;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
 import com.ludo.study.studymatchingplatform.study.repository.dto.request.PopularRecruitmentCond;
@@ -32,7 +31,6 @@ import com.ludo.study.studymatchingplatform.study.service.dto.request.ApplyRecru
 import com.ludo.study.studymatchingplatform.study.service.dto.request.EditRecruitmentRequest;
 import com.ludo.study.studymatchingplatform.study.service.dto.request.WriteRecruitmentRequest;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.ApplyRecruitmentResponse;
-import com.ludo.study.studymatchingplatform.study.service.dto.response.DeleteRecruitmentResponse;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.EditRecruitmentResponse;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.PopularRecruitmentsResponse;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.RecruitmentDetailsResponse;
@@ -41,6 +39,11 @@ import com.ludo.study.studymatchingplatform.study.service.dto.response.Recruitme
 import com.ludo.study.studymatchingplatform.study.service.dto.response.WriteRecruitmentResponse;
 import com.ludo.study.studymatchingplatform.user.domain.User;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -56,7 +59,11 @@ public class RecruitmentController {
 	private final RecruitmentService recruitmentService;
 
 	@GetMapping("/recruitments")
-	public ResponseEntity<BaseApiResponse<RecruitmentPreviewResponses>> readRecruitments(
+	@DataFieldName("recruitments")
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(description = "여러 모집 공고 조회")
+	@ApiResponse(description = "조회 성공", responseCode = "200", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
+	public RecruitmentPreviewResponses readRecruitments(
 			@RequestParam(required = false) Long last,
 			@RequestParam Integer count,
 			@RequestParam(required = false) Long category,
@@ -69,73 +76,80 @@ public class RecruitmentController {
 
 		final List<RecruitmentPreviewResponse> recruitments = recruitmentsFindService.findRecruitments(
 				recruitmentFindCursor, recruitmentFindCond);
-		final RecruitmentPreviewResponses recruitmentPreviewResponses = new RecruitmentPreviewResponses(recruitments);
-
-		return ResponseEntity.ok(BaseApiResponse.success("모집 공고 목록 조회 성공", recruitmentPreviewResponses));
+		return new RecruitmentPreviewResponses(recruitments);
 	}
 
 	@GetMapping("/recruitments/{recruitmentId}")
-	public ResponseEntity<BaseApiResponse<RecruitmentDetailsResponse>> readRecruitmentDetails(
+	@DataFieldName("recruitment")
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(description = "특정 모집 공고 조회")
+	@ApiResponse(description = "조회 성공", responseCode = "200", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
+	public RecruitmentDetailsResponse readRecruitmentDetails(
 			@PathVariable("recruitmentId") final Long recruitmentId
 	) {
-		try {
-			final RecruitmentDetailsResponse recruitmentDetails = recruitmentDetailsFindService.findRecruitmentDetails(
-					recruitmentId);
-
-			return ResponseEntity.ok(BaseApiResponse.success("모집 공고 상세 조회 성공", recruitmentDetails));
-		} catch (IllegalArgumentException exception) {
-
-			return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-		}
+		return recruitmentDetailsFindService.findRecruitmentDetails(
+				recruitmentId);
 	}
 
 	@GetMapping("/recruitments/popular")
-	public ResponseEntity<BaseApiResponse<PopularRecruitmentsResponse>> readPopularRecruitments(
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(description = "인기 있는 다수의 모집 공고 조회")
+	@ApiResponse(description = "조회 성공", responseCode = "200", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
+	public PopularRecruitmentsResponse readPopularRecruitments(
 			@ModelAttribute PopularRecruitmentCond request) {
-		PopularRecruitmentsResponse popularRecruitments = popularRecruitmentsFindService.findPopularRecruitments(
+		return popularRecruitmentsFindService.findPopularRecruitments(
 				request);
-
-		return ResponseEntity.ok(BaseApiResponse.success("인기 모집 공고 목록 조회 성공", popularRecruitments));
 	}
 
 	@IsAuthenticated
 	@PostMapping("/studies/{studyId}/recruitments")
 	@ResponseStatus(HttpStatus.CREATED)
-	public ResponseEntity<BaseApiResponse<WriteRecruitmentResponse>> write(
-			@RequestBody final WriteRecruitmentRequest request,
-			@AuthUser final User user) {
+	@DataFieldName("recruitment")
+	@Operation(description = "모집 공고 작성")
+	@ApiResponse(description = "모집 공고 작성 성공", responseCode = "201", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
+	public WriteRecruitmentResponse write(
+			@RequestBody final WriteRecruitmentRequest request, @Parameter(hidden = true) @AuthUser final User user) {
 		final Recruitment recruitment = recruitmentService.write(user, request);
-		final WriteRecruitmentResponse response = WriteRecruitmentResponse.from(recruitment);
-
-		return ResponseEntity.ok(BaseApiResponse.success("모집 공고 작성 성공", response));
+		return WriteRecruitmentResponse.from(recruitment);
 	}
 
-	@IsAuthenticated
 	@PutMapping("/studies/{studyId}/recruitments")
-	public ResponseEntity<BaseApiResponse<EditRecruitmentResponse>> edit(@AuthUser final User user,
-																		 @PathVariable("studyId") final Long studyId,
-																		 @PathVariable("recruitmentId") final Long recruitmentId,
-																		 @RequestBody final EditRecruitmentRequest request) {
+	@ResponseStatus(HttpStatus.OK)
+	@DataFieldName("recruitment")
+	@Operation(description = "모집 공고 수정")
+	@ApiResponse(description = "모집 공고 수정 성공", responseCode = "200", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
+	@Parameters({
+			@Parameter(name = "studyId", description = "모집 공고에 대한 스터디 id", required = true),
+			@Parameter(name = "recruitmentId", description = "지원할 모집 공고 id", required = true)
+	})
+	public EditRecruitmentResponse edit(
+			@Parameter(hidden = true) @AuthUser final User user,
+			@PathVariable("studyId") final Long studyId,
+			@PathVariable("recruitmentId") final Long recruitmentId,
+			@RequestBody final EditRecruitmentRequest request) {
 		final Recruitment recruitment = recruitmentService.edit(user, recruitmentId, request);
-		return ResponseEntity.ok(BaseApiResponse.success("모집 공고 수정", EditRecruitmentResponse.from(recruitment)));
+		return EditRecruitmentResponse.from(recruitment);
 	}
 
-	@IsAuthenticated
 	@PostMapping("/studies/{studyId}/recruitments/{recruitmentId}/apply")
-	@ResponseStatus(HttpStatus.CREATED)
-	public ResponseEntity<BaseApiResponse<ApplyRecruitmentResponse>> apply(
+	@ResponseStatus(HttpStatus.OK)
+	@DataFieldName("recruitment")
+	@Operation(description = "모집 공고 지원")
+	@ApiResponse(description = "모집 공고 지원 성공", responseCode = "200", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
+	public ApplyRecruitmentResponse apply(
 			@PathVariable("recruitmentId") final Long recruitmentId,
 			@RequestBody final ApplyRecruitmentRequest request,
-			@AuthUser final User user) {
+			@Parameter(hidden = true) @AuthUser final User user) {
 		final Applicant applicant = recruitmentService.apply(user, recruitmentId, request);
-		return ResponseEntity.ok(BaseApiResponse.success("지원 성공", ApplyRecruitmentResponse.from(applicant)));
+		return ApplyRecruitmentResponse.from(applicant);
 	}
 
 	@DeleteMapping("/studies/{studyId}/recruitments")
-	public ResponseEntity<BaseApiResponse<DeleteRecruitmentResponse>> delete(@PathVariable Long studyId,
-																			 @AuthUser final User user) {
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(description = "모집 공고 삭제")
+	@ApiResponse(description = "모집 공고 삭제 성공", responseCode = "200", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
+	public void delete(@PathVariable Long studyId, @Parameter(hidden = true) @AuthUser final User user) {
 		recruitmentService.delete(user, studyId);
-		return ResponseEntity.ok(BaseApiResponse.success("모집 공고가 비활성화 되었습니다.", null));
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/controller/StackController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/controller/StackController.java
@@ -2,10 +2,13 @@ package com.ludo.study.studymatchingplatform.study.controller;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.ludo.study.studymatchingplatform.common.annotation.DataFieldName;
 import com.ludo.study.studymatchingplatform.study.controller.dto.response.BaseApiResponse;
 import com.ludo.study.studymatchingplatform.study.domain.stack.Stack;
 import com.ludo.study.studymatchingplatform.study.domain.stack.StackCategory;
@@ -13,6 +16,9 @@ import com.ludo.study.studymatchingplatform.study.repository.stack.StackCategory
 import com.ludo.study.studymatchingplatform.study.repository.stack.StackRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.StackResponses;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -25,11 +31,14 @@ public class StackController {
 	private final StackCategoryRepositoryImpl stackCategoryRepository;
 
 	@GetMapping("/stacks")
-	public ResponseEntity<BaseApiResponse<StackResponses>> getStacks() {
+	@ResponseStatus(HttpStatus.OK)
+	@DataFieldName("stacks")
+	@Operation(description = "기술 스택 조회")
+	@ApiResponse(description = "기술 스택 조회 성공", responseCode = "200", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
+	public StackResponses getStacks() {
 		List<StackCategory> stackCategories = stackCategoryRepository.findAll();
 		List<Stack> stacks = stackRepository.findAll();
-		StackResponses stackResponses = new StackResponses(stacks, stackCategories);
-		return ResponseEntity.ok(BaseApiResponse.success("기술 스택 조회 성공", stackResponses));
+		return new StackResponses(stacks, stackCategories);
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/controller/MyPageController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/controller/MyPageController.java
@@ -2,20 +2,24 @@ package com.ludo.study.studymatchingplatform.user.controller;
 
 import java.util.List;
 
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ludo.study.studymatchingplatform.auth.common.AuthUser;
-import com.ludo.study.studymatchingplatform.auth.common.IsAuthenticated;
-import com.ludo.study.studymatchingplatform.study.controller.dto.BaseApiResponse;
+import com.ludo.study.studymatchingplatform.common.annotation.DataFieldName;
 import com.ludo.study.studymatchingplatform.study.domain.Participant;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Applicant;
 import com.ludo.study.studymatchingplatform.user.domain.User;
 import com.ludo.study.studymatchingplatform.user.service.MyPageService;
 import com.ludo.study.studymatchingplatform.user.service.dto.response.MyPageResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -24,16 +28,18 @@ public class MyPageController {
 
 	private final MyPageService myPageService;
 
-	@IsAuthenticated
 	@GetMapping("/users/mypage")
-	public ResponseEntity<BaseApiResponse<MyPageResponse>> retrieveMyPage(
+	@ResponseStatus(HttpStatus.CREATED)
+	@DataFieldName("user")
+	@Operation(description = "로그인 된 사용자 정보 조회")
+	@ApiResponse(description = "조회 성공", responseCode = "200", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
+	public MyPageResponse retrieveMyPage(
 			@CookieValue(name = "Authorization") final String auth,
-			@AuthUser final User user) {
+			@Parameter(hidden = true) @AuthUser final User user) {
 		final List<Participant> participants = myPageService.retrieveParticipantStudies(user);
 		final List<Applicant> applicants = myPageService.retrieveApplicantRecruitment(user);
 		final List<Participant> completedStudies = myPageService.retrieveCompletedStudy(user);
-		final MyPageResponse response = MyPageResponse.from(participants, applicants, completedStudies);
-		return ResponseEntity.ok(BaseApiResponse.success("마이페이지 조회가 완료되었습니다.", response));
+		return MyPageResponse.from(participants, applicants, completedStudies);
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/controller/UserController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/controller/UserController.java
@@ -23,6 +23,10 @@ import com.ludo.study.studymatchingplatform.user.service.dto.request.ChangeUserN
 import com.ludo.study.studymatchingplatform.user.service.dto.response.ChangeUserNicknameResponse;
 import com.ludo.study.studymatchingplatform.user.service.dto.response.UserResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -41,17 +45,22 @@ public class UserController {
 	private final Redirection redirection;
 
 	@DeleteMapping("/users/deactivate")
-	@ResponseStatus(HttpStatus.NO_CONTENT)
-	public void withdraw(@AuthUser final User user, final HttpServletResponse response) throws IOException {
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(description = "회원 탈퇴")
+	@ApiResponse(description = "회원 탈퇴 성공", responseCode = "200", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
+	public void withdraw(@Parameter(hidden = true) @AuthUser final User user, final HttpServletResponse response) throws
+			IOException {
 		userService.withdraw(user);
 		cookieProvider.clearAuthCookie(response);
 		redirection.to("/", response);
 	}
 
 	@GetMapping("/users/me")
-	public ResponseEntity<BaseApiResponse<UserResponse>> fetchMe(@AuthUser final User user) {
-		final UserResponse response = UserResponse.from(user);
-		return ResponseEntity.ok(BaseApiResponse.success("사용자 조회 성공", response));
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(description = "로그인 된 사용자 정보 조회")
+	@ApiResponse(description = "조회 성공", responseCode = "200", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
+	public UserResponse getMe(@Parameter(hidden = true) @AuthUser final User user) {
+		return UserResponse.from(user);
 	}
 
 	@PostMapping("/users/me/nickname")


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

Controller Layer에서 `Response`를 내보낼 때 형식 통일을 위해 `ResponseEntity<BaseApiResponse<T>>` 형식의 코드가 중복되는 현상을 제거하였으며, Annotation을 통해 약간의 Swagger 문서를 추가 하였습니다.
```java
@PostMapping
@ResponseStatus(HttpStatus.CREATED)
@DataFieldName("study")
@Operation(description = "스터디 생성")
@ApiResponse(description = "스터디 생성 성공", responseCode = "201", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
public StudyResponse create(@RequestBody final WriteStudyRequest request,
						@Parameter(hidden = true) @AuthUser final User user) {
  final Study study = studyCreateService.create(request, user);
  return StudyResponse.from(study);
}
```

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

아래 코드를 통해 Controller Layer에서의 처리가 완료되고 실제 Serialization이 발생하기 전, `Response Body`에 삽입될 데이터의 형식을 바꿔주도록 후속 작업을 해줍니다.
Controller에서 반환된 타입명은 `BaseApiResponse`가 존재하여 혼동을 줄이기 위해 `CommonResponse`로 명명했습니다.

reflection을 통해 `MessageConverter`의 타입을 검사하고, Json parser일 때만 요청을 처리합니다.
이 외에 정확히 어떤 검사가 일어나는지 스프링에서 추상화가 되어 있어서 `isApi`로 경로 검사, `isOk`로 상태 검사를 하였으며, 추가로 redirection인 경우 Spring 내부 동작에 따라 문제가 발생할 수도 있을 것 같다는 생각이 들었는데 이 부분은 현재 구조상 경로 검사로 커버가 되는 부분이라 따로 실험하진 않았습니다.

```java
// CommonResponseAdvice.java
@Component
@RestControllerAdvice
@RequiredArgsConstructor
public final class CommonResponseAdvice implements ResponseBodyAdvice<Object> {

	@Override
	public boolean supports(final MethodParameter returnType,
							final Class<? extends HttpMessageConverter<?>> converterType) {
		return converterType.isAssignableFrom(MappingJackson2HttpMessageConverter.class);
	}

	@SneakyThrows
	@Override
	public Object beforeBodyWrite(Object body, final MethodParameter returnType,
								  final MediaType selectedContentType,
								  final Class<? extends HttpMessageConverter<?>> selectedConverterType,
								  final ServerHttpRequest request, final ServerHttpResponse response) {
		if (isApi(request) && isOk(body)) {
			final DataFieldName annotation = returnType.getMethodAnnotation(DataFieldName.class);
			body = (annotation != null && body instanceof String) ? CommonResponse.success(annotation.value(), body) :
					CommonResponse.success(body);
		}
		return body;
	}

	private boolean isApi(final ServerHttpRequest request) {
		if(request.getHeaders().containsKey(HttpHeaders.LOCATION)) {
			return false;
		}
		return request.getURI().getPath().startsWith("/api");
	}

	private boolean isOk(final Object body) {
		if (CommonResponse.class.isAssignableFrom(body.getClass())) {
			final CommonResponse resp = (CommonResponse)body;
			return resp.isOk();
		}
		return true;
	}

}
```

<br><br>

### 💡 필요한 후속작업이 있어요.

inner class를 제거하고 dto를 record로 일괄 변환

<br><br>

### ✅ 셀프 체크리스트

- [O] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [O] 커밋 메세지를 컨벤션에 맞추었습니다.
- [O] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [O] 변경 후 코드는 기존의 테스트를 통과합니다.
- [O] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [O] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
