### PR TITLE
Fix: @PostConstructor 데이터 삽입 로직 제거에 따른 테스트 실패 해결

### DIFF
--- a/src/test/java/com/ludo/study/studymatchingplatform/config/DbInitializer.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/config/DbInitializer.java
@@ -1,18 +1,69 @@
 package com.ludo.study.studymatchingplatform.config;
 
-import javax.sql.DataSource;
+import org.springframework.stereotype.Component;
 
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.jdbc.datasource.init.DataSourceInitializer;
-import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
+import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
+import com.ludo.study.studymatchingplatform.study.repository.recruitment.position.PositionRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.study.category.CategoryRepositoryImpl;
 
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
 public class DbInitializer {
 
-	public DataSourceInitializer dataSourceInitializer(DataSource dataSource) {
-		DataSourceInitializer initializer = new DataSourceInitializer();
-		initializer.setDataSource(dataSource);
-		initializer.setDatabasePopulator(new ResourceDatabasePopulator(new ClassPathResource("/data.sql")));
-		return initializer;
+	private final CategoryRepositoryImpl categoryRepository;
+	private final PositionRepositoryImpl positionsRepository;
+
+	@PostConstruct
+	public void init() {
+		initCategories();
+		initPositions();
+	}
+
+	private void initCategories() {
+		saveCategories(
+				Category.builder()
+						.name("프로젝트")
+						.build(),
+				Category.builder()
+						.name("코딩 테스트")
+						.build(),
+				Category.builder()
+						.name("모의 면접")
+						.build()
+		);
+	}
+
+	private void saveCategories(Category... categories) {
+		for (Category category : categories) {
+			categoryRepository.save(category);
+		}
+	}
+
+	private void initPositions() {
+		savePositions(
+				Position.builder()
+						.name("백엔드")
+						.build(),
+				Position.builder()
+						.name("프론트엔드")
+						.build(),
+				Position.builder()
+						.name("디자이너")
+						.build(),
+				Position.builder()
+						.name("데브옵스")
+						.build()
+		);
+	}
+
+	private void savePositions(Position... positions) {
+		for (Position position : positions) {
+			positionsRepository.save(position);
+		}
 	}
 
 }

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/service/recruitment/PopularRecruitmentsFindServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/service/recruitment/PopularRecruitmentsFindServiceTest.java
@@ -11,18 +11,17 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
-import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
 import com.ludo.study.studymatchingplatform.study.domain.study.Platform;
 import com.ludo.study.studymatchingplatform.study.domain.study.Study;
 import com.ludo.study.studymatchingplatform.study.domain.study.StudyStatus;
 import com.ludo.study.studymatchingplatform.study.domain.study.Way;
+import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
 import com.ludo.study.studymatchingplatform.study.fixture.recruitment.RecruitmentFixture;
 import com.ludo.study.studymatchingplatform.study.fixture.study.StudyFixture;
 import com.ludo.study.studymatchingplatform.study.repository.dto.request.PopularRecruitmentCond;
 import com.ludo.study.studymatchingplatform.study.repository.recruitment.RecruitmentRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.repository.study.StudyRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.repository.study.category.CategoryRepositoryImpl;
-import com.ludo.study.studymatchingplatform.study.service.dto.mapper.RecruitmentPreviewResponseMapper;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.recruitment.PopularRecruitmentsResponse;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.recruitment.RecruitmentPreviewResponse;
 import com.ludo.study.studymatchingplatform.user.domain.user.Social;
@@ -49,14 +48,11 @@ class PopularRecruitmentsFindServiceTest {
 	@Autowired
 	CategoryRepositoryImpl categoryRepository;
 
-	@Autowired
-	RecruitmentPreviewResponseMapper recruitmentPreviewResponseMapper;
-
 	@BeforeEach
 	void init() {
 		User user = UserFixture.createUser(Social.GOOGLE, "아카", "hihi@google.com");
 		Category project = categoryRepository.findByName("프로젝트").get();
-		Category algorithm = categoryRepository.findByName("코딩 테스트").get();
+		Category codingTest = categoryRepository.findByName("코딩 테스트").get();
 		Category interview = categoryRepository.findByName("모의 면접").get();
 
 		userRepository.save(user);
@@ -69,9 +65,9 @@ class PopularRecruitmentsFindServiceTest {
 				Platform.GATHER);
 		Study studyD = StudyFixture.createStudy(StudyStatus.RECRUITING, "스터디D", Way.ONLINE, project, user, 5, 5,
 				Platform.GATHER);
-		Study studyE = StudyFixture.createStudy(StudyStatus.RECRUITING, "스터디E", Way.ONLINE, algorithm, user, 5, 5,
+		Study studyE = StudyFixture.createStudy(StudyStatus.RECRUITING, "스터디E", Way.ONLINE, codingTest, user, 5, 5,
 				Platform.GATHER);
-		Study studyF = StudyFixture.createStudy(StudyStatus.RECRUITING, "스터디F", Way.ONLINE, algorithm, user, 5, 5,
+		Study studyF = StudyFixture.createStudy(StudyStatus.RECRUITING, "스터디F", Way.ONLINE, codingTest, user, 5, 5,
 				Platform.GATHER);
 		Study studyG = StudyFixture.createStudy(StudyStatus.RECRUITING, "스터디G", Way.ONLINE, interview, user, 5, 5,
 				Platform.GATHER);
@@ -123,6 +119,7 @@ class PopularRecruitmentsFindServiceTest {
 	}
 
 	@Test
+	@Transactional
 	void 인기있는_코딩테스트_모집공고_조회() {
 		PopularRecruitmentCond request = new PopularRecruitmentCond(6);
 		PopularRecruitmentsResponse result = popularRecruitmentsFindService.findPopularRecruitments(request);


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

- @PostConstructor 데이터 삽입 로직 제거에 따른 테스트 실패 해결

<br><br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.
### @PostContructor + 카테고리, 포지션 데이터 삽입 로직을 테스트에 추가
```java
// src/test/java/com/ludo/study/studymatchingplatform/config
@Component
@RequiredArgsConstructor
public class DbInitializer {

	private final CategoryRepositoryImpl categoryRepository;
	private final PositionRepositoryImpl positionsRepository;

	@PostConstruct
	public void init() {
		initCategories();
		initPositions();
	}

	private void initCategories() {
		saveCategories(
				Category.builder()
						.name("프로젝트")
						.build(),
				Category.builder()
						.name("코딩 테스트")
						.build(),
				Category.builder()
						.name("모의 면접")
						.build()
		);
	}

	private void saveCategories(Category... categories) {
		for (Category category : categories) {
			categoryRepository.save(category);
		}
	}

	private void initPositions() {
		savePositions(
				Position.builder()
						.name("백엔드")
						.build(),
				Position.builder()
						.name("프론트엔드")
						.build(),
				Position.builder()
						.name("디자이너")
						.build(),
				Position.builder()
						.name("데브옵스")
						.build()
		);
	}

	private void savePositions(Position... positions) {
		for (Position position : positions) {
			positionsRepository.save(position);
		}
	}

}

```

<br><br>

### ✅ 셀프 체크리스트

- [o] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [o] 커밋 메세지를 컨벤션에 맞추었습니다.
- [o] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [o] 변경 후 코드는 기존의 테스트를 통과합니다.
- [o] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [o] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
