### PR TITLE
Sp-376/Feature: 카카오 토큰 리프레시 기능 추가 / Redis 설정 파일 추가 (RDB 비교 성능 측정 테스트 코드 포함)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,12 @@ dependencies {
     // springdoc-openapi (Swagger 사용)
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
+    // redis
+    // Client 구현체는 크게 Lettuce, Jedis가 있는데, Lettuce로 구현 했습니다.
+    // 이유는 별도의 의존성 설정 없이 사용할 수 있기 때문이고,
+    // Jedis에 비해 더 높은 성능과 상세한 문서를 제공하기 때문입니다.
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.7'
 }
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/common/AuthController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/common/AuthController.java
@@ -7,7 +7,9 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
+import com.ludo.study.studymatchingplatform.auth.service.kakao.KakaoRefreshService;
 import com.ludo.study.studymatchingplatform.study.controller.dto.response.BaseApiResponse;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -20,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 
 	private final CookieProvider cookieProvider;
+	private final KakaoRefreshService kakaoRefreshService;
 
 	@PostMapping("/auth/logout")
 	@ResponseStatus(HttpStatus.FOUND)
@@ -30,4 +33,16 @@ public class AuthController {
 		cookieProvider.clearAuthCookie(response);
 		return ResponseEntity.ok(BaseApiResponse.success(null));
 	}
+
+	@PostMapping("/auth/refresh")
+	@ResponseStatus(HttpStatus.CONTINUE)
+	@Operation(description = "현재 카카오 사용자 토큰 갱신")
+	@ApiResponse(description = "토큰 갱신", responseCode = "302")
+	public ResponseEntity kakaoRefresh(@Parameter(hidden = true) final HttpServletResponse response,
+									   @Parameter(hidden = true) @AuthUser User user) {
+		final String accessToken = kakaoRefreshService.refreshToRDB(user);
+		cookieProvider.setAuthCookie(accessToken, response);
+		return ResponseEntity.ok().build();
+	}
+
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/common/AuthController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/common/AuthController.java
@@ -34,7 +34,7 @@ public class AuthController {
 		return ResponseEntity.ok(BaseApiResponse.success(null));
 	}
 
