### PR TITLE
SP-401/Feat: prometheus 의존성 추가 및 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -72,5 +72,33 @@ logging.level:
   org.hibernate.SQL: debug
   org.hibernate.type: trace
 
+management:
+  info:
+    java:
+      enabled: true
+    os:
+      enabled: true
+    env:
+      enabled: true
+    build:
+      enabled: true
+    defaults:
+      enabled: true
+  endpoint:
+    health:
+      show-components: always
+    prometheus:
+      enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  server:
+    port:
+      ${METRIC_PORT:9999}
+
 server:
   port: ${PORT}
+  tomcat:
+    mbeanregistry:
+      enabled: true


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.



<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.


- (없다면 이 문항을 지워주세요.)

1. Prometheus 의존성 추가
```gradle
// build.gradle

dependencies {
  // ...
  runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
}
```

2. application.yaml 설정 추가
 
```yaml
# application.yml

# ...

management:
  info:
    java:
      enabled: true
    os:
      enabled: true
    env:
      enabled: true
    build:
      enabled: true
    defaults:
      enabled: true
  endpoint:
    health:
      show-components: always
    prometheus:
      enabled: true
  endpoints:
    web:
      exposure:
        include: "*"
  server:
    port:
      # metric api port
      ${METRIC_PORT:9999}

server:
  port: ${PORT}
  tomcat:
    mbeanregistry:
      enabled: true
```

기본적인 metric들을 노출시켰으며,

metric endpoint는 api와 별개의 PORT(9999)로 설정하였습니다.

metric 정보에 아무나 접근할 수 없도록 public network로 노출시키지 않고 VPC를 통해 WAS와 private subnet을 통해 metric을 수집하기 위함입니다.

<br><br>

### 💡 필요한 후속작업이 있어요.

- 모니터링 서버 연결 필요

https://github.com/Ludo-SMP/ludo-backend-monitoring/pull/1

<br><br>

---
<img width="990" alt="image" src="https://github.com/Ludo-SMP/ludo-backend-monitoring/assets/121966058/b39dce88-c9a0-411f-bd9a-b97f24a45073">

was에서 노출시킨 metric endpoint는 9999 port에서 serving 됩니다.

prometheus는 pulling 방식으로 metric endpoint을 통해 주기적으로 데이터를 수집합니다.

grafana는 prometheus container 내의 저장소로부터 수집된 데이터를 pulling하여 dashboard에 시각화합니다.

💡 이슈를 처리하면서 추가된 코드가 있어요

dashboards 디렉토리 하에 grafana가 보여줄 dashboard의 metadata들이 들어 있습니다.

datasource.yml은 grafana에서 시각화를 위한 데이터를 가져올 src를 설정합니다. (prometheus)

provision.yml은 dashboard를 grafana app spin up 시점에 자동으로 provisioning 하기 위한 설정입니다.

prometheus.yml은 15초마다 was로부터 metric을 scrape 해옵니다.

metric path는 기본 설정인 `/actuator/prometheus`입니다.

`static_configs.targets`에 was url를 기재해야 합니다.

docker-compose.yml에서 volumes property에 docker bind mount를 통해 별도의 docker volume을 생성하지 않고 host의 volume을 mount하여 container가 재생성 되어도 데이터가 날아가지 않도록 구성했습니다.

3종의 dashboard를 넣었지만, LOKI를 의존하는 대시보드가 하나 있어서 해당 대시보드의 일부분이 제대로 보이지 않습니다.

💡 필요한 후속작업이 있어요.

- grafana dashboard에 credential을 가진 사용자만 접근할 수 있도록 GCP에서 설정이 필요합니다.
- `prometheus.yml` 파일에서 `targets`의 host를 실제 GCP ip로 변경해야 합니다. 추후 구성 요소가 늘어나면 ansible을 통해 자동 설정을 할 수도 있겠지만 현재는 shell script를 통해 동적으로 구해오는 방법이 적당해 보입니다.
```yml
# prometheus.yml
  static_configs:
  - targets:
    # Spring Public IP on GCP
    - "host.docker.internal:9999" < < < < < ✅
```


---

### ✅ 셀프 체크리스트

- [O] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [O] 커밋 메세지를 컨벤션에 맞추었습니다.
- [O] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [O] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
