### PR TITLE
Sp-389/Feat: Redis에서 동작하는 토큰 리프레시 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,12 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.7'
+
+    // redis
+    // Client 구현체는 크게 Lettuce, Jedis가 있는데, Lettuce로 구현 했습니다.
+    // 이유는 별도의 의존성 설정 없이 사용할 수 있기 때문이고,
+    // Jedis에 비해 더 높은 성능과 상세한 문서를 제공하기 때문입니다.
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/common/provider/CookieProvider.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/common/provider/CookieProvider.java
@@ -58,7 +58,7 @@ public final class CookieProvider {
 		cookie.setPath("/");
 		cookie.setHttpOnly(true);
 		cookie.setSecure(clientProperties.isSecure());
-		cookie.setAttribute("SameSite", "None");
+		cookie.setAttribute("SameSite", "Strict");
 		cookie.setMaxAge(maxAge);
 
 		return cookie;

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/common/provider/JwtTokenProvider.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/common/provider/JwtTokenProvider.java
@@ -21,8 +21,6 @@ import lombok.Getter;
 @Component
 public class JwtTokenProvider {
 
-	private static final String TYPE_CLAIM_KEY = "type";
-
 	@Value("${jwt.token.secret-key}")
 	private String secretKey;
 
@@ -32,7 +30,6 @@ public class JwtTokenProvider {
 
 	public String createAccessToken(final AuthUserPayload payload) {
 		final Claims claims = createClaims(payload);
-		claims.put(TYPE_CLAIM_KEY, "Access");
 		return createToken(accessTokenExpiresIn, claims);
 	}
 
@@ -62,10 +59,6 @@ public class JwtTokenProvider {
 		byte[] secretKeyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
 		return Keys.hmacShaKeyFor(secretKeyBytes);
 	}
-
-	// public void isValidTokenOrThrows(final String token) {
-	// 	verifyAuthTokenOrThrow(token);
-	// }
 
 	public Claims verifyAuthTokenOrThrow(final String token) {
 		try {

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/common/provider/JwtTokenProvider.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/common/provider/JwtTokenProvider.java
@@ -16,21 +16,30 @@ import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
 
 @Component
 public class JwtTokenProvider {
 
+	private static final String TYPE_CLAIM_KEY = "type";
+
 	@Value("${jwt.token.secret-key}")
 	private String secretKey;
 
+	@Getter
 	@Value("${jwt.token.access-token-expiresin}")
 	private String accessTokenExpiresIn;
 
 	public String createAccessToken(final AuthUserPayload payload) {
 		final Claims claims = createClaims(payload);
-		final Date expiresIn = createExpiresIn();
-		final Key signingKey = createSigningKey();
+		claims.put(TYPE_CLAIM_KEY, "Access");
+		return createToken(accessTokenExpiresIn, claims);
+	}
 
+	private String createToken(final String tokenValidityInSeconds, final Claims claims) {
+		final Long tokenValidity = Long.parseLong(tokenValidityInSeconds);
+		final Date expiresIn = createExpiresIn(tokenValidity);
+		final Key signingKey = createSigningKey();
 		return Jwts.builder()
 				.setClaims(claims)
 				.setExpiration(expiresIn)
@@ -44,9 +53,9 @@ public class JwtTokenProvider {
 		return claims;
 	}
 
-	private Date createExpiresIn() {
-		long currentDateTime = new Date().getTime();
-		return new Date(currentDateTime + Long.parseLong(accessTokenExpiresIn));
+	private Date createExpiresIn(final Long tokenValidityInSeconds) {
+		final Long currentDateTime = new Date().getTime();
+		return new Date(currentDateTime + tokenValidityInSeconds);
 	}
 
 	private Key createSigningKey() {
@@ -54,13 +63,9 @@ public class JwtTokenProvider {
 		return Keys.hmacShaKeyFor(secretKeyBytes);
 	}
 
-	public String getAccessTokenExpiresIn() {
-		return accessTokenExpiresIn;
-	}
-
-	public void isValidTokenOrThrows(final String token) {
-		verifyAuthTokenOrThrow(token);
-	}
+	// public void isValidTokenOrThrows(final String token) {
+	// 	verifyAuthTokenOrThrow(token);
+	// }
 
 	public Claims verifyAuthTokenOrThrow(final String token) {
 		try {

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/common/redis/UserDetails.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/common/redis/UserDetails.java
@@ -1,0 +1,32 @@
+package com.ludo.study.studymatchingplatform.auth.common.redis;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@RedisHash(value = "user_details")
+public class UserDetails {
+
+	@Id
+	private Long userId;
+
+	private String userAgent;
+
+	private String clientIp;
+
+	@TimeToLive
+	private Long ttl;
+
+	public void update(final Long ttl) {
+		this.ttl = ttl;
+	}
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/common/service/UserDetailsService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/common/service/UserDetailsService.java
@@ -1,0 +1,43 @@
+package com.ludo.study.studymatchingplatform.auth.common.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.ludo.study.studymatchingplatform.auth.common.redis.UserDetails;
+import com.ludo.study.studymatchingplatform.auth.common.util.WebUtils;
+import com.ludo.study.studymatchingplatform.auth.repository.UserDetailsRepository;
+import com.ludo.study.studymatchingplatform.study.service.exception.AuthenticationException;
+import com.ludo.study.studymatchingplatform.study.service.exception.NotFoundException;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsService {
+
+	@Value("${jwt.token.refresh-token-expiresin}")
+	private String refreshExpiresIn;
+
+	private final UserDetailsRepository userDetailsRepository;
+
+	public void createUserDetails(final User user, final HttpServletRequest request) {
+		final String userAgent = WebUtils.getUserAgent(request);
+		final String clientIp = WebUtils.getClientIp(request);
+		final UserDetails userDetails =
+				new UserDetails(user.getId(), userAgent, clientIp, Long.parseLong(refreshExpiresIn));
+		userDetailsRepository.save(userDetails);
+	}
+
+	public void verifyUserDetails(final Long userId, final HttpServletRequest request) {
+		final String userAgent = WebUtils.getUserAgent(request);
+		final String clientIp = WebUtils.getClientIp(request);
+		final UserDetails userDetails = userDetailsRepository.findById(userId)
+				.orElseThrow(() -> new NotFoundException("만료된 사용자 정보 입니다."));
+		if (!userDetails.getUserAgent().equals(userAgent) || !userDetails.getClientIp().equals(clientIp)) {
+			throw new AuthenticationException("검증되지 않은 사용자 입니다.");
+		}
+	}
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/common/util/Headers.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/common/util/Headers.java
@@ -1,0 +1,31 @@
+package com.ludo.study.studymatchingplatform.auth.common.util;
+
+public enum Headers {
+
+	USER_AGENT("User-Agent"),
+	X_FORWARDED_FOR("X-Forwarded-For"),
+	X_REAL_IP("x-real-ip"),
+	X_ORIGINAL_FORWARDED_FOR("x-original-forwarded-for"),
+	PROXY_CLIENT_IP("Proxy-Client-IP"),
+	WL_PROXY_CLIENT_IP("WL-Proxy-Client-IP"),
+	HTTP_X_FORWARDED_FOR("HTTP_X_FORWARDED_FOR"),
+	HTTP_X_FORWARDED("HTTP_X_FORWARDED"),
+	HTTP_X_CLUSTER_CLIENT_IP("HTTP_X_CLUSTER_CLIENT_IP"),
+	HTTP_CLIENT_IP("HTTP_CLIENT_IP"),
+	HTTP_FORWARDED_FOR("HTTP_FORWARDED_FOR"),
+	HTTP_FORWARDED("HTTP_FORWARDED"),
+	HTTP_VIA("HTTP_VIA"),
+	REMOTE_ADDR("REMOTE_ADDR"),
+	UNKNOWN("unknown");
+
+	private final String header;
+
+	Headers(final String header) {
+		this.header = header;
+	}
+
+	public String getHeader() {
+		return header;
+	}
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/common/util/WebUtils.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/common/util/WebUtils.java
@@ -4,51 +4,61 @@ import jakarta.servlet.http.HttpServletRequest;
 
 public class WebUtils {
 
-	public static String getUserAgent(HttpServletRequest request) {
-		return request.getHeader("User-Agent");
+	private static String getHeader(final Headers headers, final HttpServletRequest request) {
+		final String header = headers.getHeader();
+		return request.getHeader(header);
 	}
 
-	public static String getClientIp(HttpServletRequest request) {
+	private static String getUnknown(final Headers headers) {
+		return headers.getHeader();
+	}
 
-		String ip = request.getHeader("X-Forwarded-For");
+	public static String getUserAgent(final HttpServletRequest request) {
+		return getHeader(Headers.USER_AGENT, request);
+	}
 
-		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
-			ip = request.getHeader("x-real-ip");
+	public static String getClientIp(final HttpServletRequest request) {
+
+		String ip = getHeader(Headers.X_FORWARDED_FOR, request);
+		final String unknown = getUnknown(Headers.UNKNOWN);
+
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase(unknown)) {
+			ip = getHeader(Headers.X_REAL_IP, request);
 		}
-		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
-			ip = request.getHeader("x-original-forwarded-for");
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase(unknown)) {
+			ip = getHeader(Headers.X_ORIGINAL_FORWARDED_FOR, request);
 		}
-		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
-			ip = request.getHeader("Proxy-Client-IP");
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase(unknown)) {
+			ip = getHeader(Headers.PROXY_CLIENT_IP, request);
 		}
-		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
-			ip = request.getHeader("WL-Proxy-Client-IP");
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase(unknown)) {
+			ip = getHeader(Headers.WL_PROXY_CLIENT_IP, request);
 		}
-		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
-			ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase(unknown)) {
+			ip = getHeader(Headers.HTTP_X_FORWARDED_FOR, request);
 		}
-		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
-			ip = request.getHeader("HTTP_X_FORWARDED");
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase(unknown)) {
+			ip = getHeader(Headers.HTTP_X_FORWARDED, request);
 		}
-		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
-			ip = request.getHeader("HTTP_X_CLUSTER_CLIENT_IP");
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase(unknown)) {
+			ip = getHeader(Headers.HTTP_X_CLUSTER_CLIENT_IP, request);
 		}
-		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
-			ip = request.getHeader("HTTP_CLIENT_IP");
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase(unknown)) {
+			ip = getHeader(Headers.HTTP_CLIENT_IP, request);
 		}
-		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
-			ip = request.getHeader("HTTP_FORWARDED_FOR");
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase(unknown)) {
+			ip = getHeader(Headers.HTTP_FORWARDED_FOR, request);
 		}
-		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
-			ip = request.getHeader("HTTP_FORWARDED");
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase(unknown)) {
+			ip = getHeader(Headers.HTTP_FORWARDED, request);
 		}
-		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
-			ip = request.getHeader("HTTP_VIA");
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase(unknown)) {
+			ip = getHeader(Headers.HTTP_VIA, request);
 		}
-		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
-			ip = request.getHeader("REMOTE_ADDR");
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase(unknown)) {
+			ip = getHeader(Headers.REMOTE_ADDR, request);
 		}
-		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase(unknown)) {
 			ip = request.getRemoteAddr();
 		}
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/common/util/WebUtils.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/common/util/WebUtils.java
@@ -1,0 +1,58 @@
+package com.ludo.study.studymatchingplatform.auth.common.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class WebUtils {
+
+	public static String getUserAgent(HttpServletRequest request) {
+		return request.getHeader("User-Agent");
+	}
+
+	public static String getClientIp(HttpServletRequest request) {
+
+		String ip = request.getHeader("X-Forwarded-For");
+
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
+			ip = request.getHeader("x-real-ip");
+		}
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
+			ip = request.getHeader("x-original-forwarded-for");
+		}
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
+			ip = request.getHeader("Proxy-Client-IP");
+		}
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
+			ip = request.getHeader("WL-Proxy-Client-IP");
+		}
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
+			ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+		}
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
+			ip = request.getHeader("HTTP_X_FORWARDED");
+		}
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
+			ip = request.getHeader("HTTP_X_CLUSTER_CLIENT_IP");
+		}
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
+			ip = request.getHeader("HTTP_CLIENT_IP");
+		}
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
+			ip = request.getHeader("HTTP_FORWARDED_FOR");
+		}
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
+			ip = request.getHeader("HTTP_FORWARDED");
+		}
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
+			ip = request.getHeader("HTTP_VIA");
+		}
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
+			ip = request.getHeader("REMOTE_ADDR");
+		}
+		if (ip == null || ip.length() == 0 || ip.equalsIgnoreCase("unknown")) {
+			ip = request.getRemoteAddr();
+		}
+
+		return ip;
+	}
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/kakao/KakaoLoginController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/kakao/KakaoLoginController.java
@@ -13,12 +13,14 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import com.ludo.study.studymatchingplatform.auth.common.AuthUserPayload;
 import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
 import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
