### PR TITLE
Sp 490: Write Review usecase, testcase 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .idea/**/usage.statistics.xml
 .idea/**/dictionaries
 .idea/**/shelf
+.idea/material_theme_project_new.xml
 
 # AWS User-specific
 .idea/**/aws.xml
@@ -167,3 +168,4 @@ src/main/generated/
 front-test-app/
 
 .env*
+

--- a/src/main/java/com/ludo/study/studymatchingplatform/common/utils/LocalDateTimePicker.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/utils/LocalDateTimePicker.java
@@ -1,0 +1,7 @@
+package com.ludo.study.studymatchingplatform.common.utils;
+
+import java.time.LocalDateTime;
+
+public interface LocalDateTimePicker {
+    LocalDateTime now();
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/common/utils/LocalDateTimePickerImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/utils/LocalDateTimePickerImpl.java
@@ -12,6 +12,8 @@ public class LocalDateTimePickerImpl implements LocalDateTimePicker {
     public LocalDateTime now() {
         return LocalDateTime.now().truncatedTo(ChronoUnit.MICROS);
     }
+        return LocalDateTime.now().truncatedTo(ChronoUnit.MICROS);
+    }
         return LocalDateTime.now();
     }
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/common/utils/LocalDateTimePickerImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/utils/LocalDateTimePickerImpl.java
@@ -10,6 +10,8 @@ import java.time.LocalDateTime;
 public class LocalDateTimePickerImpl implements LocalDateTimePicker {
 
     public LocalDateTime now() {
+        return LocalDateTime.now().truncatedTo(ChronoUnit.MICROS);
+    }
         return LocalDateTime.now();
     }
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/common/utils/LocalDateTimePickerImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/utils/LocalDateTimePickerImpl.java
@@ -1,0 +1,15 @@
+package com.ludo.study.studymatchingplatform.common.utils;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Profile("!test")
+@Component
+public class LocalDateTimePickerImpl implements LocalDateTimePicker {
+
+    public LocalDateTime now() {
+        return LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/controller/ReviewController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/controller/ReviewController.java
@@ -1,0 +1,39 @@
+package com.ludo.study.studymatchingplatform.study.controller;
+
+import com.ludo.study.studymatchingplatform.auth.common.AuthUser;
+import com.ludo.study.studymatchingplatform.common.annotation.DataFieldName;
+import com.ludo.study.studymatchingplatform.study.service.dto.request.study.WriteReviewRequest;
+import com.ludo.study.studymatchingplatform.study.service.dto.response.study.ReviewResponse;
+import com.ludo.study.studymatchingplatform.study.service.study.ReviewService;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+@Validated
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @PostMapping("/studies/{studyId}/reviews")
+    @ResponseStatus(HttpStatus.CREATED)
+    @DataFieldName("review")
+    @Operation(description = "리뷰 작성")
+    @ApiResponse(description = "리뷰 작성 성공", responseCode = "201", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
+    public ReviewResponse write(@Parameter(hidden = true) @AuthUser final User user, @PathVariable("studyId") Long studyId, @Valid @RequestBody WriteReviewRequest request) {
+        return reviewService.write(request, studyId, user);
+    }
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Review.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Review.java
@@ -1,0 +1,58 @@
+package com.ludo.study.studymatchingplatform.study.domain.study;
+
+import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Slf4j
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "study_id")
+    private Study study;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "reviewer_id")
+    private User reviewer;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "reviewee_id")
+    private User reviewee;
+
+    // 적극성
+    private Long activenessScore;
+
+    // 전문성
+    private Long professionalismScore;
+
+    // 의사소통
+    private Long communicationScore;
+
+    // 다시함께
+    private Long togetherScore;
+
+    // 추천 여부
+    private Long recommendScore;
+
+    public boolean isDuplicateReview(final Long studyId, final Long reviewerId, final Long revieweeId) {
+        return study.getId() == studyId && reviewer.getId() == reviewerId && reviewee.getId() == revieweeId;
+    }
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Study.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Study.java
@@ -342,7 +342,10 @@ public class Study extends BaseEntity {
         final LocalDateTime reviewAvailEndTime = endDateTime.plusDays(14).plusSeconds(1);
 
         // Order Specific
-        if (isReviewPeriodElapsed(now)) {
+        if (isAvailableReviewPeriod()) {
+            return;
+        }
+        throw new InvalidReviewPeriodException("리뷰 작성 기간이 아닙니다.", reviewAvailStartTime, reviewAvailEndTime);
             throw new InvalidReviewPeriodException("리뷰 작성 기간이 지났습니다.", reviewAvailStartTime, reviewAvailEndTime);
         }
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Study.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Study.java
@@ -370,6 +370,13 @@ public class Study extends BaseEntity {
         return now.isAfter(reviewAvailEndTime);
     }
     
+    private boolean isAvailableReviewPeriod() {
+        final LocalDateTime reviewAvailStartTime = getReviewAvailStartTime();
+        final LocalDateTime reviewAvailEndTime = getReviewAvailEndTime();
+        
+        return now.isAfter(getReviewAvailStartTime) && now.isBefore(reviewAvailEndTime);
+    }
+    
     private LocalDateTime getReviewAvailStartTime() {
         return endDateTime;
     }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Study.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Study.java
@@ -1,41 +1,26 @@
 package com.ludo.study.studymatchingplatform.study.domain.study;
 
-import static jakarta.persistence.FetchType.*;
-
-import java.time.LocalDateTime;
-import java.time.Period;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
 import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
+import com.ludo.study.studymatchingplatform.common.utils.LocalDateTimePicker;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.applicant.Applicant;
 import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
 import com.ludo.study.studymatchingplatform.study.domain.study.participant.Participant;
 import com.ludo.study.studymatchingplatform.study.domain.study.participant.Role;
+import com.ludo.study.studymatchingplatform.study.service.exception.InvalidReviewPeriodException;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.Size;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
 @Getter
@@ -45,294 +30,339 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class Study extends BaseEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "study_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_id")
+    private Long id;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, columnDefinition = "char(10)")
-	private StudyStatus status;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "char(10)")
+    private StudyStatus status;
 
-	@ManyToOne(fetch = LAZY)
-	@JoinColumn(name = "category_id", nullable = false)
-	private Category category;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
 
-	@ManyToOne(fetch = LAZY)
-	@JoinColumn(name = "owner_id", nullable = false)
-	private User owner;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "owner_id", nullable = false)
+    private User owner;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, columnDefinition = "char(20)")
-	private Platform platform;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "char(20)")
+    private Platform platform;
 
-	@Column(nullable = true, length = 2048)
-	@Size(max = 2048)
-	private String platformUrl;
+    @Column(nullable = true, length = 2048)
+    @Size(max = 2048)
+    private String platformUrl;
 
