### PR TITLE
Fix: 모집공고 수정날짜가 생성날짜보다 이전 날짜로 기록되는 문제 해결

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/recruitment/Recruitment.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/recruitment/Recruitment.java
@@ -9,6 +9,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import org.springframework.data.annotation.CreatedDate;
+
 import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
 import com.ludo.study.studymatchingplatform.study.domain.id.ApplicantId;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.applicant.Applicant;
@@ -49,7 +51,7 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 // @SQLDelete(sql = "UPDATE recruitment SET deleted_date_time = NOW() WHERE recruitment_id = ?")
 // @SQLRestriction("deleted_date_time is null")
-@ToString(of = {"id", "title"}, callSuper = true)
+@ToString(of = {"id", "title", "modifiedDateTime"}, callSuper = true)
 @Slf4j
 public class Recruitment extends BaseEntity {
 
@@ -74,8 +76,9 @@ public class Recruitment extends BaseEntity {
 	@Builder.Default
 	private List<RecruitmentPosition> recruitmentPositions = new ArrayList<>();
 
-	@Builder.Default
-	private LocalDateTime modifiedDateTime = LocalDateTime.now();
+	@CreatedDate
+	@Column(nullable = false)
+	private LocalDateTime modifiedDateTime;
 
 	// contact 추가 (연결 방법)
 	@Enumerated(EnumType.STRING)


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

- [x] 모집공고 수정날짜가 생성날짜보다 이전 날짜로 기록되는 문제

<br><br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.
### `Recruitment` 엔티티의 `modifiedDateTime` 초기화 로직을 변경했습니다.

`기존`
```java
@Entity
public class Recruitment extends BaseEntity {
	@Builder.Default
	private LocalDateTime modifiedDateTime = LocalDateTime.now();
}
```
`변경후`
```java
@Entity
public class Recruitment extends BaseEntity {
	@CreatedDate
	@Column(nullable = false)
	private LocalDateTime modifiedDateTime;
}
```
**문제상황**
기존 로직에서는 아래와 같이 `수정날짜(modifiedDateTime)`이 `생성날짜(createdDateTime)` 보다 이전인 예외가 발생합니다.
<img width="431" alt="스크린샷 2024-03-28 오후 9 50 05" src="https://github.com/Ludo-SMP/ludo-backend/assets/68291395/8dfda1b7-639b-4a88-b784-5591404e8767">


**이유**
- `수정날짜(modifiedDateTime)`는 객체를 생성하는 시점에 초기화됩니다.
- `생성날짜(createdDateTime)`는 JPA Auditing에 의해 객체를 `insert` 하는 시점에 초기화됩니다.
- 따라서 수정날짜가 생성날짜보다 ms 단위로 앞서게 됩니다.

**해결**
- `수정날짜(modifiedDateTime)`에도 JPA Auditing 기능을 이용하여 @CreatedDate 를 적용했습니다.
- 이전 회의에서 적용이 안될 것으로 예측했지만, Recruitment 는 BaseEntity를 상속받고 있고 그에 따라 **@EntityListeners(AuditingEntityListener.class) 애노테이션도 함께 상속**받으므로 적용이 가능합니다.


<br><br>

### ✅ 셀프 체크리스트

- [o] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [o] 커밋 메세지를 컨벤션에 맞추었습니다.
- [o] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [o] 변경 후 코드는 기존의 테스트를 통과합니다.
- [o] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [o] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
