### PR TITLE
SP-234/Fix: 소셜 로그인 사용자 프로필 수집 대상 변경으로 인한 코드 수정

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/google/GoogleLoginService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/google/GoogleLoginService.java
@@ -3,7 +3,7 @@ package com.ludo.study.studymatchingplatform.auth.service.google;
 import org.springframework.stereotype.Service;
 
 import com.ludo.study.studymatchingplatform.auth.service.google.vo.GoogleOAuthToken;
-import com.ludo.study.studymatchingplatform.auth.service.google.vo.GoogleUserInfo;
+import com.ludo.study.studymatchingplatform.auth.service.google.vo.GoogleUserProfile;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
 
@@ -21,7 +21,7 @@ public class GoogleLoginService {
 
 	public User login(final String authorizationCode) {
 		final GoogleOAuthToken oAuthToken = googleOAuthTokenRequestService.createOAuthToken(authorizationCode, false);
-		final GoogleUserInfo userInfo = googleProfileRequestService.createGoogleUserInfo(
+		final GoogleUserProfile userInfo = googleProfileRequestService.createGoogleUserInfo(
 				oAuthToken.getAccessToken());
 
 		final User user = validateNotSignUp(userInfo);
@@ -29,7 +29,7 @@ public class GoogleLoginService {
 		return user;
 	}
 
-	private User validateNotSignUp(final GoogleUserInfo userInfo) {
+	private User validateNotSignUp(final GoogleUserProfile userInfo) {
 		return userRepository.findByEmail(userInfo.getEmail())
 				.orElseThrow(() -> new IllegalArgumentException("가입되어 있지 않은 회원입니다."));
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/google/GoogleProfileRequestService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/google/GoogleProfileRequestService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import com.ludo.study.studymatchingplatform.auth.repository.InMemoryClientRegistrationAndProviderRepository;
-import com.ludo.study.studymatchingplatform.auth.service.google.vo.GoogleUserInfo;
+import com.ludo.study.studymatchingplatform.auth.service.google.vo.GoogleUserProfile;
 import com.ludo.study.studymatchingplatform.user.domain.user.Social;
 
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,7 @@ public class GoogleProfileRequestService {
 	private final RestTemplate restTemplate;
 	private final InMemoryClientRegistrationAndProviderRepository clientRegistrationAndProviderRepository;
 
-	public GoogleUserInfo createGoogleUserInfo(final String accessToken) {
+	public GoogleUserProfile createGoogleUserInfo(final String accessToken) {
 		final String userInfoUri = clientRegistrationAndProviderRepository.findUserInfoUri(Social.GOOGLE);
 		final HttpHeaders headers = createHeaders(accessToken);
 
@@ -35,13 +35,13 @@ public class GoogleProfileRequestService {
 		return headers;
 	}
 
-	private GoogleUserInfo requestUserProfile(final String userInfoUri, final HttpHeaders headers) {
+	private GoogleUserProfile requestUserProfile(final String userInfoUri, final HttpHeaders headers) {
 
 		return restTemplate.exchange(
 						userInfoUri,
 						HttpMethod.GET,
 						new HttpEntity<>(headers),
-						GoogleUserInfo.class)
+						GoogleUserProfile.class)
 				.getBody();
 	}
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/google/GoogleSignUpService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/google/GoogleSignUpService.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ludo.study.studymatchingplatform.auth.service.google.vo.GoogleOAuthToken;
-import com.ludo.study.studymatchingplatform.auth.service.google.vo.GoogleUserInfo;
+import com.ludo.study.studymatchingplatform.auth.service.google.vo.GoogleUserProfile;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
 
@@ -21,21 +21,22 @@ public class GoogleSignUpService {
 	@Transactional
 	public User googleSignUp(final String authorizationCode) {
 		final GoogleOAuthToken oAuthToken = googleOAuthTokenRequestService.createOAuthToken(authorizationCode, true);
-		final GoogleUserInfo userInfo = googleProfileRequestService.createGoogleUserInfo(oAuthToken.getAccessToken());
+		final GoogleUserProfile userInfo = googleProfileRequestService.createGoogleUserInfo(
+				oAuthToken.getAccessToken());
 
 		validateAlreadySignUp(userInfo);
 
 		return signup(userInfo);
 	}
 
-	private void validateAlreadySignUp(final GoogleUserInfo userInfo) {
+	private void validateAlreadySignUp(final GoogleUserProfile userInfo) {
 		userRepository.findByEmail(userInfo.getEmail())
 				.ifPresent(user -> {
 					throw new IllegalArgumentException("이미 가입되어 있는 회원입니다.");
 				});
 	}
 
-	private User signup(final GoogleUserInfo userInfo) {
+	private User signup(final GoogleUserProfile userInfo) {
 		final User user = userRepository.save(userInfo.toUser());
 		user.setInitialDefaultNickname();
 		return user;

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/google/vo/GoogleUserProfile.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/google/vo/GoogleUserProfile.java
@@ -8,17 +8,15 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class GoogleUserInfo {
+public class GoogleUserProfile {
 
 	private final String id;
 	private final String email;
-	private final String name;
 
 	public User toUser() {
 		return User.builder()
 				.social(Social.GOOGLE)
 				.email(email)
-				.nickname(name)
 				.build();
 	}
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/kakao/dto/response/KakaoUserProfile.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/kakao/dto/response/KakaoUserProfile.java
@@ -22,7 +22,6 @@ public class KakaoUserProfile {
 	@ToString
 	public static class Response {
 		private String id;
-		private String nickname;
 		private String email;
 	}
 
@@ -33,7 +32,6 @@ public class KakaoUserProfile {
 	public User toUser() {
 		return User.builder()
 				.social(Social.NAVER)
-				.nickname(response.nickname)
 				.email(response.email)
 				.build();
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/naver/NaverLoginService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/naver/NaverLoginService.java
@@ -3,7 +3,7 @@ package com.ludo.study.studymatchingplatform.auth.service.naver;
 import org.springframework.stereotype.Service;
 
 import com.ludo.study.studymatchingplatform.auth.service.naver.vo.NaverOAuthToken;
-import com.ludo.study.studymatchingplatform.auth.service.naver.vo.UserProfile;
+import com.ludo.study.studymatchingplatform.auth.service.naver.vo.NaverUserProfile;
 import com.ludo.study.studymatchingplatform.study.service.exception.NotFoundException;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
@@ -22,12 +22,12 @@ public class NaverLoginService {
 
 	public User login(final String authorizationCode) {
 		final NaverOAuthToken oAuthToken = naverOAuthTokenRequestService.createOAuthToken(authorizationCode);
-		final UserProfile profileResponse = naverProfileRequestService.createNaverProfile(oAuthToken);
+		final NaverUserProfile profileResponse = naverProfileRequestService.createNaverProfile(oAuthToken);
 
 		return validateNotSignUp(profileResponse);
 	}
 
-	private User validateNotSignUp(final UserProfile profileResponse) {
+	private User validateNotSignUp(final NaverUserProfile profileResponse) {
 		return userRepository.findByEmail(profileResponse.getEmail())
 				.orElseThrow(() -> new NotFoundException("가입되어 있지 않은 회원입니다."));
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/naver/NaverProfileRequestService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/naver/NaverProfileRequestService.java
@@ -8,7 +8,7 @@ import org.springframework.web.client.RestTemplate;
 
 import com.ludo.study.studymatchingplatform.auth.repository.InMemoryClientRegistrationAndProviderRepository;
 import com.ludo.study.studymatchingplatform.auth.service.naver.vo.NaverOAuthToken;
-import com.ludo.study.studymatchingplatform.auth.service.naver.vo.UserProfile;
+import com.ludo.study.studymatchingplatform.auth.service.naver.vo.NaverUserProfile;
 import com.ludo.study.studymatchingplatform.user.domain.user.Social;
 
 import lombok.RequiredArgsConstructor;
@@ -22,7 +22,7 @@ public class NaverProfileRequestService {
 	private final RestTemplate restTemplate;
 	private final InMemoryClientRegistrationAndProviderRepository clientRegistrationAndProviderRepository;
 
-	public UserProfile createNaverProfile(final NaverOAuthToken naverOAuthToken) {
+	public NaverUserProfile createNaverProfile(final NaverOAuthToken naverOAuthToken) {
 		final String userInfoUri = clientRegistrationAndProviderRepository.findUserInfoUri(Social.NAVER);
 		final HttpHeaders headers = createHeaders(naverOAuthToken);
 
@@ -36,13 +36,13 @@ public class NaverProfileRequestService {
 		return headers;
 	}
 
-	private UserProfile requestUserProfile(final String userInfoUri, final HttpHeaders headers) {
+	private NaverUserProfile requestUserProfile(final String userInfoUri, final HttpHeaders headers) {
 
 		return restTemplate.exchange(
 						userInfoUri,
 						HttpMethod.GET,
 						new HttpEntity<>(headers),
-						UserProfile.class)
+						NaverUserProfile.class)
 				.getBody();
 	}
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/naver/NaverSignUpService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/naver/NaverSignUpService.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ludo.study.studymatchingplatform.auth.service.naver.vo.NaverOAuthToken;
-import com.ludo.study.studymatchingplatform.auth.service.naver.vo.UserProfile;
+import com.ludo.study.studymatchingplatform.auth.service.naver.vo.NaverUserProfile;
 import com.ludo.study.studymatchingplatform.study.service.exception.DuplicatedSignUpException;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
@@ -22,20 +22,20 @@ public class NaverSignUpService {
 	@Transactional
 	public User naverSignUp(final String authorizationCode) {
 		final NaverOAuthToken oAuthToken = naverOAuthTokenRequestService.createOAuthToken(authorizationCode);
-		final UserProfile userProfile = naverProfileRequestService.createNaverProfile(oAuthToken);
+		final NaverUserProfile userProfile = naverProfileRequestService.createNaverProfile(oAuthToken);
 
 		validateAlreadySignUp(userProfile);
 		return signup(userProfile);
 	}
 
-	private void validateAlreadySignUp(final UserProfile userProfile) {
+	private void validateAlreadySignUp(final NaverUserProfile userProfile) {
 		userRepository.findByEmail(userProfile.getEmail())
 				.ifPresent(user -> {
 					throw new DuplicatedSignUpException("이미 가입되어 있는 회원입니다.");
 				});
 	}
 
-	private User signup(final UserProfile userProfile) {
+	private User signup(final NaverUserProfile userProfile) {
 		User user = userRepository.save(userProfile.toUser());
 		user.setInitialDefaultNickname();
 		return user;

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/naver/vo/NaverUserProfile.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/naver/vo/NaverUserProfile.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 
 @Getter
 @ToString
-public class UserProfile {
+public class NaverUserProfile {
 
 	@JsonProperty("resultcode")
 	private String resultCode;
@@ -22,7 +22,6 @@ public class UserProfile {
 	@ToString
 	public static class Response {
 		private String id;
-		private String nickname;
 		private String email;
 	}
 
@@ -33,7 +32,6 @@ public class UserProfile {
 	public User toUser() {
 		return User.builder()
 				.social(Social.NAVER)
-				.nickname(response.nickname)
 				.email(response.email)
 				.build();
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/domain/user/User.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/domain/user/User.java
@@ -41,7 +41,7 @@ public class User extends BaseEntity {
 	@Column(nullable = false, updatable = false, columnDefinition = "char(10)")
 	private Social social;
 
-	@Column(nullable = false)
+	@Column
 	@Size(min = 1, max = 20)
 	private String nickname;
 


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

- [x] 네이버 회원가입 시 발생하는 insert 쿼리에서 `nickname not null` 제약 조건 오류 해결

<br><br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.
### User 엔티티의 `nickname` 제약 조건 `not null → null` 로 변경
```java
// User Entity
@Column
@Size(min = 1, max = 20)
private String nickname;
```
- 저희 서비스의 닉네임은 `prefix문자` + `기본숫자값` + `user_id (auto_increment)`로 지정됩니다.
- 즉 기본 닉네임을 부여하기 위해선 User 레코드를 한 번 삽입해야 합니다.
- 삽입 이전엔 nickname 이 null 이므로, `nullable = false`에 의해 insert 쿼리에서 오류가 발생합니다.
- `nickname = ""` 와 같은 방식으로 빈문자열로 초기화하여 넣어줄 수도 있지만, 불 필요한 코스트라 생각하여 `nullable = true`로 제약 조건을 변경했습니다.

<br> <br>
### Google, Kakao OAuth 유저 프로필 응답값 변경
- Naver 뿐만 아니라 Google, Kakao도 유저 프로필 응답값의 nickname을 제거했습니다. 후속 작업으로 카카오, 구글 로그인 Open API 사용자 프로필 수집 항목 중 `닉네임`을 제거해야 하기 때문에 일괄 처리했습니다.


<br><br>

## 💡 필요한 후속작업이 있어요.

- 카카오, 구글 로그인 Open API 사용자 프로필 수집 항목 중 `닉네임` 제거
- MyPageServiceTest 테스트 실패 문제 해결 필요


<br><br>

### ✅ 셀프 체크리스트

- [o] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [o] 커밋 메세지를 컨벤션에 맞추었습니다.
- [o] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [_] 변경 후 코드는 기존의 테스트를 통과합니다.
- [o] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [o] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