-	@Column(nullable = false, length = 50)
-	private String title;
+    @Column(nullable = false, length = 50)
+    private String title;
 
-	@OneToOne(mappedBy = "study", fetch = LAZY)
-	private Recruitment recruitment;
+    @OneToOne(mappedBy = "study", fetch = LAZY)
+    private Recruitment recruitment;
 
-	@OneToMany(mappedBy = "study", fetch = LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-	@Builder.Default
-	private List<Participant> participants = new ArrayList<>();
+    @OneToMany(mappedBy = "study", fetch = LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Participant> participants = new ArrayList<>();
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, columnDefinition = "char(10)")
-	private Way way;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "char(10)")
+    private Way way;
 
-	@Column(nullable = false)
-	private Integer participantLimit;
+    @Column(nullable = false)
+    private Integer participantLimit;
 
-	// null 제거 필요
-	@Column(nullable = false)
-	private Integer participantCount;
+    // null 제거 필요
+    @Column(nullable = false)
+    private Integer participantCount;
 
-	@Column(nullable = false)
-	private LocalDateTime startDateTime;
+    @Column(nullable = false)
+    private LocalDateTime startDateTime;
 
-	@Column(nullable = false)
-	private LocalDateTime endDateTime;
+    @Column(nullable = false)
+    private LocalDateTime endDateTime;
 
-	public void addParticipant(final Participant participant) {
-		this.participants.add(participant);
-		this.participantCount = this.participants.size();
-	}
+    public void addParticipant(final Participant participant) {
+        this.participants.add(participant);
+        this.participantCount = this.participants.size();
+    }
 
-	public void registerRecruitment(final Recruitment recruitment) {
-		this.recruitment = recruitment;
-		this.recruitment.connectToStudy(this);
-	}
+    public void registerRecruitment(final Recruitment recruitment) {
+        this.recruitment = recruitment;
+        this.recruitment.connectToStudy(this);
+    }
 
-	public void changeStatus(final StudyStatus status) {
-		this.status = status;
-	}
+    public void changeStatus(final StudyStatus status) {
+        this.status = status;
+    }
 
-	public void addRecruitment(Recruitment recruitment) {
-		this.recruitment = recruitment;
-	}
+    public void addRecruitment(Recruitment recruitment) {
+        this.recruitment = recruitment;
+    }
 
-	public Integer getParticipantCount() {
-		return participants.size();
-	}
+    public Integer getParticipantCount() {
+        return participants.size();
+    }
 
-	public String getCategoryByName() {
-		return category.getName();
-	}
+    public String getCategoryByName() {
+        return category.getName();
+    }
 
-	public Long getCategoryId() {
-		return category.getId();
-	}
+    public Long getCategoryId() {
+        return category.getId();
+    }
 
-	public Long getOwnerId() {
-		return owner.getId();
-	}
+    public Long getOwnerId() {
+        return owner.getId();
+    }
 
-	public String getOwnerNickname() {
-		return owner.getNickname();
-	}
+    public String getOwnerNickname() {
+        return owner.getNickname();
+    }
 
-	public String getOwnerEmail() {
-		return owner.getEmail();
-	}
+    public String getOwnerEmail() {
+        return owner.getEmail();
+    }
 
-	public String getCategoryName() {
-		return category.getName();
-	}
+    public String getCategoryName() {
+        return category.getName();
+    }
 
-	public void ensureRecruitmentWritableBy(final User user) {
-		if (recruitment != null && !recruitment.isDeleted()) {
-			throw new IllegalArgumentException("이미 작성된 모집 공고가 존재합니다.");
-		}
+    public void ensureRecruitmentWritableBy(final User user) {
+        if (recruitment != null && !recruitment.isDeleted()) {
+            throw new IllegalArgumentException("이미 작성된 모집 공고가 존재합니다.");
+        }
 
-		if (!isOwner(user)) {
-			throw new IllegalArgumentException("모집 공고를 작성할 권한이 없습니다.");
-		}
-	}
+        if (!isOwner(user)) {
+            throw new IllegalArgumentException("모집 공고를 작성할 권한이 없습니다.");
+        }
+    }
 
-	public Recruitment ensureRecruitmentEditable(final User user) {
-		if (!owner.getId().equals(user.getId())) {
-			throw new IllegalArgumentException("모집 공고를 수정할 권한이 없습니다.");
-		}
-		if (recruitment == null || recruitment.isDeleted()) {
-			throw new IllegalArgumentException("존재하지 않는 모집 공고입니다.");
-		}
-		return recruitment;
-	}
+    public Recruitment ensureRecruitmentEditable(final User user) {
+        if (!owner.getId().equals(user.getId())) {
+            throw new IllegalArgumentException("모집 공고를 수정할 권한이 없습니다.");
+        }
+        if (recruitment == null || recruitment.isDeleted()) {
+            throw new IllegalArgumentException("존재하지 않는 모집 공고입니다.");
+        }
+        return recruitment;
+    }
 
-	public void ensureStudyEditable(final User user) {
-		if (!owner.getId().equals(user.getId())) {
-			throw new IllegalArgumentException("스터디를 수정할 권한이 없습니다.");
-		}
-	}
+    public void ensureStudyEditable(final User user) {
+        if (!owner.getId().equals(user.getId())) {
+            throw new IllegalArgumentException("스터디를 수정할 권한이 없습니다.");
+        }
+    }
 
-	public Boolean isOwner(final User user) {
-		return Objects.equals(owner.getId(), user.getId());
-	}
+    public Boolean isOwner(final User user) {
+        return Objects.equals(owner.getId(), user.getId());
+    }
 
-	public Boolean isOwner(final Participant participant) {
-		return participant.matchesUser(owner);
-	}
+    public Boolean isOwner(final Participant participant) {
+        return participant.matchesUser(owner);
+    }
 
-	public void ensureRecruiting() {
-		if (status != StudyStatus.RECRUITING) {
-			throw new IllegalStateException("현재 모집 중인 스터디가 아닙니다.");
-		}
-	}
+    public void ensureRecruiting() {
+        if (status != StudyStatus.RECRUITING) {
+            throw new IllegalStateException("현재 모집 중인 스터디가 아닙니다.");
+        }
+    }
 
-	public void acceptApplicant(final User owner, final User applicantUser) {
-		ensureAcceptApplicant(owner, applicantUser);
-		accept(applicantUser);
-		if (isMaxParticipantCount()) {
-			changeStatus(StudyStatus.RECRUITED);
-		}
-	}
+    public void acceptApplicant(final User owner, final User applicantUser) {
+        ensureAcceptApplicant(owner, applicantUser);
+        accept(applicantUser);
+        if (isMaxParticipantCount()) {
+            changeStatus(StudyStatus.RECRUITED);
+        }
+    }
 
