### PR TITLE
SP-348/Refactor: 마이 페이지, 내가 지원한 스터디 목록 항목 추가

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/user/service/dto/response/ApplicantRecruitmentResponse.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/service/dto/response/ApplicantRecruitmentResponse.java
@@ -1,5 +1,6 @@
 package com.ludo.study.studymatchingplatform.user.service.dto.response;
 
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.applicant.Applicant;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.applicant.ApplicantStatus;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.recruitment.position.PositionResponse;
@@ -10,6 +11,7 @@ import lombok.Builder;
 public record ApplicantRecruitmentResponse(
 
 		Long recruitmentId,
+		Long studyId,
 		String title,
 		PositionResponse position,
 		ApplicantStatus applicantStatus
@@ -18,9 +20,11 @@ public record ApplicantRecruitmentResponse(
 
 	public static ApplicantRecruitmentResponse from(final Applicant applicant) {
 		final PositionResponse positionResponse = PositionResponse.from(applicant.getPosition());
+		final Recruitment recruitment = applicant.getRecruitment();
 		return ApplicantRecruitmentResponse.builder()
-				.recruitmentId(applicant.getRecruitment().getId())
-				.title(applicant.getRecruitment().getTitle())
+				.recruitmentId(recruitment.getId())
+				.studyId(recruitment.getStudy().getId())
+				.title(recruitment.getTitle())
 				.position(positionResponse)
 				.applicantStatus(applicant.getApplicantStatus())
 				.build();

--- a/src/test/java/com/ludo/study/studymatchingplatform/user/service/MyPageServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/user/service/MyPageServiceTest.java
@@ -139,7 +139,7 @@ class MyPageServiceTest {
 		// then
 		final MyPageResponse expectedResponse = new MyPageResponse(
 				new UserResponse(2L, "닉네임", "이메일"),
-				List.of(), List.of(new ApplicantRecruitmentResponse(1L, "모집 공고",
+				List.of(), List.of(new ApplicantRecruitmentResponse(1L, 1L, "모집 공고",
 				new PositionResponse(1L, "포지션"), ApplicantStatus.UNCHECKED)), List.of());
 
 		Assertions.assertThat(myPageResponse)


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 지원 취소시 사용할 studyId 추가

<br><br>


### ✅ 셀프 체크리스트

- [X] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [X] 커밋 메세지를 컨벤션에 맞추었습니다.
- [X] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [X] 변경 후 코드는 기존의 테스트를 통과합니다.
- [X] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [X] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
