### PR TITLE
SP-447: docker-compose.yml에 redis 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,15 @@ services:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     ports:
       - '3306:3306'
+
+  redis:
+    image: redis
+    restart: always
+    ports:
+      - "6379:6379"
+    command: redis-server --requirepass ludoredis777!
+    volumes:
+      - "./redis-data:/data"
 #    volumes:
 #      - './docker/db/data:/var/lib/mysql' # MySQL 데이터베이스를 로컬 디렉토리에 연동
 #      - './docker/db/my.cnf:/etc/mysql/conf.d/my.cnf'


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

docker compose 설정 파일에 redis를 추가 하였습니다.

<br><br>


### ✅ 셀프 체크리스트

- [O] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [O] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