-	public void rejectApplicant(final User owner, final User applicantUser) {
-		ensureRejectApplicant(owner, applicantUser);
-		recruitment.rejectApplicant(applicantUser);
-	}
+    public void rejectApplicant(final User owner, final User applicantUser) {
+        ensureRejectApplicant(owner, applicantUser);
+        recruitment.rejectApplicant(applicantUser);
+    }
 
-	private void ensureRejectApplicant(final User owner, final User applicantUser) {
-		ensureCorrectOwner(owner);
-		ensureApplicantUserIsNotOwner(owner, applicantUser);
-		recruitment.ensureCorrectApplicantUser(applicantUser);
-	}
+    private void ensureRejectApplicant(final User owner, final User applicantUser) {
+        ensureCorrectOwner(owner);
+        ensureApplicantUserIsNotOwner(owner, applicantUser);
+        recruitment.ensureCorrectApplicantUser(applicantUser);
+    }
 
-	private void ensureApplicantUserIsNotOwner(final User owner, final User applicantUser) {
-		if (owner.equals(applicantUser)) {
-			throw new IllegalArgumentException("스터디 장과 지원자가 같습니다.");
-		}
-	}
+    private void ensureApplicantUserIsNotOwner(final User owner, final User applicantUser) {
+        if (owner.equals(applicantUser)) {
+            throw new IllegalArgumentException("스터디 장과 지원자가 같습니다.");
+        }
+    }
 
-	private void ensureAcceptApplicant(final User owner, final User applicantUser) {
-		ensureCorrectOwner(owner);
-		ensureApplicantUserIsNotOwner(owner, applicantUser);
-		ensureRecruiting();
-		ensureRemainParticipantLimit();
-		recruitment.ensureCorrectApplicantUser(applicantUser);
-	}
+    private void ensureAcceptApplicant(final User owner, final User applicantUser) {
+        ensureCorrectOwner(owner);
+        ensureApplicantUserIsNotOwner(owner, applicantUser);
+        ensureRecruiting();
+        ensureRemainParticipantLimit();
+        recruitment.ensureCorrectApplicantUser(applicantUser);
+    }
 
-	private void ensureCorrectOwner(final User owner) {
-		log.info("스터디장 = {}", this.owner.getId());
-		log.info("파라미터 = {}", owner.getId());
-		if (!isOwner(owner)) {
-			throw new IllegalStateException(
-					String.format("스터디 장이 아닙니다. 스터디 장 id = %s, 잘못된 id = %s", this.owner, owner));
-		}
-	}
+    private void ensureCorrectOwner(final User owner) {
+        log.info("스터디장 = {}", this.owner.getId());
+        log.info("파라미터 = {}", owner.getId());
+        if (!isOwner(owner)) {
+            throw new IllegalStateException(
+                    String.format("스터디 장이 아닙니다. 스터디 장 id = %s, 잘못된 id = %s", this.owner, owner));
+        }
+    }
 
-	private void ensureRemainParticipantLimit() {
-		if (Objects.equals(getParticipantCount(), participantLimit)) {
-			throw new IllegalStateException("남아있는 자리가 없습니다.");
-		}
-	}
+    private void ensureRemainParticipantLimit() {
+        if (Objects.equals(getParticipantCount(), participantLimit)) {
+            throw new IllegalStateException("남아있는 자리가 없습니다.");
+        }
+    }
 
-	private void accept(final User applicantUser) {
-		recruitment.acceptApplicant(applicantUser);
-		final Applicant applicant = recruitment.getApplicant(applicantUser);
-		addParticipant(Participant.from(this, applicantUser, applicant.getPosition(), Role.MEMBER));
-	}
+    private void accept(final User applicantUser) {
+        recruitment.acceptApplicant(applicantUser);
+        final Applicant applicant = recruitment.getApplicant(applicantUser);
+        addParticipant(Participant.from(this, applicantUser, applicant.getPosition(), Role.MEMBER));
+    }
 
-	private Boolean isMaxParticipantCount() {
-		return Objects.equals(participantCount, participantLimit);
-	}
+    private Boolean isMaxParticipantCount() {
+        return Objects.equals(participantCount, participantLimit);
+    }
 
-	public Boolean isParticipating(final User user) {
-		return participants.stream()
-				.anyMatch(p -> p.matchesUser(user));
-	}
+    public Boolean allParticipating(final Long... userIds) {
+        return Arrays.stream(userIds).allMatch(this::isParticipating);
+    }
 
-	public Integer getDday() {
-		return Period.between(startDateTime.toLocalDate(), endDateTime.toLocalDate()).getDays();
-	}
+    public Boolean isParticipating(final User user) {
+        return isParticipating(user.getId());
+    }
 
-	public Participant getParticipant(final User user) {
-		return participants.stream()
-				.filter(p -> p.matchesUser(user))
-				.findFirst()
-				.orElseThrow(() -> new IllegalStateException("현재 참여 중인 스터디원이 아닙니다."));
-	}
+    public Boolean isParticipating(final Long userId) {
+        return participants.stream()
+                .anyMatch(p -> p.matchesUser(userId));
+    }
 
-	public void removeParticipant(final Participant participant) {
-		participants.removeIf(p -> Objects.equals(p, participant));
-	}
+    public Integer getDday() {
+        return Period.between(startDateTime.toLocalDate(), endDateTime.toLocalDate()).getDays();
+    }
 
-	public void modifyStatus(final StudyStatus status, final LocalDateTime now) {
-		// 모집 마감 상태는 시간에 따라 다른 결과 반영
-		if (status == StudyStatus.RECRUITED) {
-			modifyStatusToRecruited(now);
-			modifyStatusToProgress(now);
-		}
-	}
+    public Participant getParticipant(final User user) {
+        return getParticipant(user.getId());
+    }
 
-	public void modifyStatusToRecruiting() {
-		this.status = StudyStatus.RECRUITING;
-	}
+    public Optional<Participant> findParticipant(final Long userId) {
+        return participants.stream()
+                .filter(p -> p.matchesUser(userId))
+                .findFirst();
+    }
 
-	private void modifyStatusToRecruited(final LocalDateTime now) {
-		if (this.startDateTime.isAfter(now)) {
-			this.status = StudyStatus.RECRUITED;
-		}
-	}
+    public Participant getParticipant(final Long userId) {
+        return findParticipant(userId)
+                .orElseThrow(() -> new IllegalStateException("현재 참여 중인 스터디원이 아닙니다."));
+    }
 
-	private void modifyStatusToProgress(final LocalDateTime now) {
-		if (this.startDateTime.isBefore(now) && this.endDateTime.isAfter(now)) {
-			this.status = StudyStatus.PROGRESS;
-		}
-	}
+    public void removeParticipant(final Participant participant) {
+        participants.removeIf(p -> Objects.equals(p, participant));
+    }
 
