### PR TITLE
Sp-348/Hotfix: 모집 공고 지원자 거절시 softdelete 되는 시점을 지원 기록 삭제 시로 변경

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/recruitment/Recruitment.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/recruitment/Recruitment.java
@@ -340,8 +340,8 @@ public class Recruitment extends BaseEntity {
 	public void rejectApplicant(final User applicantUser) {
 		final Applicant applicant = getApplicant(applicantUser);
 		applicant.changeStatus(ApplicantStatus.REFUSED);
-		// 지원자 거절시 소프트 딜리트 추가
-		applicant.softDelete();
+		// 지원자 거절시 소프트 딜리트 제거
+		// applicant.softDelete();
 	}
 
 	public Applicant getApplicant(final User applicantUser) {

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Study.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Study.java
@@ -280,8 +280,7 @@ public class Study extends BaseEntity {
 		}
 	}
 
-	public void modifyStatusToCompleted() {
-		final LocalDateTime now = LocalDateTime.now();
+	public void modifyStatusToCompleted(final LocalDateTime now) {
 		if (this.endDateTime.isBefore(now)) {
 			this.status = StudyStatus.COMPLETED;
 		}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/repository/recruitment/applicant/ApplicantRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/repository/recruitment/applicant/ApplicantRepositoryImpl.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import com.ludo.study.studymatchingplatform.study.domain.id.ApplicantId;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.applicant.Applicant;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -45,6 +46,14 @@ public class ApplicantRepositoryImpl {
 				.where(applicant.recruitment.id.eq(id))
 				.where(applicant.deletedDateTime.isNull())
 				.fetch();
+	}
+
+	public Optional<Applicant> findById(final ApplicantId applicantId) {
+		return Optional.ofNullable(
+				q.selectFrom(applicant)
+						.where(applicant.id.eq(applicantId))
+						.where(applicant.deletedDateTime.isNull())
+						.fetchOne());
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentService.java
@@ -150,11 +150,4 @@ public class RecruitmentService {
 		recruitmentRepository.save(study.getRecruitment());
 	}
 
-	public void deleteApplyHistory(final User user, final Long recruitmentId) {
-		final Applicant applicant = applicantRepository.find(recruitmentId, user.getId())
-				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지원 기록 입니다."));
-		applicant.softDelete();
-		applicantRepository.save(applicant);
-	}
-
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/StudyCreateService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/StudyCreateService.java
@@ -1,5 +1,7 @@
 package com.ludo.study.studymatchingplatform.study.service.study;
 
+import java.time.LocalDateTime;
+
 import org.springframework.stereotype.Service;
 
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
@@ -36,7 +38,8 @@ public class StudyCreateService {
 		final Position ownerPosition = findPositionById(request.positionId());
 
 		// 생성된 스터디의 endDateTime 이 현재보다 이전일 경우 진행 완료 상태로 변경
-		study.modifyStatusToCompleted();
+		final LocalDateTime now = LocalDateTime.now();
+		study.modifyStatusToCompleted(now);
 
 		studyRepository.save(study);
 		participantService.add(study, user, ownerPosition, Role.OWNER);

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/StudyFetchService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/StudyFetchService.java
@@ -1,5 +1,7 @@
 package com.ludo.study.studymatchingplatform.study.service.study;
 
+import java.time.LocalDateTime;
+
 import org.springframework.stereotype.Service;
 
 import com.ludo.study.studymatchingplatform.study.domain.study.Study;
@@ -24,7 +26,8 @@ public class StudyFetchService {
 			throw new IllegalArgumentException("스터디원만 조회 가능합니다.");
 		}
 		// endDateTime 에 따른 진행 완료 상태 변경
-		study.modifyStatusToCompleted();
+		final LocalDateTime now = LocalDateTime.now();
+		study.modifyStatusToCompleted(now);
 		return StudyResponse.from(study);
 	}
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/StudyUpdateService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/StudyUpdateService.java
@@ -1,5 +1,7 @@
 package com.ludo.study.studymatchingplatform.study.service.study;
 
+import java.time.LocalDateTime;
+
 import org.springframework.stereotype.Service;
 
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
@@ -35,7 +37,8 @@ public class StudyUpdateService {
 				request.startDateTime(), request.endDateTime());
 
 		// 수정된 endDateTime이 현재 시간 이전일 경우 진행 완료 상태로 변경
-		study.modifyStatusToCompleted();
+		final LocalDateTime now = LocalDateTime.now();
+		study.modifyStatusToCompleted(now);
 
 		final Position ownerPosition = findPositionById(request.positionId());
 		final Participant participant = findParticipantByIds(study.getId(), user.getId());

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/controller/MyPageController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/controller/MyPageController.java
@@ -1,5 +1,7 @@
 package com.ludo.study.studymatchingplatform.user.controller;
 
+import java.time.LocalDateTime;
+
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,7 +9,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ludo.study.studymatchingplatform.auth.common.AuthUser;
-import com.ludo.study.studymatchingplatform.study.service.recruitment.RecruitmentService;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import com.ludo.study.studymatchingplatform.user.service.MyPageService;
 import com.ludo.study.studymatchingplatform.user.service.dto.response.MyPageResponse;
@@ -23,14 +24,14 @@ import lombok.RequiredArgsConstructor;
 public class MyPageController {
 
 	private final MyPageService myPageService;
-	private final RecruitmentService recruitmentService;
 
 	@GetMapping("/users/mypage")
 	@Operation(description = "로그인 된 사용자 정보 조회")
 	@ApiResponse(description = "조회 성공", responseCode = "200", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
 	public MyPageResponse retrieveMyPage(@CookieValue(name = "Authorization") final String auth,
 										 @Parameter(hidden = true) @AuthUser final User user) {
-		return myPageService.retrieveMyPage(user);
+		final LocalDateTime now = LocalDateTime.now();
+		return myPageService.retrieveMyPage(user, now);
 	}
 
 	@DeleteMapping("/users/recruitments/{recruitmentId}/apply-history")
@@ -38,7 +39,7 @@ public class MyPageController {
 	@ApiResponse(description = "조회 성공", responseCode = "200", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
 	public void deleteApplyHistory(@PathVariable Long recruitmentId,
 								   @Parameter(hidden = true) @AuthUser final User user) {
-		recruitmentService.deleteApplyHistory(user, recruitmentId);
+		myPageService.deleteApplyHistory(user, recruitmentId);
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/service/dto/response/MyPageResponse.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/service/dto/response/MyPageResponse.java
@@ -41,6 +41,7 @@ public record MyPageResponse(
 
 	private static List<ApplicantRecruitmentResponse> makeApplicantRecruitments(final List<Applicant> applicants) {
 		return applicants.stream()
+				.filter(applicant -> applicant.getDeletedDateTime() == null)
 				.map(ApplicantRecruitmentResponse::from)
 				.toList();
 	}

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/applicant/ApplicantFixture.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/applicant/ApplicantFixture.java
@@ -1,9 +1,10 @@
 package com.ludo.study.studymatchingplatform.study.fixture.recruitment.applicant;
 
-import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
+import com.ludo.study.studymatchingplatform.study.domain.id.ApplicantId;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.applicant.Applicant;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.applicant.ApplicantStatus;
-import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 
 public class ApplicantFixture {
@@ -20,6 +21,19 @@ public class ApplicantFixture {
 											User user,
 											Position position) {
 		return Applicant.builder()
+				.recruitment(recruitment)
+				.user(user)
+				.position(position)
+				.applicantStatus(ApplicantStatus.UNCHECKED)
+				.build();
+	}
+
+	public static Applicant createApplicant(ApplicantId applicantId,
+											Recruitment recruitment,
+											User user,
+											Position position) {
+		return Applicant.builder()
+				.id(applicantId)
 				.recruitment(recruitment)
 				.user(user)
 				.position(position)


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- **모집 공고 지원자 거절시 softdelete 되는 시점을 지원 기록 삭제 시로 변경했습니다.**
- **지원 기록 삭제 메서드의 위치를 변경했습니다.**
  - recruitmentService -> mypageService
- **테스트 케이스의 불변을 유지하기 위해서 endDateTime 시점에 따른 스터디 상태 변경 시점을 변경했습니다.**
  - LocalDateTime.now() 선언 시점, domain -> service

<br><br>

### 💡 필요한 후속작업이 있어요.
- 모집 공고 생성 후 지원자가 없는 상태에서 `지원자 확인 버튼`이 활성화 되는 예외는 아직 손대지 않았습니다. 이유는 `아직 지원자가 없어요` 라는 상태를 띄워 주는것이 조금 더 자연스럽지 않을까 하는 생각 때문인데, 오늘 데일리 스크럼에서 이야기 나누고 확정된 사안을 반영하도록 하겠습니다. 

<br><br>

### ✅ 셀프 체크리스트

- [X] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [X] 커밋 메세지를 컨벤션에 맞추었습니다.
- [X] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [X] 변경 후 코드는 기존의 테스트를 통과합니다.
- [X] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [X] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
