### PR TITLE
SP-210/Fix: `모집 공고 상세 조회`, `스터디 지원`시 모집 공고 목록 조회 순서가 바뀌는 이슈 해결

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/recruitment/Recruitment.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/recruitment/Recruitment.java
@@ -74,6 +74,9 @@ public class Recruitment extends BaseEntity {
 	@Builder.Default
 	private List<RecruitmentPosition> recruitmentPositions = new ArrayList<>();
 
+	@Builder.Default
+	private LocalDateTime modifiedDateTime = LocalDateTime.now();
+
 	// contact 추가 (연결 방법)
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false, columnDefinition = "char(20)")
@@ -194,6 +197,9 @@ public class Recruitment extends BaseEntity {
 		}
 		if (content != null) {
 			this.content = content;
+		}
+		if (modifiedDateTime != null) {
+			this.modifiedDateTime = LocalDateTime.now();
 		}
 	}
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/repository/recruitment/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/repository/recruitment/RecruitmentRepositoryImpl.java
@@ -107,7 +107,7 @@ public class RecruitmentRepositoryImpl {
 						eqPosition(recruitmentFindCond.positionId()),
 						eqStack(recruitmentFindCond.stackIds()))
 				.where(lessThan(recruitmentFindCursor.last()))
-				.orderBy(recruitment.updatedDateTime.desc())
+				.orderBy(recruitment.modifiedDateTime.desc())
 				.limit(recruitmentFindCursor.count())
 				.fetch();
 

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentsFindServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentsFindServiceTest.java
@@ -15,11 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.RecruitmentStack;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.StackCategory;
-import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
 import com.ludo.study.studymatchingplatform.study.domain.study.Platform;
 import com.ludo.study.studymatchingplatform.study.domain.study.Study;
 import com.ludo.study.studymatchingplatform.study.domain.study.StudyStatus;
 import com.ludo.study.studymatchingplatform.study.domain.study.Way;
+import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
 import com.ludo.study.studymatchingplatform.study.fixture.recruitment.RecruitmentFixture;
 import com.ludo.study.studymatchingplatform.study.fixture.recruitment.stack.RecruitmentStackFixture;
 import com.ludo.study.studymatchingplatform.study.fixture.recruitment.stack.StackCategoryFixture;
@@ -39,6 +39,8 @@ import com.ludo.study.studymatchingplatform.user.domain.user.Social;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import com.ludo.study.studymatchingplatform.user.fixture.user.UserFixture;
 import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
+
+import jakarta.persistence.EntityManager;
 
 @SpringBootTest
 class RecruitmentsFindServiceTest {
@@ -71,6 +73,9 @@ class RecruitmentsFindServiceTest {
 	@Autowired
 	StackRepositoryImpl stackRepository;
 
+	@Autowired
+	EntityManager em;
+
 	@Nested
 	@DisplayName("검색 필터 조건이 없는 경우 모집 공고 조회 테스트")
 	class RecruitmentFindNoFilterCond {
@@ -79,6 +84,8 @@ class RecruitmentsFindServiceTest {
 			User user = saveUser();
 			Category category = saveCategory();
 			saveRecruitments(category, user);
+			em.flush();
+			em.clear();
 		}
 
 		@Test


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

- [x] `모집 공고 상세 조회`, `모집 공고 지원`시 모집 공고 목록 조회에서 제일 먼저 조회되는 이슈

![모집 공고 목록 조회 이슈 용량축소](https://github.com/Ludo-SMP/ludo-backend/assets/68291395/fbaec2e1-17f7-455f-9e26-14e3c04ab4c7)


<br> <br>
## 💡 이슈를 처리하면서 추가된 코드가 있어요.
### Recruitment 엔티티에 `modifiedDateTime` 컬럼 추가
- 기존의 `updatedDateTime` 컬럼은 **변경 감지가 발생할 때 마다** 수정 날짜가 갱신되는 구조에요.
```java
@Getter
@EntityListeners(AuditingEntityListener.class)
public abstract class BaseEntity {

	@LastModifiedDate
	@Column(nullable = false)
	private LocalDateTime updatedDateTime;

        // something ..
}
```

<br> <br>
### 모집 공고 목록 조회 정렬 조건 변경 `updatedDateTime` → `modifiedDateTime` 
```java
	public List<Recruitment> findRecruitments(final RecruitmentFindCursor recruitmentFindCursor,
											  final RecruitmentFindCond recruitmentFindCond) {

		JPAQuery<Recruitment> recruitmentTable = q.select(recruitment)
				.from(recruitment);
		// 동적 조인 코드 생략
		return recruitmentTable
				.where(
						eqCategory(recruitmentFindCond.categoryId()),
						eqWay(recruitmentFindCond.way()),
						eqPosition(recruitmentFindCond.positionId()),
						eqStack(recruitmentFindCond.stackIds()))
				.where(lessThan(recruitmentFindCursor.last()))
				.orderBy(recruitment.modifiedDateTime.desc()) // 변경
				.limit(recruitmentFindCursor.count())
				.fetch();
	}
```


- 모집 공고 상세 조회는 `조회수(hit)`를 1 증가시키기 때문에 변경 감지가 발동해요.
- 모집 공고를 통한 스터디 지원도 `List<Applicant> applicants` 에 대한 변경 감지가 발동해요.
- 사실상 모집 공고에 대한 모든 변경이 일어날 때마다 `updatedDateTime` 이 갱신되고,
- 해당 컬럼 내림차순으로 조회하고 있기 때문에 발생했던 이슈에요.


<br><br>

## ✅ 셀프 체크리스트

- [o] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [o] 커밋 메세지를 컨벤션에 맞추었습니다.
- [o] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [o] 변경 후 코드는 기존의 테스트를 통과합니다.
- [o] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [o] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