-	public void modifyStatusToCompleted(final LocalDateTime now) {
-		if (this.endDateTime.isBefore(now)) {
-			this.status = StudyStatus.COMPLETED;
-		}
-	}
+    public void modifyStatus(final StudyStatus status, final LocalDateTime now) {
+        // 모집 마감 상태는 시간에 따라 다른 결과 반영
+        if (status == StudyStatus.RECRUITED) {
+            modifyStatusToRecruited(now);
+            modifyStatusToProgress(now);
+        }
+    }
 
-	public void deactivateForRecruitment() {
-		this.recruitment.softDelete();
-	}
+    public void modifyStatusToRecruiting() {
+        this.status = StudyStatus.RECRUITING;
+    }
 
-	public void activateForRecruitment() {
-		this.recruitment.activate();
-	}
+    private void modifyStatusToRecruited(final LocalDateTime now) {
+        if (this.startDateTime.isAfter(now)) {
+            this.status = StudyStatus.RECRUITED;
+        }
+    }
 
-	public Boolean ensureHasRecruitment() {
-		if (this.recruitment != null && !this.recruitment.isDeleted()) {
-			return Boolean.TRUE;
-		}
-		return Boolean.FALSE;
-	}
+    private void modifyStatusToProgress(final LocalDateTime now) {
+        if (this.startDateTime.isBefore(now) && this.endDateTime.isAfter(now)) {
+            this.status = StudyStatus.PROGRESS;
+        }
+    }
 
-	public void update(final String title, final Category category, final Integer participantLimit,
-					   final Way way, final Platform platform, final String platformUrl,
-					   final LocalDateTime startDateTime, final LocalDateTime endDateTime) {
-		if (title != null) {
-			this.title = title;
-		}
-		if (category != null) {
-			this.category = category;
-		}
-		if (participantLimit != null) {
-			this.participantLimit = participantLimit;
-		}
-		if (way != null) {
-			this.way = way;
-		}
-		if (platform != null) {
-			this.platform = platform;
-		}
-		if (platformUrl != null) {
-			this.platformUrl = platformUrl;
-		}
-		if (startDateTime != null) {
-			this.startDateTime = startDateTime;
-		}
-		if (endDateTime != null) {
-			this.endDateTime = endDateTime;
-		}
-	}
+    public void modifyStatusToCompleted(final LocalDateTime now) {
+        if (this.endDateTime.isBefore(now)) {
+            this.status = StudyStatus.COMPLETED;
+        }
+    }
 