+import com.ludo.study.studymatchingplatform.auth.common.service.UserDetailsService;
 import com.ludo.study.studymatchingplatform.auth.repository.InMemoryClientRegistrationAndProviderRepository;
 import com.ludo.study.studymatchingplatform.auth.service.kakao.KakaoLoginService;
 import com.ludo.study.studymatchingplatform.common.annotation.DataFieldName;
 import com.ludo.study.studymatchingplatform.user.domain.user.Social;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +35,7 @@ public class KakaoLoginController {
 	private final KakaoLoginService kakaoLoginService;
 	private final JwtTokenProvider jwtTokenProvider;
 	private final CookieProvider cookieProvider;
+	private final UserDetailsService userDetailsService;
 
 	@GetMapping("/kakao")
 	@ResponseStatus(HttpStatus.FOUND)
@@ -51,9 +54,11 @@ public class KakaoLoginController {
 	@ResponseStatus(HttpStatus.FOUND)
 	public void kakaoLoginCallback(
 			@RequestParam(name = "code") String authorizationCode,
+			final HttpServletRequest request,
 			final HttpServletResponse response) throws IOException {
 		final User user = kakaoLoginService.login(authorizationCode);
 		final String accessToken = jwtTokenProvider.createAccessToken(AuthUserPayload.from(user));
+		userDetailsService.createUserDetails(user, request);
 		cookieProvider.setAuthCookie(accessToken, response);
 		response.sendRedirect("https://ludoapi.store");
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/kakao/KakaoSignUpController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/kakao/KakaoSignUpController.java
@@ -14,12 +14,14 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import com.ludo.study.studymatchingplatform.auth.common.AuthUserPayload;
 import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
 import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
+import com.ludo.study.studymatchingplatform.auth.common.service.UserDetailsService;
 import com.ludo.study.studymatchingplatform.auth.repository.InMemoryClientRegistrationAndProviderRepository;
 import com.ludo.study.studymatchingplatform.auth.service.kakao.KakaoSignUpService;
 import com.ludo.study.studymatchingplatform.common.annotation.DataFieldName;
 import com.ludo.study.studymatchingplatform.user.domain.user.Social;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +36,7 @@ public class KakaoSignUpController {
 	private final KakaoSignUpService kakaoSignUpService;
 	private final JwtTokenProvider jwtTokenProvider;
 	private final CookieProvider cookieProvider;
+	private final UserDetailsService userDetailsService;
 
 	@GetMapping("/kakao")
 	@Transactional
@@ -53,9 +56,11 @@ public class KakaoSignUpController {
 	@GetMapping("/kakao/callback")
 	public void kakaoSignUpCallback(
 			@RequestParam(name = "code") String authorizationCode,
+			final HttpServletRequest request,
 			final HttpServletResponse response) throws IOException {
 		final User user = kakaoSignUpService.kakaoSignUp(authorizationCode);
 		final String accessToken = jwtTokenProvider.createAccessToken(AuthUserPayload.from(user));
+		userDetailsService.createUserDetails(user, request);
 		cookieProvider.setAuthCookie(accessToken, response);
 		response.sendRedirect("https://ludoapi.store");
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/naver/NaverLoginController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/naver/NaverLoginController.java
@@ -13,12 +13,14 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import com.ludo.study.studymatchingplatform.auth.common.AuthUserPayload;
 import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
 import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
+import com.ludo.study.studymatchingplatform.auth.common.service.UserDetailsService;
 import com.ludo.study.studymatchingplatform.auth.repository.InMemoryClientRegistrationAndProviderRepository;
 import com.ludo.study.studymatchingplatform.auth.service.naver.NaverLoginService;
 import com.ludo.study.studymatchingplatform.common.annotation.DataFieldName;
 import com.ludo.study.studymatchingplatform.user.domain.user.Social;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +35,7 @@ public class NaverLoginController {
 	private final NaverLoginService naverLoginService;
 	private final JwtTokenProvider jwtTokenProvider;
 	private final CookieProvider cookieProvider;
+	private final UserDetailsService userDetailsService;
 
 	@GetMapping("/naver")
 	@ResponseStatus(HttpStatus.FOUND)
@@ -53,11 +56,12 @@ public class NaverLoginController {
 	@DataFieldName("user")
 	public void naverLoginCallback(
 			@RequestParam(name = "code") final String authorizationCode,
+			final HttpServletRequest request,
 			final HttpServletResponse response) throws IOException {
 
 		final User user = naverLoginService.login(authorizationCode);
 		final String accessToken = jwtTokenProvider.createAccessToken(AuthUserPayload.from(user));
-
+		userDetailsService.createUserDetails(user, request);
 		cookieProvider.setAuthCookie(accessToken, response);
 		response.sendRedirect("https://ludoapi.store");
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/naver/NaverSignUpController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/controller/naver/NaverSignUpController.java
@@ -13,12 +13,14 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import com.ludo.study.studymatchingplatform.auth.common.AuthUserPayload;
 import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
 import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
+import com.ludo.study.studymatchingplatform.auth.common.service.UserDetailsService;
 import com.ludo.study.studymatchingplatform.auth.repository.InMemoryClientRegistrationAndProviderRepository;
 import com.ludo.study.studymatchingplatform.auth.service.naver.NaverSignUpService;
 import com.ludo.study.studymatchingplatform.common.annotation.DataFieldName;
 import com.ludo.study.studymatchingplatform.user.domain.user.Social;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +35,7 @@ public class NaverSignUpController {
 	private final NaverSignUpService naverSignUpService;
 	private final JwtTokenProvider jwtTokenProvider;
 	private final CookieProvider cookieProvider;
+	private final UserDetailsService userDetailsService;
 
 	@GetMapping("/naver")
 	@ResponseStatus(HttpStatus.FOUND)
@@ -52,11 +55,12 @@ public class NaverSignUpController {
 	@DataFieldName("user")
 	public void naverSignupCallback(
 			@RequestParam(name = "code") final String authorizationCode,
+			final HttpServletRequest request,
 			final HttpServletResponse response) throws IOException {
 
 		final User user = naverSignUpService.naverSignUp(authorizationCode);
 		final String accessToken = jwtTokenProvider.createAccessToken(AuthUserPayload.from(user));
-
+		userDetailsService.createUserDetails(user, request);
 		cookieProvider.setAuthCookie(accessToken, response);
 		response.sendRedirect("https://ludoapi.store");
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/repository/UserDetailsRepository.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/repository/UserDetailsRepository.java
@@ -1,0 +1,9 @@
+package com.ludo.study.studymatchingplatform.auth.repository;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.ludo.study.studymatchingplatform.auth.common.redis.UserDetails;
+
+public interface UserDetailsRepository extends CrudRepository<UserDetails, Long> {
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/kakao/KakaoSignUpService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/kakao/KakaoSignUpService.java
@@ -43,7 +43,7 @@ public class KakaoSignUpService {
 	}
 
 	private User sinup(KakaoUserProfileDto kakaoUserProfileDto) {
-		User user = userRepository.save(kakaoUserProfileDto.toUser());
+		final User user = userRepository.save(kakaoUserProfileDto.toUser());
 		user.setInitialDefaultNickname();
 		return user;
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/common/advice/CommonResponseAdvice.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/advice/CommonResponseAdvice.java
@@ -33,13 +33,17 @@ public final class CommonResponseAdvice implements ResponseBodyAdvice<Object> {
 								  final MediaType selectedContentType,
 								  final Class<? extends HttpMessageConverter<?>> selectedConverterType,
 								  final ServerHttpRequest request, final ServerHttpResponse response) {
-		if (hasError(body) || isStatic(request) || isLocation(response)) {
+		if (hasError(body) || isStatic(request) || isLocation(response) || isApiDocs(request)) {
 			return body;
 		}
 		final DataFieldName annotation = returnType.getMethodAnnotation(DataFieldName.class);
 		body = (annotation != null) ? CommonResponse.success(annotation.value(), body) :
 				CommonResponse.success(body);
 		return body;
+	}
+
+	private boolean isApiDocs(final ServerHttpRequest request) {
+		return request.getURI().getPath().startsWith("/v3/api-docs");
 	}
 
 	private boolean isStatic(final ServerHttpRequest request) {

--- a/src/main/java/com/ludo/study/studymatchingplatform/common/properties/ClientProperties.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/properties/ClientProperties.java
@@ -14,8 +14,6 @@ public class ClientProperties {
 
 	private final String domain;
 
-	private final int port;
-
 	private final String url;
 
 	public boolean isSecure() {

--- a/src/main/java/com/ludo/study/studymatchingplatform/config/RedisConfig.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/config/RedisConfig.java
@@ -16,13 +16,17 @@ public class RedisConfig {
 	private String host;
 
 	@Value("${spring.data.redis.port}")
-	private int port;
+	private Integer port;
+
+	@Value("${spring.data.redis.password}")
+	private String password;
 
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
 		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
 		config.setHostName(host);
 		config.setPort(port);
+		config.setPassword(password);
 		return new LettuceConnectionFactory(config);
 	}
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/config/RedisConfig.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/config/RedisConfig.java
@@ -1,0 +1,40 @@
+package com.ludo.study.studymatchingplatform.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+		config.setHostName(host);
+		config.setPort(port);
+		return new LettuceConnectionFactory(config);
+	}
+
+	@Bean
+	public RedisTemplate<String, String> redisTemplate() {
+		// redisTemplate 을 받아와서 set, get, delete 를 사용
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+		// setKeySerializer, setValueSerializer 설정
+		// redis-cli 을 통해 직접 데이터 조회 시 알아볼 수 없는 형태로 출력되는 것을 방지
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		return redisTemplate;
+	}
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/config/ServletFilterConfig.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/config/ServletFilterConfig.java
@@ -8,6 +8,7 @@ import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
 import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
 import com.ludo.study.studymatchingplatform.auth.common.service.UserDetailsService;
 import com.ludo.study.studymatchingplatform.filter.JwtAuthenticationFilter;
+import com.ludo.study.studymatchingplatform.user.service.UserService;
 
 import jakarta.servlet.Filter;
 import lombok.RequiredArgsConstructor;
@@ -19,13 +20,14 @@ public class ServletFilterConfig {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final CookieProvider cookieProvider;
 	private final UserDetailsService userDetailsService;
+	private final UserService userService;
 
 	@Bean
 	public FilterRegistrationBean<Filter> jwtAuthenticationFilter() {
 		FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
 
 		filterRegistrationBean.setFilter(
-				new JwtAuthenticationFilter(jwtTokenProvider, cookieProvider, userDetailsService));
+				new JwtAuthenticationFilter(jwtTokenProvider, cookieProvider, userDetailsService, userService));
 		filterRegistrationBean.setOrder(1);
 		addAuthenticationEndpoints(filterRegistrationBean);
 		return filterRegistrationBean;

--- a/src/main/java/com/ludo/study/studymatchingplatform/config/ServletFilterConfig.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/config/ServletFilterConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
 import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
+import com.ludo.study.studymatchingplatform.auth.common.service.UserDetailsService;
 import com.ludo.study.studymatchingplatform.filter.JwtAuthenticationFilter;
 
 import jakarta.servlet.Filter;
@@ -17,12 +18,14 @@ public class ServletFilterConfig {
 
 	private final JwtTokenProvider jwtTokenProvider;
 	private final CookieProvider cookieProvider;
+	private final UserDetailsService userDetailsService;
 
 	@Bean
 	public FilterRegistrationBean<Filter> jwtAuthenticationFilter() {
 		FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
 
-		filterRegistrationBean.setFilter(new JwtAuthenticationFilter(jwtTokenProvider, cookieProvider));
+		filterRegistrationBean.setFilter(
+				new JwtAuthenticationFilter(jwtTokenProvider, cookieProvider, userDetailsService));
 		filterRegistrationBean.setOrder(1);
 		addAuthenticationEndpoints(filterRegistrationBean);
 		return filterRegistrationBean;

--- a/src/main/java/com/ludo/study/studymatchingplatform/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/filter/JwtAuthenticationFilter.java
@@ -14,6 +14,8 @@ import com.ludo.study.studymatchingplatform.auth.common.service.UserDetailsServi
 import com.ludo.study.studymatchingplatform.common.advice.CommonResponse;
 import com.ludo.study.studymatchingplatform.study.service.exception.AuthenticationException;
 import com.ludo.study.studymatchingplatform.study.service.exception.NotFoundException;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import com.ludo.study.studymatchingplatform.user.service.UserService;
 
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
@@ -30,6 +32,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final CookieProvider cookieProvider;
 	private final UserDetailsService userDetailsService;
+	private final UserService userService;
 
 	public static final String AUTH_USER_PAYLOAD = "AUTH_USER_PAYLOAD";
 
@@ -49,7 +52,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				// 사용자 agent / ip 검증
 				userDetailsService.verifyUserDetails(payload.getId(), request);
 				request.setAttribute(AUTH_USER_PAYLOAD, payload);
-				// 만료된 사용자 정보 검증 추가
+				// 토큰 갱신
+				accessTokenRefresh(payload.getId(), response);
+				// NotFoundException - 만료된 사용자 정보 검증 추가
 			} catch (final AuthenticationException | NotFoundException e) {
 				// 만료되거나 잘못된 토큰일 경우 예외 response 를 반환한다.
 				cookieProvider.clearAuthCookie(response);
@@ -71,6 +76,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		} catch (Exception e) {
 			log.error(e.getMessage());
 		}
+	}
+
+	private void accessTokenRefresh(final Long userId, final HttpServletResponse response) {
+		final User user = userService.findById(userId);
+		final String accessToken = jwtTokenProvider.createAccessToken(AuthUserPayload.from(user));
+		cookieProvider.setAuthCookie(accessToken, response);
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/filter/JwtAuthenticationFilter.java
@@ -10,8 +10,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ludo.study.studymatchingplatform.auth.common.AuthUserPayload;
 import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
 import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
+import com.ludo.study.studymatchingplatform.auth.common.service.UserDetailsService;
 import com.ludo.study.studymatchingplatform.common.advice.CommonResponse;
 import com.ludo.study.studymatchingplatform.study.service.exception.AuthenticationException;
+import com.ludo.study.studymatchingplatform.study.service.exception.NotFoundException;
 
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
@@ -27,6 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private final JwtTokenProvider jwtTokenProvider;
 	private final CookieProvider cookieProvider;
+	private final UserDetailsService userDetailsService;
 
 	public static final String AUTH_USER_PAYLOAD = "AUTH_USER_PAYLOAD";
 
@@ -40,12 +43,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				jwtExceptionHandler(response, HttpStatus.UNAUTHORIZED, "Authorization 쿠키가 없습니다.");
 				return;
 			}
-
 			try {
 				Claims claims = jwtTokenProvider.verifyAuthTokenOrThrow(authToken.get());
 				final AuthUserPayload payload = AuthUserPayload.from(claims);
+				// 사용자 agent / ip 검증
+				userDetailsService.verifyUserDetails(payload.getId(), request);
 				request.setAttribute(AUTH_USER_PAYLOAD, payload);
-			} catch (final AuthenticationException e) {
+				// 만료된 사용자 정보 검증 추가
+			} catch (final AuthenticationException | NotFoundException e) {
 				// 만료되거나 잘못된 토큰일 경우 예외 response 를 반환한다.
 				cookieProvider.clearAuthCookie(response);
 				jwtExceptionHandler(response, HttpStatus.UNAUTHORIZED, e.getMessage());

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentService.java
@@ -119,7 +119,7 @@ public class RecruitmentService {
 		} else {
 			final Applicant reapplicant = applicant.get();
 			reapplicant.ensureApplicable();
-			reapplicant.reapply();
+			// reapplicant.reapply();
 
 			return reapplicant;
 		}

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/controller/UserController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/controller/UserController.java
@@ -56,8 +56,7 @@ public class UserController {
 	@Operation(description = "로그인 된 사용자 정보 조회")
 	@ApiResponse(description = "조회 성공", responseCode = "200", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
 	@DataFieldName("user")
-	public UserResponse getMe(@Parameter(hidden = true) @AuthUser final User user,
-							  final HttpServletResponse response) {
+	public UserResponse getMe(@Parameter(hidden = true) @AuthUser final User user) {
 		return UserResponse.from(user);
 	}
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/controller/UserController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/controller/UserController.java
@@ -11,10 +11,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ludo.study.studymatchingplatform.auth.common.AuthUser;
-import com.ludo.study.studymatchingplatform.auth.common.AuthUserPayload;
 import com.ludo.study.studymatchingplatform.auth.common.Redirection;
 import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
-import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
 import com.ludo.study.studymatchingplatform.common.annotation.DataFieldName;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import com.ludo.study.studymatchingplatform.user.service.ChangeNicknameService;
@@ -39,7 +37,6 @@ public class UserController {
 
 	private final UserService userService;
 	private final ChangeNicknameService changeNicknameService;
-	private final JwtTokenProvider jwtTokenProvider;
 	private final CookieProvider cookieProvider;
 	private final Redirection redirection;
 
@@ -61,8 +58,6 @@ public class UserController {
 	@DataFieldName("user")
 	public UserResponse getMe(@Parameter(hidden = true) @AuthUser final User user,
 							  final HttpServletResponse response) {
-		final String accessToken = jwtTokenProvider.createAccessToken(AuthUserPayload.from(user));
-		cookieProvider.setAuthCookie(accessToken, response);
 		return UserResponse.from(user);
 	}
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/controller/UserController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/controller/UserController.java
@@ -11,8 +11,10 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ludo.study.studymatchingplatform.auth.common.AuthUser;
+import com.ludo.study.studymatchingplatform.auth.common.AuthUserPayload;
 import com.ludo.study.studymatchingplatform.auth.common.Redirection;
 import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
+import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
 import com.ludo.study.studymatchingplatform.common.annotation.DataFieldName;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import com.ludo.study.studymatchingplatform.user.service.ChangeNicknameService;
@@ -36,11 +38,9 @@ import lombok.extern.slf4j.Slf4j;
 public class UserController {
 
 	private final UserService userService;
-
 	private final ChangeNicknameService changeNicknameService;
-
+	private final JwtTokenProvider jwtTokenProvider;
 	private final CookieProvider cookieProvider;
-
 	private final Redirection redirection;
 
 	@DeleteMapping("/users/deactivate")
@@ -59,7 +59,10 @@ public class UserController {
 	@Operation(description = "로그인 된 사용자 정보 조회")
 	@ApiResponse(description = "조회 성공", responseCode = "200", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
 	@DataFieldName("user")
-	public UserResponse getMe(@Parameter(hidden = true) @AuthUser final User user) {
+	public UserResponse getMe(@Parameter(hidden = true) @AuthUser final User user,
+							  final HttpServletResponse response) {
+		final String accessToken = jwtTokenProvider.createAccessToken(AuthUserPayload.from(user));
+		cookieProvider.setAuthCookie(accessToken, response);
 		return UserResponse.from(user);
 	}
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/user/service/UserService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/user/service/UserService.java
@@ -20,8 +20,7 @@ public class UserService {
 
 	public void withdraw(final User user) {
 
-		final User foundUser = userRepository.findById(user.getId())
-				.orElseThrow(() -> new NotFoundException("가입되지 않은 회원입니다."));
+		final User foundUser = findById(user.getId());
 
 		if (foundUser.isDeleted()) {
 			throw new ResponseStatusException(HttpStatus.CONFLICT, "비활성화 된 회원입니다. 복구하시려면 해당 계정으로 다시 회원 가입을 시도해주세요.");
@@ -29,4 +28,10 @@ public class UserService {
 
 		user.softDelete();
 	}
+
+	public User findById(final Long userId) {
+		return userRepository.findById(userId)
+				.orElseThrow(() -> new NotFoundException("가입되지 않은 회원입니다."));
+	}
+
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -8,6 +8,11 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  data:
+    redis:
+      host: 34.127.61.11 # 로컬에서 테스트 할 때는 localhost 사용
+      port: 6379
+
   jpa:
     hibernate:
       ddl-auto: none
@@ -57,12 +62,12 @@ jwt:
   token:
     secret-key: ${JWT_SECRET_KEY}
     access-token-expiresin: ${JWT_ACCESS_TOKEN_EXPIRES_IN}
+    refresh-token-expiresin: ${JWT_REFRESH_TOKEN_EXPIRES_IN}
 
 client:
   scheme: https
-  domain: local.ludoapi.store
-  port: 3000
-  url: ${client.scheme}://${client.domain}:${client.port}
+  domain: ludoapi.store
+  url: ${client.scheme}://${client.domain}
 
 server:
   port: ${PORT}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -10,8 +10,9 @@ spring:
 
   data:
     redis:
-      host: 34.127.61.11 # 로컬에서 테스트 할 때는 localhost 사용
-      port: 6379
+      host: ${REDIS_HOST} # 로컬에서 테스트 할 때는 localhost 사용
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
 
   jpa:
     hibernate:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,8 +15,9 @@ spring:
 
   data:
     redis:
-      host: 34.127.61.11 # 로컬에서 테스트 할 때는 localhost 사용
-      port: 6379
+      host: ${REDIS_HOST} # 로컬에서 테스트 할 때는 localhost 사용
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
 
   jpa:
     hibernate:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,11 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  data:
+    redis:
+      host: 34.127.61.11 # 로컬에서 테스트 할 때는 localhost 사용
+      port: 6379
+
   jpa:
     hibernate:
       ddl-auto: none
@@ -61,12 +66,12 @@ jwt:
   token:
     secret-key: ${JWT_SECRET_KEY}
     access-token-expiresin: ${JWT_ACCESS_TOKEN_EXPIRES_IN}
+    refresh-token-expiresin: ${JWT_REFRESH_TOKEN_EXPIRES_IN}
 
 client:
   scheme: https
-  domain: local.ludoapi.store
-  port: 3000
-  url: ${client.scheme}://${client.domain}:${client.port}
+  domain: ludoapi.store
+  url: ${client.scheme}://${client.domain}
 
 logging.level:
   org.hibernate.SQL: debug

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/RecruitmentFixture.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/RecruitmentFixture.java
@@ -40,6 +40,7 @@ public class RecruitmentFixture {
 				.title(title)
 				.hits(0)
 				.recruitmentEndDateTime(endDateTime)
+				.modifiedDateTime(LocalDateTime.now())
 				.build();
 	}
 

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -15,7 +15,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
 
     properties:
       hibernate:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -15,7 +15,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
 
     properties:
       hibernate:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -13,6 +13,12 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  data:
+    redis:
+      host: ${REDIS_HOST} # 로컬에서 테스트 할 때는 localhost 사용
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+
   jpa:
     hibernate:
       ddl-auto: create
@@ -63,11 +69,11 @@ jwt:
   token:
     secret-key: ${JWT_SECRET_KEY}
     access-token-expiresin: ${JWT_ACCESS_TOKEN_EXPIRES_IN}
+    refresh-token-expiresin: ${JWT_REFRESH_TOKEN_EXPIRES_IN}
 
 client:
   scheme: http
   domain: localhost
-  port: 3000
   url: ${client.scheme}://${client.domain}:${client.port}
 
 logging.level:


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- **별도의 인스턴스로 redis 서버 생성**
  - 현재 운영중인 java 서버로 통합을 고민했으나, 1gb라는 한정된 자원에서 지속적으로 늘어날 사용자 수를 고려했을 때 scale-out이 옳다고 판단했습니다. 

<br><br>

- **사용자 accessToken refresh 로직 추가**
  - 서비스에 지속적인 접근을 원하는 사용자의 안전한 토큰 갱신 목적
  - 단순히 refreshToken을 적용하는 방법으로는 보안상의 이점 없이 accessToken을 연장 시키는 것 밖에 되지 않는다고 판단하여 특정 할 수 있는 사용자 식별 정보를 활용하는 방법을 채택했습니다.
  - userAgent 헤더 / clientIp 활용 (refreshToken 방식 X)
  - redis서버에서 동작하도록 하여 chache hit를 통한 성능 향상

<br><br>

- **고려한 보안 사항**
  - **중간자 공격(MITM Attack) - 네트워크 통신을 조작하여 통신 내용을 훔쳐 보거나 조작하는 공격 유형.**
    - 기존에 적용된 Secure 속성 사용으로 해결했습니다. HTTPS를 사용하면 모든 통신 내용은 암호화되기 때문에 공격자의 중간자 공격을 통한 토큰 탈취를 방지할 수 있습니다.

  - **XSS(Cross-Site Scripting) - 대상 웹사이트에 악성 스크립트를 주입하여 비정상적인 동작을 실행시키는 공격 유형.**
      - HttpOnly 속성 사용으로 해결했습니다. HttpOnly 속성은 웹브라우저가 스크립트를 통한 Dom document.cookie 객체 접근을 허용하지 않도록 합니다. 즉 공격자의 XSS를 통한 토큰 탈취를 방지할 수 있습니다.

  - **CSRF(Cross Site Request Forgery) - 사용자가 자신의 의지와는 무관하게 공격자가 의도한 행위를 특정 웹사이트에 요청하도록 만드는 공격 유형.**
    -  가장 많은 고민을 녹인 공격 유형입니다. 해결하기 위해 몇 가지 보안 요소를 추가했지만 위험을 최소화 했을 뿐, 완벽한 방어는 아니라고 생각됩니다.
       1. SameSite Strict 적용: Strict는 가장 보수적인 보안 정책으로 같은 도메인 사이에서만 쿠키 전달을 가능하게 합니다.
       2. CORS 허용 도메인 지정
       3. accessToken / userAgent 헤더 / clientIp 를 통한 유효한 사용자 검증
       4. 만료 시간: access 30분 /  refresh  7일 

<br><br>

- **토큰 리프레시 시점을 기존 `/users/me` API에서 `JwtAuthenticationFilter` 내부로 변경** 
  - 별도의 API로  관리하는 방법을 고민했지만, 사용자 경험과 개발 관점에서 득보다 실이 많은 방법으로 판단되어 해당 클래스에 토큰 리프레시 로직을 통합하여 유효한 사용자일 경우 모든 권한이 필요한 요청에서 작동하도록 설계했습니다.
  - access 만료 시간인 30분 이내에 호출시 지속적으로 만료기간을 연장합니다.
  - refresh 만료 시간인 7일 초과시 로그아웃 처리 됩니다.
  - 필터 단에서  accessToken / userAgent / clientIp를 검증을 진행하며 다른 정보로 접근한 경우 로그아웃 처리 됩니다. 

<br><br>

- **redis 서버 내에서 최대 할당 메모리를 1gb로 설정하고, 초과시 가장 오래된 데이터를 지워 메모리를 확보하는 알고리즘을 적용했습니다.**

<br><br>

- **redis 서버 비밀번호를 설정했습니다.**
  - 현재는 `.env` 에 반영되어 있으며 슬랙으로 공유하도록 하겠습니다.

<br><br>

- **test, .yaml 레디스 설정 추가**
  - auto-ddl: create로 설정되어 있습니다.

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- **소셜 로그인 / 회원가입 컨트롤러에서 createUserDetails를 호출하여  userAgent / clientIp를 redis에 저장합니다.**
- **사용자의 로그인 환경은 매번 변경될 가능성이 높다고 생각하여 로그인시 현재 환경의 userAgent / clientIp를 저장하도록 구현했습니다.**
- **기존에 저장된 정보가 있는 경우 update 됩니다.** 
<img width="818" alt="스크린샷 2024-04-09 오후 7 42 52" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/b0c44a56-c6e5-4b18-9f73-ada346426230">

<img width="786" alt="스크린샷 2024-04-09 오후 7 43 35" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/2d4981cd-01c5-4ac1-a0a8-c8bff1e81fa4">

<br><br>

-  **redis 객체인 UserDetails 입니다.**
<img width="598" alt="스크린샷 2024-04-09 오후 7 49 46" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/a6ef02f3-4654-42e1-8cac-1cfcd8aa3eab">

<br><br>

- **clientIp의 경우 다양한 종류의 proxy를 고려하여 각 header를 전부 확인하는 작업이 필요합니다.**
<img width="916" alt="스크린샷 2024-04-09 오후 7 48 35" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/154585f4-58e1-41f4-a888-bfe7f04867cb">

<br><br>

- **JwtAuthenticationFilter에서 accessToken / userAgent / clientIp 를 검증합니다.**
- **유효하지 않을 경우 쿠키를 삭제하여 로그 아웃 처리합니다.**
<img width="872" alt="스크린샷 2024-04-09 오후 8 39 31" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/3e40bbc8-f8a3-4a3f-ab5e-85559ca0c426">
<img width="839" alt="스크린샷 2024-04-09 오후 8 41 35" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/5f0dee8a-4048-40f2-9de9-f2b886e4a34c">

<br><br>

- **SameSite Strict를 적용한 CookieProvider 입니다.**
<img width="654" alt="스크린샷 2024-04-09 오후 8 43 30" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/65d391d1-207c-40e5-b046-d9f4eb04b9d0">

<br><br>
- **토큰 리프레시 시점을 기존 `/users/me` API에서 `JwtAuthenticationFilter` 내부로 변경했습니다. 유효한 사용자일 경우 모든 권한이 필요한 요청에서 작동합니다.** 
<img width="883" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/af25a88f-0b1a-46e8-b0d6-ad2ce4e96b3c">
<img width="795" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/16f5252b-a145-49d3-b7b7-00b96cf62a7f">

<br><br>

- **redis config 클래스와 내부 저장 방식 입니다.**
<img width="852" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/dba1a3b1-282a-4a0f-9715-299e669212f9">
<img width="336" alt="스크린샷 2024-04-10 오후 2 13 37" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/0e06a27d-f3f1-4598-8d49-6fc48f135337">

<br><br>

- **redis 서버 내에서 최대 할당 메모리를 1gb로 설정하고, 초과시 가장 오래된 데이터를 지워 메모리를 확보하는 알고리즘을 적용했습니다. 따라서 최대 1gb까지의 사용자가 동시 접속 가능한 환경입니다.** 
<img width="536" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/83931353/2c4fb07b-ce88-4e88-8cfe-5d3847ed794f">


<br><br>

### ✅ 셀프 체크리스트

- [X] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [X] 커밋 메세지를 컨벤션에 맞추었습니다.
- [X] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [X] 변경 후 코드는 기존의 테스트를 통과합니다.
- [X] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [X] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
