### PR TITLE
SP-234/Fix: 네이버 소셜 로그인 로직 변경

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/naver/NaverLoginController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/naver/NaverLoginController.java
@@ -18,7 +18,6 @@ import com.ludo.study.studymatchingplatform.auth.service.naver.NaverLoginService
 import com.ludo.study.studymatchingplatform.common.annotation.DataFieldName;
 import com.ludo.study.studymatchingplatform.user.domain.user.Social;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
-import com.ludo.study.studymatchingplatform.user.service.dto.response.UserResponse;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -52,18 +51,15 @@ public class NaverLoginController {
 	@GetMapping("/naver/callback")
 	@ResponseStatus(HttpStatus.FOUND)
 	@DataFieldName("user")
-	public UserResponse naverLoginCallback(
+	public void naverLoginCallback(
 			@RequestParam(name = "code") final String authorizationCode,
 			final HttpServletResponse response) throws IOException {
 
 		final User user = naverLoginService.login(authorizationCode);
 		final String accessToken = jwtTokenProvider.createAccessToken(AuthUserPayload.from(user));
-		final UserResponse userResponse = UserResponse.from(user);
 
 		cookieProvider.setAuthCookie(accessToken, response);
-		response.sendRedirect("https://local.ludoapi.store:3000");
-
-		return userResponse;
+		response.sendRedirect("https://ludoapi.store");
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/naver/NaverSignUpController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/naver/NaverSignUpController.java
@@ -18,7 +18,6 @@ import com.ludo.study.studymatchingplatform.auth.service.naver.NaverSignUpServic
 import com.ludo.study.studymatchingplatform.common.annotation.DataFieldName;
 import com.ludo.study.studymatchingplatform.user.domain.user.Social;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
-import com.ludo.study.studymatchingplatform.user.service.dto.response.UserResponse;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -51,17 +50,14 @@ public class NaverSignUpController {
 	@GetMapping("/naver/callback")
 	@ResponseStatus(HttpStatus.FOUND)
 	@DataFieldName("user")
-	public UserResponse naverSignupCallback(
+	public void naverSignupCallback(
 			@RequestParam(name = "code") final String authorizationCode,
 			final HttpServletResponse response) throws IOException {
 
 		final User user = naverSignUpService.naverSignUp(authorizationCode);
 		final String accessToken = jwtTokenProvider.createAccessToken(AuthUserPayload.from(user));
-		final UserResponse userResponse = UserResponse.from(user);
 
 		cookieProvider.setAuthCookie(accessToken, response);
-		response.sendRedirect("https://local.ludoapi.store:3000");
-
-		return userResponse;
+		response.sendRedirect("https://ludoapi.store");
 	}
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/naver/NaverLoginService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/naver/NaverLoginService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 
 import com.ludo.study.studymatchingplatform.auth.service.naver.vo.NaverOAuthToken;
 import com.ludo.study.studymatchingplatform.auth.service.naver.vo.UserProfile;
+import com.ludo.study.studymatchingplatform.study.service.exception.NotFoundException;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
 
@@ -28,7 +29,7 @@ public class NaverLoginService {
 
 	private User validateNotSignUp(final UserProfile profileResponse) {
 		return userRepository.findByEmail(profileResponse.getEmail())
-				.orElseThrow(() -> new IllegalArgumentException("가입되어 있지 않은 회원입니다."));
+				.orElseThrow(() -> new NotFoundException("가입되어 있지 않은 회원입니다."));
 	}
 
 }


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

- [x] 로그인 성공, 회원가입 성공 시 반환 타입을 void로 변경했습니다.
  - (액세스 토큰을 쿠키에 담아 보내주기 때문이에요.)
- [x] 로그인 성공, 회원가입 성공 시 리다이렉트 uri를 개발환경 uri에서 실 도메인 uri로 변경했습니다.
- [x] 로그인 실패 시 예외 타입을 `IllegalArgumentException` → `NotFoundException(Custom)` 으로 변경했습니다.
  - 현재 글로벌 예외 핸들러는 `IllegalArugmentException`은 메인 페이지로 리다이렉트를 추가하는 기능을 수행하고 있습니다.
  - 현재 비즈니스 요구사항에 로그인 실패 시, 메인 페이지 리다이렉트가 아닌 예외 모달을 띄워주는 방식으므로, 예외를 그에 맞게 변경했습니다.

<br><br>

### ✅ 셀프 체크리스트

- [o] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [o] 커밋 메세지를 컨벤션에 맞추었습니다.
- [o] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [o] 변경 후 코드는 기존의 테스트를 통과합니다.
- [o] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [o] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
