### PR TITLE
Sp-235/Hotfix: 구글 로그인 / 회원가입 예외 전역 처리, 스터디 지원자 거절시 목록에서 제거 로직 추가

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/google/GoogleLoginService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/google/GoogleLoginService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 
 import com.ludo.study.studymatchingplatform.auth.service.google.vo.GoogleOAuthToken;
 import com.ludo.study.studymatchingplatform.auth.service.google.vo.GoogleUserProfile;
+import com.ludo.study.studymatchingplatform.study.service.exception.NotFoundException;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
 
@@ -31,7 +32,7 @@ public class GoogleLoginService {
 
 	private User validateNotSignUp(final GoogleUserProfile userInfo) {
 		return userRepository.findByEmail(userInfo.getEmail())
-				.orElseThrow(() -> new IllegalArgumentException("가입되어 있지 않은 회원입니다."));
+				.orElseThrow(() -> new NotFoundException("가입되어 있지 않은 회원입니다."));
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/google/GoogleSignUpService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/google/GoogleSignUpService.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.ludo.study.studymatchingplatform.auth.service.google.vo.GoogleOAuthToken;
 import com.ludo.study.studymatchingplatform.auth.service.google.vo.GoogleUserProfile;
+import com.ludo.study.studymatchingplatform.study.service.exception.DuplicatedSignUpException;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
 
@@ -32,7 +33,7 @@ public class GoogleSignUpService {
 	private void validateAlreadySignUp(final GoogleUserProfile userInfo) {
 		userRepository.findByEmail(userInfo.getEmail())
 				.ifPresent(user -> {
-					throw new IllegalArgumentException("이미 가입되어 있는 회원입니다.");
+					throw new DuplicatedSignUpException("이미 가입되어 있는 회원입니다.");
 				});
 	}
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/exception/GlobalExceptionHandler.java
@@ -47,14 +47,14 @@ public final class GlobalExceptionHandler {
 	@ExceptionHandler(value = DuplicatedSignUpException.class)
 	public ResponseEntity<CommonResponse> duplicatedSignUp(DuplicatedSignUpException e,
 														   HttpServletResponse response) throws IOException {
-		response.sendRedirect("https://ludoapi.store");
+		response.sendRedirect("https://ludoapi.store/signup/fail");
 		return toResponseEntity(e, HttpStatus.CONFLICT);
 	}
 
 	@ExceptionHandler(value = NotFoundException.class)
 	public ResponseEntity<CommonResponse> noSignUpInformation(NotFoundException e,
 															  HttpServletResponse response) throws IOException {
-		response.sendRedirect("https://ludoapi.store");
+		response.sendRedirect("https://ludoapi.store/login/fail");
 		return toResponseEntity(e, HttpStatus.NOT_FOUND);
 	}
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/config/DataInitializer.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/config/DataInitializer.java
@@ -7,7 +7,6 @@ import com.ludo.study.studymatchingplatform.study.domain.study.category.Category
 import com.ludo.study.studymatchingplatform.study.repository.recruitment.position.PositionRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.repository.study.category.CategoryRepositoryImpl;
 
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -17,7 +16,7 @@ public class DataInitializer {
 	private final CategoryRepositoryImpl categoryRepository;
 	private final PositionRepositoryImpl positionsRepository;
 
-	@PostConstruct
+	// @PostConstruct
 	public void init() {
 		initCategories();
 		initPositions();

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/repository/recruitment/applicant/ApplicantRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/repository/recruitment/applicant/ApplicantRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 
 import com.ludo.study.studymatchingplatform.study.domain.id.ApplicantId;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.applicant.Applicant;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.applicant.ApplicantStatus;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -44,6 +45,7 @@ public class ApplicantRepositoryImpl {
 	public List<Applicant> findStudyApplicantInfoByRecruitmentId(final Long id) {
 		return q.selectFrom(applicant)
 				.where(applicant.recruitment.id.eq(id))
+				.where(applicant.applicantStatus.ne(ApplicantStatus.REFUSED))
 				.where(applicant.deletedDateTime.isNull())
 				.fetch();
 	}


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- [refactor: 구글 로그인 / 회원가입 예외 전역 처리](https://github.com/Ludo-SMP/ludo-backend/commit/4287cf556662d5be165244ec78c952d6555cde99)
- [refactor: 로그인 / 회원가입 예외 페이지 리다이렉션 적용](https://github.com/Ludo-SMP/ludo-backend/commit/deff464dfef150f09de902a619e576afcfea2430)
- [refactor: 스터디 지원자 거절시 목록에서 제거 로직 추가](https://github.com/Ludo-SMP/ludo-backend/commit/dfe922de639cce943e7a51a70d34683b6275a6d4)
- [refactor: DataInitializer, 주석 처리](https://github.com/Ludo-SMP/ludo-backend/pull/98/commits/2f9c40a8e4aa551ca8d9fc1b296c62beb38726ae)

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- **구글 로그인 / 회원가입 예외시 전역처리 하도록 변경했습니다.**
<img width="704" alt="스크린샷 2024-03-26 오후 3 21 05" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/716bfa58-48ae-4b8d-bb22-bed616796dd7">
<img width="710" alt="스크린샷 2024-03-26 오후 3 22 07" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/fcbed090-01cb-4c25-8518-480ee08d2a45">

<br><br>

- **로그인 / 회원가입 예외 페이지 리다이렉션을 적용했습니다.**
<img width="842" alt="스크린샷 2024-03-26 오후 3 20 30" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/bb2696ea-9284-47b9-961b-56f763241970">

<br><br>

- **지원자 거절시 목록에서 지워주도록 하는 로직을 추가했습니다.**
<img width="639" alt="스크린샷 2024-03-26 오후 3 19 36" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/cc7e30a8-013c-42fe-bf6d-8b584efbfba1">

<br><br>

- **DataInitializer클래스가 동작하지 않도록 주석 처리 했습니다.**
<img width="631" alt="스크린샷 2024-03-26 오후 3 41 38" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/d8a1c41f-fbf2-4bd5-9f23-daa6b3ebeea1">


### ✅ 셀프 체크리스트

- [X] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [X] 커밋 메세지를 컨벤션에 맞추었습니다.
- [X] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [X] 변경 후 코드는 기존의 테스트를 통과합니다.
- [X] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [X] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