+    public void deactivateForRecruitment() {
+        this.recruitment.softDelete();
+    }
+
+    public void activateForRecruitment() {
+        this.recruitment.activate();
+    }
+
+    public Boolean ensureHasRecruitment() {
+        if (this.recruitment != null && !this.recruitment.isDeleted()) {
+            return Boolean.TRUE;
+        }
+        return Boolean.FALSE;
+    }
+
+    public void update(final String title, final Category category, final Integer participantLimit,
+                       final Way way, final Platform platform, final String platformUrl,
+                       final LocalDateTime startDateTime, final LocalDateTime endDateTime) {
+        if (title != null) {
+            this.title = title;
+        }
+        if (category != null) {
+            this.category = category;
+        }
+        if (participantLimit != null) {
+            this.participantLimit = participantLimit;
+        }
+        if (way != null) {
+            this.way = way;
+        }
+        if (platform != null) {
+            this.platform = platform;
+        }
+        if (platformUrl != null) {
+            this.platformUrl = platformUrl;
+        }
+        if (startDateTime != null) {
+            this.startDateTime = startDateTime;
+        }
+        if (endDateTime != null) {
+            this.endDateTime = endDateTime;
+        }
+    }
+
+    public void ensureReviewPeriodAvailable(final LocalDateTimePicker localDateTimePicker) {
+        final LocalDateTime now = localDateTimePicker.now();
+        final LocalDateTime reviewAvailStartTime = endDateTime.plusDays(3).minusSeconds(1);
+        final LocalDateTime reviewAvailEndTime = endDateTime.plusDays(14).plusSeconds(1);
+
+        // Order Specific
+        if (isReviewPeriodElapsed(now)) {
+            throw new InvalidReviewPeriodException("리뷰 작성 기간이 지났습니다.", reviewAvailStartTime, reviewAvailEndTime);
+        }
+
+        if (isNotReviewPeriodYet(now)) {
+            throw new InvalidReviewPeriodException("아직 리뷰 작성 기간이 되지 않았습니다.", reviewAvailStartTime, reviewAvailEndTime);
+        }
+
+        System.out.println("min avail: " + reviewAvailStartTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        System.out.println("max avail: " + reviewAvailEndTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        System.out.println("now : " + now.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+
+    }
+
+    public boolean isNotReviewPeriodYet(final LocalDateTime now) {
+        final LocalDateTime reviewAvailStartTime = endDateTime.plusDays(3);
+        return now.isBefore(reviewAvailStartTime);
+    }
+
+    public boolean isReviewPeriodElapsed(final LocalDateTime now) {
+        final LocalDateTime reviewAvailEndTime = endDateTime.plusDays(14);
+        return now.isAfter(reviewAvailEndTime);
+    }
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Study.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Study.java
@@ -365,4 +365,12 @@ public class Study extends BaseEntity {
         final LocalDateTime reviewAvailEndTime = endDateTime.plusDays(14);
         return now.isAfter(reviewAvailEndTime);
     }
+    
+    private LocalDateTime getReviewAvailStartTime() {
+        return endDateTime;
+    }
+    
+    private LocalDateTime getReviewAvailEndTime() {
+        return endDateTime.plusDays(14);
+    }
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Study.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Study.java
@@ -338,7 +338,8 @@ public class Study extends BaseEntity {
 
     public void ensureReviewPeriodAvailable(final LocalDateTimePicker localDateTimePicker) {
         final LocalDateTime now = localDateTimePicker.now();
-        final LocalDateTime reviewAvailStartTime = endDateTime.plusDays(3).minusSeconds(1);
+       final LocalDateTime reviewAvailStartTime = getReviewAvailStartTime();
+       final LocalDateTime reviewAvailEndTime = getReviewAvailEndTime();
         final LocalDateTime reviewAvailEndTime = endDateTime.plusDays(14).plusSeconds(1);
 
         // Order Specific

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/UserReviewStatistics.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/UserReviewStatistics.java
@@ -1,0 +1,44 @@
+package com.ludo.study.studymatchingplatform.study.domain.study;
+
+import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserReviewStatistics extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // review count
+    private Long totalActivenessReviewCount;
+    private Long totalProfessionalismReviewCount;
+    private Long totalCommunicationReviewCount;
+    private Long totalTogetherReviewScore;
+    private Long totalRecommendReviewScore;
+
+    // scores
+    private Long totalActivenessScore;
+    private Long totalProfessionalismScore;
+    private Long totalCommunicationScore;
+    private Long totalTogetherScore;
+    private Long totalRecommendScore;
+
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/UserStudyStatistics.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/UserStudyStatistics.java
@@ -1,0 +1,50 @@
+package com.ludo.study.studymatchingplatform.study.domain.study;
+
+
+import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserStudyStatistics extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private int totalTeammateCount;
+
+    // 진행 완료 스터디(진행도 100%)
+    private int totalCompletedStudyCount;
+
+    // 완주 스터디(진행도 80% 이상)
+    private int totalFinishedStudyCount;
+
+    // 총 무단 탈주 스터디
+    private int totalLeftStudyCount;
+
+    // 총 누적 출석
+    private int totalAttendance;
+
+    // 총 유효 출석
+    private int totalValidAttendance;
+
+    // TODO: 동시에 여러 스터디를 진행하는 경우, 중복 count? 일수?
+    // 전체 스터디 진행 기간
+    private int totalStudyDays;
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/participant/Participant.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/participant/Participant.java
@@ -1,30 +1,18 @@
 package com.ludo.study.studymatchingplatform.study.domain.study.participant;
 
-import static jakarta.persistence.FetchType.*;
-
-import java.util.Objects;
-
 import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
 import com.ludo.study.studymatchingplatform.study.domain.id.ParticipantId;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
 import com.ludo.study.studymatchingplatform.study.domain.study.Study;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.EmbeddedId;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapsId;
-import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
 @Getter
@@ -34,59 +22,75 @@ import lombok.experimental.SuperBuilder;
 @Table(name = "study_user_lnk")
 public class Participant extends BaseEntity {
 
-	@EmbeddedId
-	@Builder.Default
-	private ParticipantId id = new ParticipantId();
+    @EmbeddedId
+    @Builder.Default
+    private ParticipantId id = new ParticipantId();
 
-	@ManyToOne(fetch = LAZY)
-	@MapsId("studyId")
-	@JoinColumn(name = "study_id", nullable = false)
-	private Study study;
+    @ManyToOne(fetch = LAZY)
+    @MapsId("studyId")
+    @JoinColumn(name = "study_id", nullable = false)
+    private Study study;
 
-	@ManyToOne(fetch = LAZY)
-	@MapsId("userId")
-	@JoinColumn(name = "user_id", nullable = false)
-	private User user;
+    @ManyToOne(fetch = LAZY)
+    @MapsId("userId")
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, columnDefinition = "char(10)")
-	private Role role;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "char(10)")
+    private Role role;
 
-	@ManyToOne
-	@JoinColumn(name = "position_id")
-	private Position position;
+    @ManyToOne
+    @JoinColumn(name = "position_id")
+    private Position position;
 
-	public static Participant from(final Study study, final User user, final Position position, final Role role) {
-		final Participant participant = new Participant();
-		participant.study = study;
-		participant.user = user;
-		participant.role = role;
-		participant.position = position;
-		return participant;
-	}
+    // 누적 출석
+    @Builder.Default
+    private int attendance = 0;
 
-	public Role getRole() {
-		// TODO: Role spec not determined clearly
-		// TODO: First of all, I reflected it in my own way
-		if (study.isOwner(this)) {
-			return Role.OWNER;
-		}
-		return Role.MEMBER;
-	}
+    // 누적 유효 출석
+    @Builder.Default
+    private int validAttendance = 0;
 
-	public boolean matchesUser(final User user) {
-		final boolean isMatchesUser = Objects.equals(this.user.getId(), user.getId());
-		return isMatchesUser && !isDeleted();
-	}
+    // 스터디 합류일
+    @Builder.Default
+    private LocalDateTime enrollmentDateTime = LocalDateTime.now();
 
-	public void leave(final Study study) {
-		study.removeParticipant(this);
-		this.study = null;
-		this.softDelete();
-	}
+    public static Participant from(final Study study, final User user, final Position position, final Role role) {
+        final Participant participant = new Participant();
+        participant.study = study;
+        participant.user = user;
+        participant.role = role;
+        participant.position = position;
+        return participant;
+    }
 
-	public void updatePosition(final Position position) {
-		this.position = position;
-	}
+    public Role getRole() {
+        // TODO: Role spec not determined clearly
+        // TODO: First of all, I reflected it in my own way
+        if (study.isOwner(this)) {
+            return Role.OWNER;
+        }
+        return Role.MEMBER;
+    }
+
+    public boolean matchesUser(final User user) {
+        return matchesUser(user.getId());
+    }
+
+    public boolean matchesUser(final Long userId) {
+        final boolean isMatchesUser = Objects.equals(this.user.getId(), userId);
+        return isMatchesUser && !isDeleted();
+    }
+
+    public void leave(final Study study) {
+        study.removeParticipant(this);
+        this.study = null;
+        this.softDelete();
+    }
+
+    public void updatePosition(final Position position) {
+        this.position = position;
+    }
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/repository/study/ReviewJpaRepository.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/repository/study/ReviewJpaRepository.java
@@ -1,0 +1,7 @@
+package com.ludo.study.studymatchingplatform.study.repository.study;
+
+import com.ludo.study.studymatchingplatform.study.domain.study.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewJpaRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/repository/study/ReviewRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/repository/study/ReviewRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.ludo.study.studymatchingplatform.study.repository.study;
+
+import com.ludo.study.studymatchingplatform.study.domain.study.Review;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.ludo.study.studymatchingplatform.study.domain.study.QReview.review;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl {
+
+    private final JPAQueryFactory q;
+
+    private final ReviewJpaRepository reviewJpaRepository;
+
+    public List<Review> findAllByStudyId(final Long studyId) {
+        return q.selectFrom(review)
+                .where(review.study.id.eq(studyId)
+                        .and(review.deletedDateTime.isNull()))
+                .fetch();
+    }
+
+    public Review save(final Review review) {
+        return reviewJpaRepository.save(review);
+    }
+
+    public boolean existsBy(final Long studyId, final Long reviewerId, final Long revieweeId) {
+//        q.select(review)
+//                .fetchFirst();
+        return false;
+    }
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/request/study/WriteReviewRequest.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/request/study/WriteReviewRequest.java
@@ -1,0 +1,30 @@
+package com.ludo.study.studymatchingplatform.study.service.dto.request.study;
+
+import com.ludo.study.studymatchingplatform.study.domain.study.Review;
+import com.ludo.study.studymatchingplatform.study.domain.study.Study;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import lombok.Builder;
+
+@Builder
+public record WriteReviewRequest(
+        Long revieweeId,
+        Long activenessScore,
+        Long professionalismScore,
+        Long communicationScore,
+        Long togetherScore,
+        Long recommendScore
+) {
+
+    public Review toReviewWithStudy(final Study study, final User reviewer, final User reviewee) {
+        return Review.builder()
+                .study(study)
+                .reviewer(reviewer)
+                .reviewee(reviewee)
+                .activenessScore(activenessScore)
+                .professionalismScore(professionalismScore)
+                .communicationScore(communicationScore)
+                .togetherScore(togetherScore)
+                .recommendScore(recommendScore)
+                .build();
+    }
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/study/ReviewResponse.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/study/ReviewResponse.java
@@ -1,0 +1,36 @@
+package com.ludo.study.studymatchingplatform.study.service.dto.response.study;
+
+import com.ludo.study.studymatchingplatform.study.domain.study.Review;
+import com.ludo.study.studymatchingplatform.user.service.dto.response.UserResponse;
+
+public record ReviewResponse(
+        Long id,
+        Long studyId,
+        UserResponse reviewer,
+        UserResponse reviewee,
+        // 적극성
+        Long activenessScore,
+        // 전문성
+        Long professionalismScore,
+        // 의사소통
+        Long communicationScore,
+        // 다시함께
+        Long togetherScore,
+        // 추천 여부
+        Long recommendScore
+) {
+
+    public static ReviewResponse from(final Review review) {
+        return new ReviewResponse(
+                review.getId(),
+                review.getStudy().getId(),
+                UserResponse.from(review.getReviewer()),
+                UserResponse.from(review.getReviewee()),
+                review.getActivenessScore(),
+                review.getProfessionalismScore(),
+                review.getCommunicationScore(),
+                review.getTogetherScore(),
+                review.getRecommendScore()
+        );
+    }
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/exception/InvalidReviewPeriodException.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/exception/InvalidReviewPeriodException.java
@@ -1,0 +1,18 @@
+package com.ludo.study.studymatchingplatform.study.service.exception;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+public final class InvalidReviewPeriodException extends IllegalArgumentException {
+
+    private static final String MESSAGE = "%s\n리뷰 작성은 스터디 완료 3일 후인 %s부터 14일 후인 %s까지 가능합니다.";
+
+    public InvalidReviewPeriodException(final String message, final LocalDateTime reviewAvailStartTime, final LocalDateTime reviewAvailEndTime) {
+        super(MESSAGE.formatted(message, formatAvailTime(reviewAvailStartTime), formatAvailTime((reviewAvailEndTime))));
+    }
+
+    private static String formatAvailTime(final LocalDateTime localDateTime) {
+        return localDateTime.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분", Locale.KOREA));
+    }
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/FixedLocalDateTimePicker.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/FixedLocalDateTimePicker.java
@@ -1,0 +1,22 @@
+package com.ludo.study.studymatchingplatform.study.service.study;
+
+import com.ludo.study.studymatchingplatform.common.utils.LocalDateTimePicker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Profile("test")
+@Component
+@RequiredArgsConstructor
+public class FixedLocalDateTimePicker implements LocalDateTimePicker {
+
+    public static final LocalDateTime DEFAULT_FIXED_LOCAL_DATE_TIME = LocalDateTime.of(2000, 1, 1, 0, 0, 0);
+    private final LocalDateTime fixedLocalDateTime = DEFAULT_FIXED_LOCAL_DATE_TIME;
+
+    @Override
+    public LocalDateTime now() {
+        return fixedLocalDateTime;
+    }
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewService.java
@@ -1,0 +1,53 @@
+package com.ludo.study.studymatchingplatform.study.service.study;
+
+import com.ludo.study.studymatchingplatform.common.utils.LocalDateTimePicker;
+import com.ludo.study.studymatchingplatform.study.domain.study.Review;
+import com.ludo.study.studymatchingplatform.study.domain.study.Study;
+import com.ludo.study.studymatchingplatform.study.domain.study.participant.Participant;
+import com.ludo.study.studymatchingplatform.study.repository.study.ReviewRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.study.StudyRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.service.dto.request.study.WriteReviewRequest;
+import com.ludo.study.studymatchingplatform.study.service.dto.response.study.ReviewResponse;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepositoryImpl reviewRepository;
+    private final StudyRepositoryImpl studyRepository;
+    private final LocalDateTimePicker localDateTimePicker;
+
+    public ReviewResponse write(WriteReviewRequest request, Long studyId, User reviewer) {
+        final Study study = studyRepository.findByIdWithParticipants(studyId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디입니다. 리뷰를 작성할 수 없습니다."));
+
+        final Participant participantingReviewer = study.findParticipant(reviewer.getId())
+                .orElseThrow(() -> new IllegalArgumentException("참여 중인 스터디가 아닙니다. 리뷰를 작성할 수 없습니다."));
+        final Participant participantingReviewee = study.findParticipant(request.revieweeId())
+                .orElseThrow(() -> new IllegalArgumentException("스터디에 참여 중인 사용자에게만 리뷰를 작성할 수 있습니다."));
+        if (participantingReviewer == participantingReviewee) {
+            throw new IllegalArgumentException("자기 자신에게는 리뷰를 작성할 수 없습니다.");
+        }
+
+        // 명세 - [스터디가 진행 완료 상태로 바뀐 후 3일 후 부터, 14일 간 리뷰 작성 가능]
+        // 진행 완료 상태로 바뀐 뒤 날짜를 정확히 추적하기 위해서는 추가적인 state 및 논의 필요할듯
+        // -> 일단 EndDateTime 기반으로 작성
+        study.ensureReviewPeriodAvailable(localDateTimePicker);
+
+        final boolean isDuplicateReview = reviewRepository.findAllByStudyId(studyId)
+                .stream().anyMatch(review -> review.isDuplicateReview(studyId, reviewer.getId(), request.revieweeId()));
+        if (isDuplicateReview) {
+            throw new IllegalArgumentException("이미 리뷰를 작성 하셨습니다.");
+        }
+
+        final Review review = request.toReviewWithStudy(study, participantingReviewer.getUser(), participantingReviewee.getUser());
+        return ReviewResponse.from(reviewRepository.save(review));
+
+    }
+
+}

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewServiceTest.java
@@ -1,0 +1,702 @@
+package com.ludo.study.studymatchingplatform.study.service.study;
+
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.Stack;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.StackCategory;
+import com.ludo.study.studymatchingplatform.study.domain.study.Platform;
+import com.ludo.study.studymatchingplatform.study.domain.study.Study;
+import com.ludo.study.studymatchingplatform.study.domain.study.StudyStatus;
+import com.ludo.study.studymatchingplatform.study.domain.study.Way;
+import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
+import com.ludo.study.studymatchingplatform.study.domain.study.participant.Participant;
+import com.ludo.study.studymatchingplatform.study.domain.study.participant.Role;
+import com.ludo.study.studymatchingplatform.study.fixture.recruitment.position.PositionFixture;
+import com.ludo.study.studymatchingplatform.study.fixture.recruitment.stack.StackCategoryFixture;
+import com.ludo.study.studymatchingplatform.study.fixture.recruitment.stack.StackFixture;
+import com.ludo.study.studymatchingplatform.study.fixture.study.StudyFixture;
+import com.ludo.study.studymatchingplatform.study.fixture.study.category.CategoryFixture;
+import com.ludo.study.studymatchingplatform.study.repository.recruitment.RecruitmentRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.recruitment.position.PositionRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.recruitment.stack.StackCategoryRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.recruitment.stack.StackRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.study.StudyRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.study.category.CategoryRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.study.participant.ParticipantRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.service.dto.request.study.WriteReviewRequest;
+import com.ludo.study.studymatchingplatform.study.service.dto.response.study.ReviewResponse;
+import com.ludo.study.studymatchingplatform.study.service.exception.InvalidReviewPeriodException;
+import com.ludo.study.studymatchingplatform.study.service.recruitment.RecruitmentService;
+import com.ludo.study.studymatchingplatform.study.service.recruitment.applicant.StudyApplicantDecisionService;
+import com.ludo.study.studymatchingplatform.study.service.study.participant.ParticipantService;
+import com.ludo.study.studymatchingplatform.user.domain.user.Social;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class ReviewServiceTest {
+
+    @Autowired
+    private ReviewService reviewService;
+
+    @Autowired
+    private UserRepositoryImpl userRepository;
+
+    @Autowired
+    private CategoryRepositoryImpl categoryRepository;
+
+    @Autowired
+    private StudyRepositoryImpl studyRepository;
+
+    @Autowired
+    private PositionRepositoryImpl positionRepository;
+
+    @Autowired
+    private StackRepositoryImpl stackRepository;
+
+    @Autowired
+    private StackCategoryRepositoryImpl stackCategoryRepository;
+
+    @Autowired
+    private RecruitmentRepositoryImpl recruitmentRepository;
+
+    @Autowired
+    private RecruitmentService recruitmentService;
+
+    @Autowired
+    private ParticipantRepositoryImpl participantRepository;
+
+    @Autowired
+    private StudyApplicantDecisionService studyApplicantDecisionService;
+
+    @Autowired
+    private ParticipantService participantService;
+
+    @Autowired
+    private EntityManager em;
+
+
+    @DisplayName("[Success] 스터디가 종료된지 3일 ~ 14일 내에 리뷰를 작성할 수 있다.")
+    @ParameterizedTest
+    @MethodSource("validEndDateTimes")
+    void writeReview(final LocalDateTime endDateTime) {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+
+        final LocalDateTime startDateTime = now.minusDays(20);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final Participant participantB = study.getParticipant(userB);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(participantB.getUser().getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+
+        // when
+        final ReviewResponse review = reviewService.write(request, study.getId(), userA);
+
+        // then
+        assertThat(review.reviewer().email())
+                .isEqualTo(userA.getEmail());
+
+    }
+
+    private static Stream<LocalDateTime> validEndDateTimes() {
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        return Stream.of(
+                now.minusDays(3),
+                now.minusDays(13),
+                now.minusDays(14)
+        );
+
+    }
+
+
+    @DisplayName("[Exception] 스터디가 종료된지 3일 ~ 14일 내가 아니라면 리뷰를 작성할 수 없다.")
+    @ParameterizedTest
+    @MethodSource("invalidEndDateTimes")
+    void writeReviewFailure(final LocalDateTime endDateTime) {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final Participant participantB = study.getParticipant(userB);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(participantB.getUser().getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        // when
+        // then
+        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
+                .isInstanceOf(InvalidReviewPeriodException.class);
+    }
+
+    @DisplayName("[Exception] 스터디가 종료된 후 3일이 지나기 전에는 리뷰를 작성할 수 없으며, 사용자에게 이를 인지하기 위한 적절한 안내 메세지를 보여준다.")
+    @Test
+    void writeReviewFailureBeforeThreeDaysAfterStudyDone() {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(3).plusSeconds(1);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final Participant participantB = study.getParticipant(userB);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(participantB.getUser().getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        // when
+        // then
+        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
+                .isInstanceOf(InvalidReviewPeriodException.class)
+                .hasMessage("아직 리뷰 작성 기간이 되지 않았습니다.\n리뷰 작성은 스터디 완료 3일 후인 2000년 01월 01일 00시 00분부터 14일 후인 2000년 01월 12일 00시 00분까지 가능합니다.");
+
+    }
+
+    @DisplayName("[Exception] 스터디가 종료된 후 14일이 지난 후에는 리뷰를 작성할 수 없으며, 사용자에게 이를 인지하기 위한 적절한 안내 메세지를 보여준다.")
+    @Test
+    void writeReviewFailureAfterFourteenDaysAfterStudyDone() {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(14).minusSeconds(1);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final Participant participantB = study.getParticipant(userB);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(participantB.getUser().getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        // when
+        // then
+        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
+                .isInstanceOf(InvalidReviewPeriodException.class)
+                .hasMessage("리뷰 작성 기간이 지났습니다.\n리뷰 작성은 스터디 완료 3일 후인 1999년 12월 20일 23시 59분부터 14일 후인 2000년 01월 01일 00시 00분까지 가능합니다.");
+
+    }
+
+    private static Stream<LocalDateTime> invalidEndDateTimes() {
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        return Stream.of(
+                now.minusDays(3).plusSeconds(1),
+                now.minusDays(14).minusSeconds(1)
+        );
+
+    }
+
+    @DisplayName("[Exception] 이미 리뷰를 작성한 스터디원에게는 재작성이 불가능하다.")
+    @Test
+    void writeDuplicateReview() {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(3);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final Participant participantB = study.getParticipant(userB);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(participantB.getUser().getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        reviewService.write(request, study.getId(), userA);
+        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 리뷰를 작성 하셨습니다.");
+
+
+    }
+
+    @DisplayName("[Exception] 존재하지 않는 스터디의 리뷰 작성은 불가능하다.")
+    @Test
+    void writeReviewForStudyNotExist() {
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(userB.getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        assertThatThrownBy(() -> reviewService.write(request, 2147483647L, userA))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 스터디입니다. 리뷰를 작성할 수 없습니다.");
+    }
+
+    @DisplayName("[Exception] Reviewee가 스터디원이 아닌 경우, 리뷰 작성이 불가능하다.")
+    @Test
+    void writeReviewToNonParticipants() {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(3);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(userB.getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("스터디에 참여 중인 사용자에게만 리뷰를 작성할 수 있습니다.");
+    }
+
+    @DisplayName("[Exception] Reviewer가 스터디원이 아닌 경우, 리뷰 작성이 불가능하다.")
+    @Test
+    void writeReviewIfNotParticipating() {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(3);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(userB.getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("참여 중인 스터디가 아닙니다. 리뷰를 작성할 수 없습니다.");
+    }
+
+    @DisplayName("[Exception] 자기 자신에게는 리뷰 작성이 불가능하다.")
+    @Test
+    void writeReviewForSelf() {
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(3);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(userA.getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("자기 자신에게는 리뷰를 작성할 수 없습니다.");
+    }
+
+
+    private Study saveStudy(Category category, User owner) {
+        return studyRepository.save(
+                StudyFixture.createStudy(
+                        "study",
+                        category,
+                        owner,
+                        4,
+                        Platform.GATHER
+                )
+        );
+    }
+
+    private Study saveStudy(Category category, User owner, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        return studyRepository.save(
+                Study.builder()
+                        .title("study")
+                        .category(category)
+                        .owner(owner)
+                        .platform(Platform.GATHER)
+                        .startDateTime(startDateTime)
+                        .endDateTime(endDateTime)
+                        .way(Way.ONLINE)
+                        .status(StudyStatus.COMPLETED)
+                        .participantLimit(4)
+                        .participantCount(1)
+                        .build()
+        );
+    }
+
+
+    private User saveOwner() {
+        return userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build()
+        );
+    }
+}


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

리뷰 작성 로직 및 테스트 케이스를 작성하였습니다.

아래 테스트 케이스 DisplayName에 기재된 설명을 통해 검사한 엣지 케이스들을 확인할 수 있습니다.

대략적으로 작성했는데 이후 누락된 부분이 확인된다면 추가할 예정입니다.

<img width="893" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/121966058/708745dd-c4af-42b5-a7d1-9b24c444c6f0">

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

대부분 단순 구현이지만 한가지 특이 사항이 있다면 `LocalDateTimePicker` 인터페이스입니다.

<img width="1121" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/121966058/841fa6f5-8004-44f5-88bd-4f644f66f593">

**스터디 상태가 진행 완료로 바뀐 뒤, 3일 후부터 14일 간 리뷰 작성 가능**이라는 기간 검증이 필요하기 때문에,

테스트 시 `LocalDateTime`과 같은 임의 배정 요소를 스터빙 할 필요가 있어서 1개의 인터페이스와 2개의 구현체를 두었습니다.

```java
// interface
public interface LocalDateTimePicker {
    LocalDateTime now();
}

// impl
@Profile("!test")
@Component
public class LocalDateTimePickerImpl implements LocalDateTimePicker {

    public LocalDateTime now() {
        return LocalDateTime.now();
    }
}

// impl for test
@Profile("test")
@Component
@RequiredArgsConstructor
public class FixedLocalDateTimePicker implements LocalDateTimePicker {

    public static final LocalDateTime DEFAULT_FIXED_LOCAL_DATE_TIME = LocalDateTime.of(2000, 1, 1, 0, 0, 0);
    private final LocalDateTime fixedLocalDateTime = DEFAULT_FIXED_LOCAL_DATE_TIME;

    @Override
    public LocalDateTime now() {
        return fixedLocalDateTime;
    }
}

```

`@Profile` annotation을 통해 profile이 `test`와 아닐 때의 DI 대상체를 자동으로 치환하도록 만들었으며,

이를 반영하기 위해 `ReviewServiceTest`에 `@ActiveProfiles("test")`를 명시 하였습니다.

```java
@SpringBootTest
@Transactional
@ActiveProfiles("test")
public class ReviewServiceTest {
  // ...
}
```

고로 `ReviewServiceTest` 테스트 시 실사용 되는 구현체는 `FixedLocalDateTimePicker`가 되어 `LocalDateTimePicker`로부터 얻는 현재 시간은 2000년도로 고정됩니다.

이 구현체는 `Study` 객체에서 활용합니다.

IOC Container에 Profile에 따라 `LocalDateTimePicker`를 주입 -> `ReviewService`가 IOC Container에서 구현체 가져옴 -> `Study`의 검증 메소드에서 이를 인자로 넘겨 받아서 사용

하는 형태이기 때문에 사용 시 수동 주입할 필요는 없습니다.

다른 곳에서 사용해야 한다면 Profile 설정만 해주면 됩니다.

```java
// Study.java

    public void ensureReviewPeriodAvailable(final LocalDateTimePicker localDateTimePicker) {
        final LocalDateTime now = localDateTimePicker.now();
        final LocalDateTime reviewAvailStartTime = endDateTime.plusDays(3).minusSeconds(1);
        final LocalDateTime reviewAvailEndTime = endDateTime.plusDays(14).plusSeconds(1);

        // Order Specific
        if (isReviewPeriodElapsed(now)) {
            throw new InvalidReviewPeriodException("리뷰 작성 기간이 지났습니다.", reviewAvailStartTime, reviewAvailEndTime);
        }

        if (isNotReviewPeriodYet(now)) {
            throw new InvalidReviewPeriodException("아직 리뷰 작성 기간이 되지 않았습니다.", reviewAvailStartTime, reviewAvailEndTime);
        }

        System.out.println("min avail: " + reviewAvailStartTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
        System.out.println("max avail: " + reviewAvailEndTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
        System.out.println("now : " + now.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));

    }

    public boolean isNotReviewPeriodYet(final LocalDateTime now) {
        final LocalDateTime reviewAvailStartTime = endDateTime.plusDays(3);
        return now.isBefore(reviewAvailStartTime);
    }

    public boolean isReviewPeriodElapsed(final LocalDateTime now) {
        final LocalDateTime reviewAvailEndTime = endDateTime.plusDays(14);
        return now.isAfter(reviewAvailEndTime);
    }
```

특이사항은 `// Order Specific`이라고 명시된 부분의 순서에 유의해야 합니다.

스터디 종료 후 '14일이 지났는가', '3일이 지났는가' 검사는 순서 의존적이기 때문입니다.

3일이 지났는지 먼저 검사하면, 스터디 종료 3일 이후인 시점이 되면 조건문 short circuit과 마찬가지로 절대로 14일이 지났는지 검사하지 않기 때문입니다.

<br><br>

### 💡 필요한 후속작업이 있어요.

이외 review 관련 usecase, testcase 작성

<br><br>

### 💡 다음 자료를 참고하면 좋아요.

현재까지 테스트 커버리지를 기록용으로 저장해두었습니다.

모든 테스트 통과하는 상태입니다.

<img width="1679" alt="Pasted Graphic" src="https://github.com/Ludo-SMP/ludo-backend/assets/121966058/f91b0439-3dfd-4006-b9ed-db1d5e637c6b">

<br><br>

### ✅ 셀프 체크리스트

- [O] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [O] 커밋 메세지를 컨벤션에 맞추었습니다.
- [O] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [O] 변경 후 코드는 기존의 테스트를 통과합니다.
- [O] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