-	@PostMapping("/auth/refresh")
+	@PostMapping("/auth/kakao/refresh")
 	@ResponseStatus(HttpStatus.CONTINUE)
 	@Operation(description = "현재 카카오 사용자 토큰 갱신")
 	@ApiResponse(description = "토큰 갱신", responseCode = "302")

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/common/AuthUserPayload.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/common/AuthUserPayload.java
@@ -13,21 +13,22 @@ import lombok.ToString;
 public final class AuthUserPayload {
 
 	private final Long id;
+	private final String accessToken;
 
 	public static AuthUserPayload from(final Claims claims) {
-		return new AuthUserPayload(claims.get("id", Long.class));
+		return new AuthUserPayload(claims.get("id", Long.class), claims.get("accessToken", String.class));
 	}
 
 	@Deprecated
-	public static AuthUserPayload from(final String userId) {
-		return new AuthUserPayload(Long.parseLong(userId));
+	public static AuthUserPayload from(final String userId, final String accessToken) {
+		return new AuthUserPayload(Long.parseLong(userId), accessToken);
 	}
 
-	public static AuthUserPayload from(final Long userId) {
-		return new AuthUserPayload(userId);
+	public static AuthUserPayload from(final Long userId, final String accessToken) {
+		return new AuthUserPayload(userId, accessToken);
 	}
 
-	public static AuthUserPayload from(final User user) {
-		return new AuthUserPayload(user.getId());
+	public static AuthUserPayload from(final User user, final String accessToken) {
+		return new AuthUserPayload(user.getId(), accessToken);
 	}
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/common/provider/JwtTokenProvider.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/common/provider/JwtTokenProvider.java
@@ -41,6 +41,7 @@ public class JwtTokenProvider {
 	private Claims createClaims(final AuthUserPayload payload) {
 		final Claims claims = Jwts.claims();
 		claims.put("id", payload.getId());
+		claims.put("accessToken", payload.getAccessToken());
 		return claims;
 	}
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/config/property/ClientRegistrationAndProvider.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/config/property/ClientRegistrationAndProvider.java
@@ -16,6 +16,7 @@ public class ClientRegistrationAndProvider {
 	private final String tokenUri;
 	private final String userInfoUri;
 	private final String authorizationGrantType;
+	private final String refreshGrantType;
 
 	public ClientRegistrationAndProvider(OAuthProperties.Registration registration, OAuthProperties.Provider provider) {
 		this.clientId = registration.getClientId();
@@ -27,6 +28,7 @@ public class ClientRegistrationAndProvider {
 		this.tokenUri = provider.getTokenUri();
 		this.userInfoUri = provider.getUserInfoUri();
 		this.authorizationGrantType = provider.getAuthorizationGrantType();
+		this.refreshGrantType = provider.getRefreshGrantType();
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/config/property/OAuthProperties.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/config/property/OAuthProperties.java
@@ -35,6 +35,7 @@ public class OAuthProperties {
 		private String tokenUri;
 		private String userInfoUri;
 		private String authorizationGrantType;
+		private String refreshGrantType;
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/google/GoogleLoginController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/google/GoogleLoginController.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import com.ludo.study.studymatchingplatform.auth.common.AuthUserPayload;
 import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
 import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
 import com.ludo.study.studymatchingplatform.auth.repository.InMemoryClientRegistrationAndProviderRepository;
@@ -51,8 +50,8 @@ public class GoogleLoginController {
 			HttpServletResponse response
 	) {
 		final User user = googleLoginService.login(authorizationCode);
-		final String accessToken = jwtTokenProvider.createAccessToken(AuthUserPayload.from(user));
-		cookieProvider.setAuthCookie(accessToken, response);
+		// final String accessToken = jwtTokenProvider.createAccessToken(AuthUserPayload.from(user));
+		// cookieProvider.setAuthCookie(accessToken, response);
 
 		return ResponseEntity.ok()
 				.body(new LoginResponse(user.getId().toString(), user.getNickname(), user.getEmail()));

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/google/GoogleSignUpController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/google/GoogleSignUpController.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import com.ludo.study.studymatchingplatform.auth.common.AuthUserPayload;
 import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
 import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
 import com.ludo.study.studymatchingplatform.auth.repository.InMemoryClientRegistrationAndProviderRepository;
@@ -50,8 +49,8 @@ public class GoogleSignUpController {
 	public ResponseEntity<SignupResponse> googleSignupback(
 			@RequestParam(name = "code") final String authorizationCode, final HttpServletResponse response) {
 		final User user = googleSignUpService.googleSignUp(authorizationCode);
-		final String accessToken = jwtTokenProvider.createAccessToken(AuthUserPayload.from(user));
-		cookieProvider.setAuthCookie(accessToken, response);
+		// final String accessToken = jwtTokenProvider.createAccessToken(AuthUserPayload.from(user));
+		// cookieProvider.setAuthCookie(accessToken, response);
 
 		return ResponseEntity.ok()
 				.body(new SignupResponse(true, "회원 가입에 성공했습니다."));

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/kakao/KakaoLoginController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/kakao/KakaoLoginController.java
@@ -41,7 +41,7 @@ public class KakaoLoginController {
 			@RequestParam(name = "code") String authorizationCode,
 			final HttpServletResponse response) throws IOException {
 		kakaoLoginService.login(authorizationCode, response);
-		response.sendRedirect("http://localhost:3000");
+		response.sendRedirect("https://ludoapi.store/");
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/kakao/KakaoLoginController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/kakao/KakaoLoginController.java
@@ -2,22 +2,15 @@ package com.ludo.study.studymatchingplatform.auth.controller.kakao;
 
 import java.io.IOException;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import com.ludo.study.studymatchingplatform.auth.common.AuthUserPayload;
-import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
-import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
 import com.ludo.study.studymatchingplatform.auth.repository.InMemoryClientRegistrationAndProviderRepository;
 import com.ludo.study.studymatchingplatform.auth.service.kakao.KakaoLoginService;
-import com.ludo.study.studymatchingplatform.study.controller.dto.response.BaseApiResponse;
 import com.ludo.study.studymatchingplatform.user.domain.user.Social;
-import com.ludo.study.studymatchingplatform.user.domain.user.User;
-import com.ludo.study.studymatchingplatform.user.service.dto.response.UserResponse;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -31,8 +24,6 @@ public class KakaoLoginController {
 
 	private final InMemoryClientRegistrationAndProviderRepository clientRegistrationAndProviderRepository;
 	private final KakaoLoginService kakaoLoginService;
-	private final JwtTokenProvider jwtTokenProvider;
-	private final CookieProvider cookieProvider;
 
 	@GetMapping("/kakao")
 	public String kakaoLogin(RedirectAttributes redirectAttributes) {
@@ -46,15 +37,11 @@ public class KakaoLoginController {
 	}
 
 	@GetMapping("/kakao/callback")
-	public ResponseEntity<BaseApiResponse<UserResponse>> kakaoLoginCallback(
+	public void kakaoLoginCallback(
 			@RequestParam(name = "code") String authorizationCode,
 			final HttpServletResponse response) throws IOException {
-		final User user = kakaoLoginService.login(authorizationCode);
-		final String accessToken = jwtTokenProvider.createAccessToken(AuthUserPayload.from(user));
-		final UserResponse userResponse = UserResponse.from(user);
-		cookieProvider.setAuthCookie(accessToken, response);
-		response.sendRedirect("https://local.ludoapi.store:3000");
-		return ResponseEntity.ok(BaseApiResponse.success(userResponse));
+		kakaoLoginService.login(authorizationCode, response);
+		response.sendRedirect("http://localhost:3000");
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/kakao/KakaoSignUpController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/kakao/KakaoSignUpController.java
@@ -41,7 +41,7 @@ public class KakaoSignUpController {
 			@RequestParam(name = "code") String authorizationCode,
 			final HttpServletResponse response) throws IOException {
 		kakaoSignUpService.kakaoSignUp(authorizationCode, response);
-		response.sendRedirect("http://localhost:3000");
+		response.sendRedirect("https://ludoapi.store/");
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/kakao/KakaoSignUpController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/kakao/KakaoSignUpController.java
@@ -2,22 +2,15 @@ package com.ludo.study.studymatchingplatform.auth.controller.kakao;
 
 import java.io.IOException;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import com.ludo.study.studymatchingplatform.auth.common.AuthUserPayload;
-import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
-import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
 import com.ludo.study.studymatchingplatform.auth.repository.InMemoryClientRegistrationAndProviderRepository;
 import com.ludo.study.studymatchingplatform.auth.service.kakao.KakaoSignUpService;
-import com.ludo.study.studymatchingplatform.study.controller.dto.response.BaseApiResponse;
 import com.ludo.study.studymatchingplatform.user.domain.user.Social;
-import com.ludo.study.studymatchingplatform.user.domain.user.User;
-import com.ludo.study.studymatchingplatform.user.service.dto.response.UserResponse;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -31,8 +24,6 @@ public class KakaoSignUpController {
 
 	private final InMemoryClientRegistrationAndProviderRepository clientRegistrationAndProviderRepository;
 	private final KakaoSignUpService kakaoSignUpService;
-	private final JwtTokenProvider jwtTokenProvider;
-	private final CookieProvider cookieProvider;
 
 	@GetMapping("/kakao")
 	public String kakaoSignUp(RedirectAttributes redirectAttributes) {
@@ -46,15 +37,11 @@ public class KakaoSignUpController {
 	}
 
 	@GetMapping("/kakao/callback")
-	public ResponseEntity<BaseApiResponse<UserResponse>> kakaoSignUpCallback(
+	public void kakaoSignUpCallback(
 			@RequestParam(name = "code") String authorizationCode,
 			final HttpServletResponse response) throws IOException {
-		final User user = kakaoSignUpService.kakaoSignUp(authorizationCode);
-		final String accessToken = jwtTokenProvider.createAccessToken(AuthUserPayload.from(user));
-		final UserResponse userResponse = UserResponse.from(user);
-		cookieProvider.setAuthCookie(accessToken, response);
-		response.sendRedirect("https://local.ludoapi.store:3000");
-		return ResponseEntity.ok(BaseApiResponse.success(userResponse));
+		kakaoSignUpService.kakaoSignUp(authorizationCode, response);
+		response.sendRedirect("http://localhost:3000");
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/naver/NaverLoginController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/naver/NaverLoginController.java
@@ -7,14 +7,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import com.ludo.study.studymatchingplatform.auth.common.AuthUserPayload;
 import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
 import com.ludo.study.studymatchingplatform.auth.repository.InMemoryClientRegistrationAndProviderRepository;
 import com.ludo.study.studymatchingplatform.auth.service.naver.NaverLoginService;
 import com.ludo.study.studymatchingplatform.auth.service.naver.dto.response.LoginResponse;
 import com.ludo.study.studymatchingplatform.user.domain.user.Social;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -49,13 +47,13 @@ public class NaverLoginController {
 	) {
 		LoginResponse loginResponse = naverLoginService.login(authorizationCode);
 
-		String accessToken = jwtTokenProvider.createAccessToken(AuthUserPayload.from(loginResponse.id()));
+		// String accessToken = jwtTokenProvider.createAccessToken(AuthUserPayload.from(loginResponse.id()));
 
-		Cookie cookie = new Cookie("Authorization", accessToken);
-		cookie.setPath("/");
-		cookie.setMaxAge(Integer.parseInt(jwtTokenProvider.getAccessTokenExpiresIn()));
-		cookie.setHttpOnly(true);
-		response.addCookie(cookie);
+		// Cookie cookie = new Cookie("Authorization", accessToken);
+		// cookie.setPath("/");
+		// cookie.setMaxAge(Integer.parseInt(jwtTokenProvider.getAccessTokenExpiresIn()));
+		// cookie.setHttpOnly(true);
+		// response.addCookie(cookie);
 
 		return ResponseEntity.ok()
 				.body(loginResponse);

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/repository/InMemoryClientRegistrationAndProviderRepository.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/repository/InMemoryClientRegistrationAndProviderRepository.java
@@ -46,6 +46,10 @@ public class InMemoryClientRegistrationAndProviderRepository {
 		return findByName(social.getName()).getAuthorizationGrantType();
 	}
 
+	public String findRefreshGrantType(final Social social) {
+		return findByName(social.getName()).getRefreshGrantType();
+	}
+
 	private ClientRegistrationAndProvider findByName(final String name) {
 		return providers.get(name);
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/kakao/KakaoLoginService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/kakao/KakaoLoginService.java
@@ -3,18 +3,23 @@ package com.ludo.study.studymatchingplatform.auth.service.kakao;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.ludo.study.studymatchingplatform.auth.common.AuthUserPayload;
+import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
+import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
 import com.ludo.study.studymatchingplatform.auth.repository.InMemoryClientRegistrationAndProviderRepository;
 import com.ludo.study.studymatchingplatform.auth.service.kakao.dto.KakaoOAuthToken;
 import com.ludo.study.studymatchingplatform.auth.service.kakao.dto.KakaoUserProfileDto;
 import com.ludo.study.studymatchingplatform.study.service.exception.NotFoundException;
 import com.ludo.study.studymatchingplatform.user.domain.user.Social;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import com.ludo.study.studymatchingplatform.user.domain.user.redis.RefreshToken;
 import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
+import com.ludo.study.studymatchingplatform.user.repository.user.redis.RefreshTokenRepository;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class KakaoLoginService {
 
@@ -22,19 +27,38 @@ public class KakaoLoginService {
 	private final KakaoOAuthTokenRequestService kakaoOAuthTokenRequestService;
 	private final KakaoProfileRequestService kakaoProfileRequestService;
 	private final UserRepositoryImpl userRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final CookieProvider cookieProvider;
+	private final RefreshTokenRepository refreshTokenRepository;
 
-	public User login(final String authrizationCode) {
+	@Transactional
+	public void login(final String authrizationCode, final HttpServletResponse response) {
 		final String kakaoLoginRedirectUri = clientRegistrationAndProviderRepository.findLoginRedirectUri(Social.KAKAO);
 		final KakaoOAuthToken kakaoOAuthToken =
 				kakaoOAuthTokenRequestService.createOAuthToken(authrizationCode, kakaoLoginRedirectUri);
 		final KakaoUserProfileDto kakaoUserProfileDto = kakaoProfileRequestService.createKakaoProfile(kakaoOAuthToken);
+		final User user = validateNotSignUp(kakaoUserProfileDto);
 
-		return validateNotSignUp(kakaoUserProfileDto);
+		// 로그인시 refreshToken 갱신, 회원 가입과 로그인을 분리하며 로그인시 카카오에 code 를 받기위한 요청을 보내게 되는데,
+		// 이 과정에서 새로운 refreshToken이 발급되며, 기존 token의 유효성 상실
+		// (refresh와 access가 "key:value" 형식이라고 가정, 검증 필요)
+		updatesRefreshToken(user, kakaoOAuthToken);
+
+		final String accessToken =
+				jwtTokenProvider.createAccessToken(AuthUserPayload.from(user, kakaoOAuthToken.getAccessToken()));
+		cookieProvider.setAuthCookie(accessToken, response);
 	}
 
 	private User validateNotSignUp(final KakaoUserProfileDto kakaoUserProfileDto) {
 		return userRepository.findByEmail(kakaoUserProfileDto.getEmail())
 				.orElseThrow(() -> new NotFoundException("가입되어 있지 않은 회원입니다"));
+	}
+
+	private void updatesRefreshToken(final User user, final KakaoOAuthToken token) {
+		final RefreshToken refreshToken = refreshTokenRepository.findById(user.getId())
+				.orElseThrow(() -> new NotFoundException("존재하지 않는 토큰입니다."));
+		refreshToken.update(token.getRefreshToken(), token.getExpiresIn());
+		user.changeRefreshToken(token.getRefreshToken());
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/kakao/KakaoOAuthTokenRequestService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/kakao/KakaoOAuthTokenRequestService.java
@@ -30,10 +30,30 @@ public class KakaoOAuthTokenRequestService {
 		return responseKakaoOAuthToken(tokenUri, headers, body);
 	}
 
+	public KakaoOAuthToken createRefreshOAuthToken(final String refreshToken) {
+		final String tokenUri = clientRegistrationAndProviderRepository.findTokenUri(Social.KAKAO);
+		final HttpHeaders headers = createHeaders();
+		final MultiValueMap<String, String> body = createRefreshBody(refreshToken);
+		return responseKakaoOAuthToken(tokenUri, headers, body);
+	}
+
 	private HttpHeaders createHeaders() {
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 		return headers;
+	}
+
+	private MultiValueMap<String, String> createRefreshBody(final String refreshToken) {
+		final String clientId = clientRegistrationAndProviderRepository.findClientId(Social.KAKAO);
+		final String clientSecret = clientRegistrationAndProviderRepository.findClientSecret(Social.KAKAO);
+		final String grantType = clientRegistrationAndProviderRepository.findRefreshGrantType(Social.KAKAO);
+
+		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+		body.add("grant_type", grantType);
+		body.add("client_id", clientId);
+		body.add("refresh_token", refreshToken);
+		body.add("client_secret", clientSecret);
+		return body;
 	}
 
 	private MultiValueMap<String, String> createBody(final String authorizationCode, final String redirectUri) {

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/kakao/KakaoRefreshService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/kakao/KakaoRefreshService.java
@@ -1,0 +1,41 @@
+package com.ludo.study.studymatchingplatform.auth.service.kakao;
+
+import org.springframework.stereotype.Service;
+
+import com.ludo.study.studymatchingplatform.auth.common.AuthUserPayload;
+import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
+import com.ludo.study.studymatchingplatform.auth.service.kakao.dto.KakaoOAuthToken;
+import com.ludo.study.studymatchingplatform.study.service.exception.NotFoundException;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import com.ludo.study.studymatchingplatform.user.domain.user.redis.RefreshToken;
+import com.ludo.study.studymatchingplatform.user.repository.user.redis.RefreshTokenRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoRefreshService {
+
+	private final RefreshTokenRepository refreshTokenRepository;
+	private final KakaoOAuthTokenRequestService kakaoOAuthTokenRequestService;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	public String refreshToRDB(final User user) {
+		final KakaoOAuthToken token = kakaoOAuthTokenRequestService.createRefreshOAuthToken(user.getRefresh());
+		if (token.getRefreshToken() != null) {
+			user.changeRefreshToken(token.getRefreshToken());
+		}
+		return jwtTokenProvider.createAccessToken(AuthUserPayload.from(user, token.getAccessToken()));
+	}
+
+	public String refreshToRedis(final User user) {
+		final RefreshToken refreshToken = refreshTokenRepository.findById(user.getId())
+				.orElseThrow(() -> new NotFoundException("존재하지 않는 토큰 입니다."));
+		final KakaoOAuthToken token = kakaoOAuthTokenRequestService.createRefreshOAuthToken(refreshToken.getToken());
+		if (token.getRefreshToken() != null) {
+			user.changeRefreshToken(token.getRefreshToken());
+		}
+		return jwtTokenProvider.createAccessToken(AuthUserPayload.from(user, token.getAccessToken()));
+	}
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/kakao/dto/KakaoOAuthToken.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/kakao/dto/KakaoOAuthToken.java
@@ -19,6 +19,6 @@ public class KakaoOAuthToken {
 	private String refreshToken;
 
 	@JsonProperty("expires_in")
-	private Integer expiresIn;
+	private Long expiresIn;
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/kakao/dto/KakaoOAuthToken.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/kakao/dto/KakaoOAuthToken.java
@@ -19,6 +19,6 @@ public class KakaoOAuthToken {
 	private String refreshToken;
 
 	@JsonProperty("expires_in")
-	private Long expiresIn;
+	private Integer expiresIn;
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/kakao/dto/KakaoUserProfileDto.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/kakao/dto/KakaoUserProfileDto.java
@@ -17,11 +17,12 @@ public record KakaoUserProfileDto(
 		return kakao_account.email();
 	}
 
-	public User toUser() {
+	public User toUser(final String refresh) {
 		return User.builder()
 				.social(Social.KAKAO)
 				.nickname(properties.nickname())
 				.email(kakao_account.email())
+				.refresh(refresh)
 				.build();
 	}
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/config/RedisConfig.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/config/RedisConfig.java
@@ -1,0 +1,40 @@
+package com.ludo.study.studymatchingplatform.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+		config.setHostName(host);
+		config.setPort(port);
+		return new LettuceConnectionFactory(config);
+	}
+
+	// 스프링 2.0 이후로 필요없다는 정보가 있어 검증 후 제거할 예정입니다.
+	// @Bean
+	// public RedisTemplate<String, Object> redisTemplate() {
+	// 	RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+	// 	redisTemplate.setKeySerializer(new StringRedisSerializer());
+	// 	redisTemplate.setValueSerializer(new StringRedisSerializer());
+	// 	redisTemplate.setConnectionFactory(redisConnectionFactory());
+	//
+	// 	return redisTemplate;
+	// }
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/config/ServletFilterConfig.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/config/ServletFilterConfig.java
@@ -31,6 +31,7 @@ public class ServletFilterConfig {
 	private void addAuthenticationEndpoints(FilterRegistrationBean<Filter> filterRegistrationBean) {
 		filterRegistrationBean.addUrlPatterns("/api/users/*");
 		filterRegistrationBean.addUrlPatterns("/api/studies/*");
+		filterRegistrationBean.addUrlPatterns("/api/auth/kakao/refresh");
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/controller/RecruitmentController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/controller/RecruitmentController.java
@@ -102,7 +102,8 @@ public class RecruitmentController {
 	public RecruitmentDetailsResponse write(@PathVariable("studyId") final Long studyId,
 											@RequestBody final WriteRecruitmentRequest request,
 											@Parameter(hidden = true) @AuthUser final User user) {
-		return recruitmentService.write(user, request, studyId);
+		final Recruitment recruitment = recruitmentService.write(user, request, studyId);
+		return new RecruitmentDetailsResponse(recruitment, recruitment.getStudy());
 	}
 
 	@GetMapping("/studies/{studyId}/recruitments")

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentService.java
@@ -21,7 +21,6 @@ import com.ludo.study.studymatchingplatform.study.repository.study.StudyReposito
 import com.ludo.study.studymatchingplatform.study.service.dto.request.recruitment.EditRecruitmentRequest;
 import com.ludo.study.studymatchingplatform.study.service.dto.request.recruitment.WriteRecruitmentRequest;
 import com.ludo.study.studymatchingplatform.study.service.dto.request.recruitment.applicant.ApplyRecruitmentRequest;
-import com.ludo.study.studymatchingplatform.study.service.dto.response.recruitment.RecruitmentDetailsResponse;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.recruitment.WriteRecruitmentStudyInfoResponse;
 import com.ludo.study.studymatchingplatform.study.service.recruitment.position.RecruitmentPositionService;
 import com.ludo.study.studymatchingplatform.study.service.recruitment.stack.RecruitmentStackService;
@@ -45,8 +44,8 @@ public class RecruitmentService {
 	private final ApplicantRepositoryImpl applicantRepository;
 
 	@Transactional
-	public RecruitmentDetailsResponse write(final User user, final WriteRecruitmentRequest request,
-											final Long studyId) {
+	public Recruitment write(final User user, final WriteRecruitmentRequest request,
+							 final Long studyId) {
 		final Study study = studyRepository.findByIdWithRecruitment(studyId)
 				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디입니다."));
 
@@ -59,7 +58,7 @@ public class RecruitmentService {
 		recruitmentPositionService.addMany(recruitment, request.getPositionIds());
 		study.registerRecruitment(recruitment);
 
-		return new RecruitmentDetailsResponse(recruitment, study);
+		return recruitment;
 	}
 
 	public WriteRecruitmentStudyInfoResponse getStudyInfo(final User user, final Long studyId) {

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/domain/user/User.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/domain/user/User.java
@@ -49,10 +49,14 @@ public class User extends BaseEntity {
 	@Email
 	private String email;
 
-	public User(final Social social, final String nickname, final String email) {
+	@Column(nullable = false)
+	private String refresh;
+
+	public User(final Social social, final String nickname, final String email, final String refresh) {
 		this.social = social;
 		this.nickname = nickname;
 		this.email = email;
+		this.refresh = refresh;
 	}
 
 	public void setInitialDefaultNickname() {
@@ -72,6 +76,10 @@ public class User extends BaseEntity {
 
 	public boolean equalsNickname(final String nickname) {
 		return this.nickname.equals(nickname);
+	}
+
+	public void changeRefreshToken(final String refresh) {
+		this.refresh = refresh;
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/domain/user/redis/RefreshToken.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/domain/user/redis/RefreshToken.java
@@ -1,0 +1,33 @@
+package com.ludo.study.studymatchingplatform.user.domain.user.redis;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@RedisHash(value = "refresh_token")
+public class RefreshToken {
+
+	@Id
+	private Long userId;
+
+	@Indexed
+	private String token;
+
+	@TimeToLive
+	private Long ttl;
+
+	public void update(final String token, final Long ttl) {
+		this.token = token;
+		this.ttl = ttl;
+	}
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/domain/user/redis/RefreshToken.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/domain/user/redis/RefreshToken.java
@@ -23,9 +23,9 @@ public class RefreshToken {
 	private String token;
 
 	@TimeToLive
-	private Long ttl;
+	private Integer ttl;
 
-	public void update(final String token, final Long ttl) {
+	public void update(final String token, final Integer ttl) {
 		this.token = token;
 		this.ttl = ttl;
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/repository/user/UserRepositoryImpl.java
@@ -68,4 +68,8 @@ public class UserRepositoryImpl {
 		return userId != null;
 	}
 
+	public void deleteAll() {
+		userJpaRepository.deleteAll();
+	}
+
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/repository/user/redis/RefreshTokenRepository.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/repository/user/redis/RefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package com.ludo.study.studymatchingplatform.user.repository.user.redis;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.ludo.study.studymatchingplatform.user.domain.user.redis.RefreshToken;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -2,6 +2,11 @@ spring:
   profiles:
     active: dev
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}
@@ -33,6 +38,7 @@ oauth2:
         login-redirect-uri: ${KAKAO_LOGIN_CALLBACK_URL}
         signup-redirect-uri: ${KAKAO_SIGNUP_CALLBACK_URL}
         authorization-grant-type: code
+        refresh-grant-type: refresh_token
       google:
         client-id: ${GOOGLE_CLIENT_ID}
         client-secret: ${GOOGLE_CLIENT_SECRET}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,6 +3,11 @@ spring:
     active: local
     default: local
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   devtools:
     livereload:
       enabled: true
@@ -53,6 +58,7 @@ oauth2:
         token-uri: ${KAKAO_TOKEN_API}
         user-info-uri: ${KAKAO_USER_PROFILE_API}
         authorization-grant-type: authorization_code
+        refresh-grant-type: refresh_token
       google:
         authorization-uri: ${GOOGLE_LOGIN_API}
         token-uri: ${GOOGLE_TOKEN_API}

--- a/src/test/java/com/ludo/study/studymatchingplatform/RefreshTokenTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/RefreshTokenTest.java
@@ -27,7 +27,7 @@ class RefreshTokenTest {
 	void redisConnectionTest() {
 		// given
 		final Long id = 1L;
-		RefreshToken refreshToken = new RefreshToken(id, "refreshToken", 12345556L);
+		RefreshToken refreshToken = new RefreshToken(id, "refreshToken", 12345556);
 
 		// when
 		refreshTokenRepository.save(refreshToken);

--- a/src/test/java/com/ludo/study/studymatchingplatform/RefreshTokenTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/RefreshTokenTest.java
@@ -1,0 +1,41 @@
+package com.ludo.study.studymatchingplatform;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.ludo.study.studymatchingplatform.user.domain.user.redis.RefreshToken;
+import com.ludo.study.studymatchingplatform.user.repository.user.redis.RefreshTokenRepository;
+
+@SpringBootTest
+class RefreshTokenTest {
+
+	@Autowired
+	private RefreshTokenRepository refreshTokenRepository;
+
+	@AfterEach
+	void tearDown() throws Exception {
+		refreshTokenRepository.deleteAll();
+	}
+
+	@DisplayName("[Success] 리프레시 토큰 등록 조회 태스트")
+	@Test
+	void redisConnectionTest() {
+		// given
+		final Long id = 1L;
+		RefreshToken refreshToken = new RefreshToken(id, "refreshToken", 12345556L);
+
+		// when
+		refreshTokenRepository.save(refreshToken);
+
+		// then
+		RefreshToken savedRefreshToken = refreshTokenRepository.findById(id).get();
+		assertThat(savedRefreshToken.getUserId()).isEqualTo(1L);
+		assertThat(savedRefreshToken.getToken()).isEqualTo("refreshToken");
+	}
+
+}

--- a/src/test/java/com/ludo/study/studymatchingplatform/auth/common/JwtTokenProviderTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/auth/common/JwtTokenProviderTest.java
@@ -16,14 +16,14 @@ class JwtTokenProviderTest {
 
 	@Test
 	void jwt_access_token_생성() {
-		AuthUserPayload payload = AuthUserPayload.from(1L);
+		AuthUserPayload payload = AuthUserPayload.from(1L, "access");
 		String accessToken = jwtTokenProvider.createAccessToken(payload);
 		assertThat(accessToken).isNotNull();
 	}
 
 	@Test
 	void jwt_access_token_검증() {
-		AuthUserPayload payload = AuthUserPayload.from(1L);
+		AuthUserPayload payload = AuthUserPayload.from(1L, "access");
 		String accessToken = jwtTokenProvider.createAccessToken(payload);
 
 		assertThatCode(() -> jwtTokenProvider.verifyAuthTokenOrThrow(accessToken))

--- a/src/test/java/com/ludo/study/studymatchingplatform/auth/service/KakaoRefreshServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/auth/service/KakaoRefreshServiceTest.java
@@ -1,0 +1,157 @@
+package com.ludo.study.studymatchingplatform.auth.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import com.ludo.study.studymatchingplatform.auth.common.AuthUserPayload;
+import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
+import com.ludo.study.studymatchingplatform.auth.repository.InMemoryClientRegistrationAndProviderRepository;
+import com.ludo.study.studymatchingplatform.auth.service.dto.KakaoOAuthTokenTestResponse;
+import com.ludo.study.studymatchingplatform.auth.service.kakao.KakaoOAuthTokenRequestService;
+import com.ludo.study.studymatchingplatform.study.service.exception.NotFoundException;
+import com.ludo.study.studymatchingplatform.user.domain.user.Social;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import com.ludo.study.studymatchingplatform.user.domain.user.redis.RefreshToken;
+import com.ludo.study.studymatchingplatform.user.fixture.user.UserFixture;
+import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
+import com.ludo.study.studymatchingplatform.user.repository.user.redis.RefreshTokenRepository;
+
+@SpringBootTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class KakaoRefreshServiceTest {
+
+	@Autowired
+	private KakaoOAuthTokenRequestService kakaoOAuthTokenRequestService;
+
+	@Autowired
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Autowired
+	private InMemoryClientRegistrationAndProviderRepository clientRegistrationAndProviderRepository;
+
+	@Autowired
+	private UserRepositoryImpl userRepository;
+
+	@Autowired
+	private RefreshTokenRepository refreshTokenRepository;
+
+	@AfterEach
+	void tearDown() throws Exception {
+		refreshTokenRepository.deleteAll();
+		userRepository.deleteAll();
+	}
+
+	@DisplayName("[Success] 10000명의 사용자를 생성한다.")
+	@Test
+	@Order(1)
+	void createUsersTest() {
+		for (int i = 1; i <= 10000; i++) {
+			final User user = UserFixture.createUserWithId((long)i, Social.KAKAO, "닉네임" + i,
+					"lee@kakao.com", "리프레시" + i);
+			final RefreshToken refreshToken = new RefreshToken((long)i, "리프레시" + i, 123435254L);
+			refreshTokenRepository.save(refreshToken);
+			userRepository.save(user);
+		}
+	}
+
+	@DisplayName("[Success] 10000명의 사용자가 RDB 를 통한 토큰 갱신을 요청한다.")
+	@Test
+	@Order(2)
+	void usersRefreshToRDBTest() {
+		for (int i = 1; i <= 10000; i++) {
+			final User user = userRepository.findById((long)i)
+					.orElseThrow(() -> new NotFoundException("존재 하지 않는 사용자 입니다."));
+			refreshToRDB(user);
+		}
+	}
+
+	@DisplayName("[Success] 10000명의 사용자가 Redis 를 통한 토큰 갱신을 요청한다.")
+	@Test
+	@Order(3)
+	void usersRefreshToRedisTest() {
+		for (int i = 1; i <= 10000; i++) {
+			final User user = userRepository.findById((long)i)
+					.orElseThrow(() -> new NotFoundException("존재 하지 않는 사용자 입니다."));
+			refreshToRedis(user);
+		}
+	}
+
+	@DisplayName("[Success] 1명의 사용자가 RDB 를 통한 토큰 갱신을 10000번 요청한다.")
+	@Test
+	@Order(4)
+	void userRefreshToRDBTest() {
+		final User user = userRepository.findById(1L)
+				.orElseThrow(() -> new NotFoundException("존재 하지 않는 사용자 입니다."));
+		for (int i = 1; i <= 10000; i++) {
+			refreshToRDB(user);
+		}
+	}
+
+	@DisplayName("[Success] 1명의 사용자가 Redis 를 통한 토큰 갱신을 10000번 요청한다.")
+	@Test
+	@Order(5)
+	void userRefreshToRedisTest() {
+		final User user = userRepository.findById(1L)
+				.orElseThrow(() -> new NotFoundException("존재 하지 않는 사용자 입니다."));
+		for (int i = 1; i <= 10000; i++) {
+			refreshToRedis(user);
+		}
+	}
+
+	private String refreshToRDB(final User user) {
+		final KakaoOAuthTokenTestResponse token = createRefreshOAuthToken(user.getRefresh());
+		if (token != null) {
+			user.changeRefreshToken(token.refreshToken());
+			userRepository.save(user);
+		}
+		return jwtTokenProvider.createAccessToken(AuthUserPayload.from(user, token.accessToken()));
+	}
+
+	private String refreshToRedis(final User user) {
+		final RefreshToken refreshToken = refreshTokenRepository.findById(user.getId())
+				.orElseThrow(() -> new NotFoundException("존재하지 않는 토큰 입니다."));
+		final KakaoOAuthTokenTestResponse token = createRefreshOAuthToken(refreshToken.getToken());
+		if (token.refreshToken() != null) {
+			refreshToken.update(token.refreshToken(), 213152345L);
+			refreshTokenRepository.save(refreshToken);
+		}
+		return jwtTokenProvider.createAccessToken(AuthUserPayload.from(user, token.refreshToken()));
+	}
+
+	private KakaoOAuthTokenTestResponse createRefreshOAuthToken(final String refreshToken) {
+		final String tokenUri = clientRegistrationAndProviderRepository.findTokenUri(Social.KAKAO);
+		final HttpHeaders headers = createHeaders();
+		final MultiValueMap<String, String> body = createRefreshBody(refreshToken);
+		return new KakaoOAuthTokenTestResponse("tokenType", "accessToken", "refreshToken", 12355);
+	}
+
+	private HttpHeaders createHeaders() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		return headers;
+	}
+
+	private MultiValueMap<String, String> createRefreshBody(final String refreshToken) {
+		final String clientId = clientRegistrationAndProviderRepository.findClientId(Social.KAKAO);
+		final String clientSecret = clientRegistrationAndProviderRepository.findClientSecret(Social.KAKAO);
+		final String grantType = clientRegistrationAndProviderRepository.findRefreshGrantType(Social.KAKAO);
+
+		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+		body.add("grant_type", grantType);
+		body.add("client_id", clientId);
+		body.add("refresh_token", refreshToken);
+		body.add("client_secret", clientSecret);
+		return body;
+	}
+
+}

--- a/src/test/java/com/ludo/study/studymatchingplatform/auth/service/KakaoRefreshServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/auth/service/KakaoRefreshServiceTest.java
@@ -58,7 +58,7 @@ class KakaoRefreshServiceTest {
 		for (int i = 1; i <= 10000; i++) {
 			final User user = UserFixture.createUserWithId((long)i, Social.KAKAO, "닉네임" + i,
 					"lee@kakao.com", "리프레시" + i);
-			final RefreshToken refreshToken = new RefreshToken((long)i, "리프레시" + i, 123435254L);
+			final RefreshToken refreshToken = new RefreshToken((long)i, "리프레시" + i, 123435254);
 			refreshTokenRepository.save(refreshToken);
 			userRepository.save(user);
 		}
@@ -122,7 +122,7 @@ class KakaoRefreshServiceTest {
 				.orElseThrow(() -> new NotFoundException("존재하지 않는 토큰 입니다."));
 		final KakaoOAuthTokenTestResponse token = createRefreshOAuthToken(refreshToken.getToken());
 		if (token.refreshToken() != null) {
-			refreshToken.update(token.refreshToken(), 213152345L);
+			refreshToken.update(token.refreshToken(), 213152345);
 			refreshTokenRepository.save(refreshToken);
 		}
 		return jwtTokenProvider.createAccessToken(AuthUserPayload.from(user, token.refreshToken()));

--- a/src/test/java/com/ludo/study/studymatchingplatform/auth/service/dto/KakaoOAuthTokenTestResponse.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/auth/service/dto/KakaoOAuthTokenTestResponse.java
@@ -1,0 +1,15 @@
+package com.ludo.study.studymatchingplatform.auth.service.dto;
+
+public record KakaoOAuthTokenTestResponse(
+
+		String tokenType,
+
+		String accessToken,
+
+		String refreshToken,
+
+		Integer expiresIn
+
+) {
+
+}

--- a/src/test/java/com/ludo/study/studymatchingplatform/user/fixture/user/UserFixture.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/user/fixture/user/UserFixture.java
@@ -22,4 +22,14 @@ public class UserFixture {
 				.build();
 	}
 
+	public static User createUserWithId(Long userId, Social social, String nickname, String email, String refresh) {
+		return User.builder()
+				.id(userId)
+				.social(social)
+				.nickname(nickname)
+				.email(email)
+				.refresh(refresh)
+				.build();
+	}
+
 }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -3,6 +3,11 @@ spring:
     active: local
     default: local
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   devtools:
     livereload:
       enabled: true
@@ -39,6 +44,7 @@ oauth2:
         login-redirect-uri: ${KAKAO_LOGIN_CALLBACK_URL}
         signup-redirect-uri: ${KAKAO_SIGNUP_CALLBACK_URL}
         authorization-grant-type: code
+        refresh-grant-type: refresh_token
       google:
         client-id: ${GOOGLE_CLIENT_ID}
         client-secret: ${GOOGLE_CLIENT_SECRET}


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- [카카오 토큰 리프레시 기능 추가](https://github.com/Ludo-SMP/ludo-backend/commit/2c8a9893fffa6084e72cf705a5d980fff2770679)
  - RDB / Redis 모두 구현, issue에서 언급 드린 대로 성능 테스트도 완료 했습니다.

- [accessToken 생성시 Claims 항목에 소셜에서 받아온 accessToken 추가](https://github.com/Ludo-SMP/ludo-backend/commit/3a74fc18fdc02e3057709ddf509a7f2b493d6878)

- [카카오 토큰 리프레시 쿠키 검증 필요 항목으로 추가](https://github.com/Ludo-SMP/ludo-backend/commit/7b4394f5f21c09d7bb19975a8feda48169d45c8d)

- [구글 / 네이버 컨트롤러 주석 처리](https://github.com/Ludo-SMP/ludo-backend/commit/153d6d0bfa3862eac40d97f8acf9772b62cafab7)

- [User domain, refresh 컬럼 추가](https://github.com/Ludo-SMP/ludo-backend/commit/f7b2fe1336fb7a4dd3fc1458551c016cd2222b2a)

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- 카카오 토큰 리프레시 기능 추가
<img width="818" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/95eab882-0cfd-45cb-992b-a4df805d01bd">

- 카카오 서버로 refresh_token을 grant-type으로 담아 기존에 받아온 refreshToken을 전달 하여 갱신하는 방식입니다.
<img width="841" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/d3ea2104-c249-4e36-996f-185594c989a2">

- 리프레시 토큰의 경우 갱신시 만료기간이 30일 이하로 남은 경우에만 새로운 리프레시 토큰을 내려주고, 그 외에는 null 값을 받아오기에 받아온 리프레시 토큰의 값이 null이 아닐 경우 새로운 토큰으로 update 해주는 조건문을 추가 했습니다.
<img width="1120" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/5b1228ee-48a9-4628-b5fa-67d2df008513">

- 카카오 로그인시 새로운 리프레시 토큰으로 update 하도록 구현했습니다.
<img width="971" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/7036cc35-90c8-4b69-8dc7-ff69accba6b6">

<br><br>

- AuthUserPayload에 accessToken을 추가했습니다.
<img width="709" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/1c72ca67-e12a-4d66-92c5-d393c8da7b6b">


- 기존 방식으로 갱신한 결과 입니다.
<img width="698" alt="스크린샷 2024-03-18 오후 5 35 51" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/1458732c-b5d1-4cc7-a7c2-a28b872a343e">

<img width="697" alt="스크린샷 2024-03-18 오후 4 44 04" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/9201b748-ea3c-4807-ad4f-85635bee1aeb">

<img width="1263" alt="스크린샷 2024-03-18 오후 4 43 41" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/18278cb8-9553-4fdd-b839-fef1c3ef088b">

<br><br>

- accessToken을 추가하고 갱신한 결과 입니다.
<img width="701" alt="스크린샷 2024-03-18 오후 4 41 29" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/edb652e7-80af-4cea-bd75-9bd0d95aa9c5">

<img width="695" alt="스크린샷 2024-03-18 오후 4 41 13" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/d0cf9943-1369-4a6c-b6f0-d515e8895355">

<img width="1206" alt="스크린샷 2024-03-18 오후 4 42 08" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/88f57d49-4e11-4edb-88c4-26563902be98">

- **기존에 커스텀 accessToken을 사용하고 있었는데, 갱신해도 매번 비슷한 값으로 생성되기에 갱신된 토큰인지 파악이 어렵고,  만료기간은 계속 늘어나지만, 쿠키를 주고 받는 과정에서 매번 비슷한 값으로 반환 될 시 보안 침해 시도 빈도가 늘어날 것 으로 예상해서 적용해봤는데, 다시 보니 별 차이 없는것 같기도 하네요.** 😅

<br><br>

- redis 설정 클래스 및 RefreshToken 객체 입니다. 별도의 비밀번호는 추가하지 않은 상태에요.
<img width="287" alt="스크린샷 2024-03-18 오후 5 44 01" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/ab680ba5-1779-4171-acfa-63ca9644b296">

<img width="832" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/71075698-170e-4239-9c45-da9abcd6a485">

<img width="663" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/57454d1b-8f10-4e90-98ff-1d880c058839">

<br><br>

- **리프레시 토큰 갱신에 대한 RDB와 Redis의 성능 테스트 결과를 첨부 드립니다.** 
- **10,000명을 기준으로 모든 사용자가 한 번씩 갱신요청했을 때 성능은 비슷한데, 1명의 사용자가 10000번 갱신요했을 경우 약 70% 이상 성능 향상을 검증했습니다.**

<img width="577" alt="스크린샷 2024-03-18 오전 12 41 03" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/b891e7c2-6713-4241-b87f-e3c9aa91002e">

<br><br>

### 💡 필요한 후속작업이 있어요.

- **토큰 Claims, 각 소셜에서 받아온 access 토큰 추가 여부 확정**
  - 현재 구글 / 네이버 컨트롤러의 코드가 주석 처리 되어 있습니다. 결과에 따라 리팩터링 후 반영하록 하겠습니다.

- **리프레시 토큰 저장 방식 결정**
  - RDB 저장 시 User 도메인에 refresh 컬럼을 추가 하게 되는데, 이로 인해 테스트가 어긋나는 이슈가 발생한 상태 입니다. 결정 된 방식으로 정상 동작 하도록 리팩터링 하도록 하겠습니다.

- **토큰 리프레시 시점 결정** 
  - 현재는 프론트 쪽에서 만료시간 검증 후 POST 요청을 보내는 방식으로 구현되어 있습니다. 

<br><br>

### 💡 다음 자료를 참고하면 좋아요.

[[Redis] SpringBoot Data Redis 로컬/통합 테스트 환경 구축하기](https://jojoldu.tistory.com/297)

<br><br>

### ✅ 셀프 체크리스트

- [X] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [X] 커밋 메세지를 컨벤션에 맞추었습니다.
- [X] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [X] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [X] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
