### PR TITLE
Sp-384/Refactor: 지원자 거절시 재지원 불가 / 스웨거 정상화

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/common/advice/CommonResponseAdvice.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/advice/CommonResponseAdvice.java
@@ -33,13 +33,17 @@ public final class CommonResponseAdvice implements ResponseBodyAdvice<Object> {
 								  final MediaType selectedContentType,
 								  final Class<? extends HttpMessageConverter<?>> selectedConverterType,
 								  final ServerHttpRequest request, final ServerHttpResponse response) {
-		if (hasError(body) || isStatic(request) || isLocation(response)) {
+		if (hasError(body) || isStatic(request) || isLocation(response) || isApiDocs(request)) {
 			return body;
 		}
 		final DataFieldName annotation = returnType.getMethodAnnotation(DataFieldName.class);
 		body = (annotation != null) ? CommonResponse.success(annotation.value(), body) :
 				CommonResponse.success(body);
 		return body;
+	}
+
+	private boolean isApiDocs(final ServerHttpRequest request) {
+		return request.getURI().getPath().startsWith("/v3/api-docs");
 	}
 
 	private boolean isStatic(final ServerHttpRequest request) {

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentService.java
@@ -119,7 +119,7 @@ public class RecruitmentService {
 		} else {
 			final Applicant reapplicant = applicant.get();
 			reapplicant.ensureApplicable();
-			reapplicant.reapply();
+			// reapplicant.reapply();
 
 			return reapplicant;
 		}

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/RecruitmentFixture.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/RecruitmentFixture.java
@@ -40,6 +40,7 @@ public class RecruitmentFixture {
 				.title(title)
 				.hits(0)
 				.recruitmentEndDateTime(endDateTime)
+				.modifiedDateTime(LocalDateTime.now())
 				.build();
 	}
 

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentServiceTest.java
@@ -37,6 +37,8 @@ import com.ludo.study.studymatchingplatform.study.repository.study.category.Cate
 import com.ludo.study.studymatchingplatform.study.service.dto.request.recruitment.EditRecruitmentRequest;
 import com.ludo.study.studymatchingplatform.study.service.dto.request.recruitment.WriteRecruitmentRequest;
 import com.ludo.study.studymatchingplatform.study.service.dto.request.recruitment.applicant.ApplyRecruitmentRequest;
+import com.ludo.study.studymatchingplatform.study.service.dto.request.recruitment.applicant.StudyApplicantDecisionRequest;
+import com.ludo.study.studymatchingplatform.study.service.recruitment.applicant.StudyApplicantDecisionService;
 import com.ludo.study.studymatchingplatform.user.domain.user.Social;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
@@ -70,6 +72,9 @@ class RecruitmentServiceTest {
 
 	@Autowired
 	private RecruitmentService recruitmentService;
+
+	@Autowired
+	private StudyApplicantDecisionService studyApplicantDecisionService;
 
 	@Autowired
 	private EntityManager em;
@@ -1026,6 +1031,65 @@ class RecruitmentServiceTest {
 
 		// then
 		assertThat(recruitment.getModifiedDateTime()).isAfterOrEqualTo(recruitment.getCreatedDateTime());
+	}
+
+	@DisplayName("[Exception] 사용자는 거절된 모집 공고는 재지원 할 수 없다.")
+	@Test
+	void possibleToReapplyIfAlreadyRejected() {
+
+		// given
+		final User owner = userRepository.save(
+				User.builder()
+						.nickname("owner")
+						.email("a@aa.aa")
+						.social(Social.KAKAO)
+						.build()
+		);
+		final User applier = userRepository.save(
+				User.builder()
+						.nickname("applier")
+						.email("b@bb.bb")
+						.social(Social.KAKAO)
+						.build()
+		);
+		final Category category = categoryRepository.save(
+
+				CategoryFixture.createCategory("category1"));
+
+		final Study study = studyRepository.save(
+				StudyFixture.createStudy(
+						"study",
+						category,
+						owner,
+						4,
+						Platform.GATHER
+				)
+		);
+		final Recruitment recruitment = recruitmentRepository.save(
+				RecruitmentFixture.createRecruitmentWithoutStacksAndPositions(
+						study,
+						"recruitment",
+						"content",
+						"callUrl",
+						LocalDateTime.now().plusDays(5)
+				)
+		);
+		study.registerRecruitment(recruitment);
+
+		final ApplyRecruitmentRequest request = createRequest();
+
+		final Applicant applicant = recruitmentService.apply(applier, recruitment.getId(), request);
+
+		final StudyApplicantDecisionRequest applicantDecisionRequest =
+				new StudyApplicantDecisionRequest(study.getId(), applier.getId());
+
+		// when
+		studyApplicantDecisionService.applicantReject(owner, applicantDecisionRequest);
+
+		// then
+		assertThatThrownBy(applicant::ensureApplicable)
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("이미 거절된 모집 공고입니다.");
 	}
 
 	private void assertModifiedDateChange(Recruitment findRecruitment, Recruitment recruitment) {

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -15,7 +15,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
 
     properties:
       hibernate:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -15,7 +15,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
 
     properties:
       hibernate:


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 스터디 지원자 거절시 재지원 불가 하도록 수정했습니다.
- 스웨거 정상적으로 작동하도록 수정했습니다.

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.
- **지원자 거절시 재지원 불가**
스터디 지원시 존재하는 기록이 있을 경우 상태를 기준으로 예외를 반환하도록 하여 이슈를 해결했습니다. 

<img width="838" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/b38d517c-146a-4a64-b590-3836a68f8d97">
<img width="756" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/03d59d5c-3645-4375-aa0f-ff9cc7c912c7">

<br><br>

- **스웨거 정상화**
이슈의 원인은 swagger-ui 요청 body가 `CommonResponse`에 담기는 것 이었습니다. 
요청 URL은 `/v3/api-docs`였으며, 해당 URL을 `CommonResponseAdvice`의 검증 항목에서 제외하도록 하여 이슈를 해결했습니다.

<img width="1714" alt="스크린샷 2024-04-02 오전 9 40 29" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/eaa9dd6a-a4f2-441d-ad86-79aa001fea55">
<img width="814" alt="스크린샷 2024-04-02 오전 9 41 02" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/57298144-7f56-4d93-b912-c5460db32345">

<br><br>

### ✅ 셀프 체크리스트

- [X] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [X] 커밋 메세지를 컨벤션에 맞추었습니다.
- [X] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [X] 변경 후 코드는 기존의 테스트를 통과합니다.
- [X] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [X] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.