### PR TITLE
SP-453/feat: 알림 도메인 엔티티 설계

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/config/GlobalNotificationUserConfig.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/config/GlobalNotificationUserConfig.java
@@ -1,0 +1,36 @@
+package com.ludo.study.studymatchingplatform.notification.domain.config;
+
+import com.ludo.study.studymatchingplatform.notification.domain.notification.NotificationEventType;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class GlobalNotificationUserConfig {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "global_notification_user_config_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(nullable = false, columnDefinition = "varchar(10)")
+	private NotificationEventType notificationEventType;
+
+	@Column(name = "\"on\"", nullable = false)
+	private Boolean on;
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordCategory.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordCategory.java
@@ -1,0 +1,31 @@
+package com.ludo.study.studymatchingplatform.notification.domain.keyword;
+
+import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class NotificationKeywordCategory {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "notification_keyword_category_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "category_id")
+	private Category category;
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordPosition.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordPosition.java
@@ -1,0 +1,31 @@
+package com.ludo.study.studymatchingplatform.notification.domain.keyword;
+
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class NotificationKeywordPosition {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "notification_keword_position_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "position_id")
+	private Position position;
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordStack.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordStack.java
@@ -1,0 +1,31 @@
+package com.ludo.study.studymatchingplatform.notification.domain.keyword;
+
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.Stack;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class NotificationKeywordStack {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "notification_keword_stack_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "stack_id")
+	private Stack stack;
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/Notification.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/Notification.java
@@ -1,0 +1,36 @@
+package com.ludo.study.studymatchingplatform.notification.domain.notification;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+
+@Entity
+@DiscriminatorColumn
+@Inheritance(strategy = InheritanceType.JOINED)
+public class Notification {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "notification_id")
+	private Long id;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(nullable = false, columnDefinition = "varchar(10)")
+	private NotificationEventType notificationEventType;
+
+	@Column(nullable = false)
+	private LocalDateTime createdOn;
+
+	@Column(name = "\"read\"", nullable = false)
+	private Boolean read;
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/NotificationEventType.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/NotificationEventType.java
@@ -1,0 +1,23 @@
+package com.ludo.study.studymatchingplatform.notification.domain.notification;
+
+public enum NotificationEventType {
+
+	STUDY_APPLICANT("스터디 지원 현황 알림"),
+
+	STUDY_APPLICANT_RESULT("스터디 지원 결과 알림"),
+
+	STUDY_END_DATE("스터디 종료 기간 알림"),
+
+	STUDY_PARTICIPANT_LEAVE("스터디 탈퇴자 알림"),
+
+	RECRUITMENT("모집 공고 알림"),
+
+	REVIEW("리뷰 평가 알림");
+
+	private final String description;
+
+	NotificationEventType(String description) {
+		this.description = description;
+	}
+	
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/RecruitmentNotification.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/RecruitmentNotification.java
@@ -1,0 +1,22 @@
+package com.ludo.study.studymatchingplatform.notification.domain.notification;
+
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class RecruitmentNotification extends Notification {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "recruitment_id", nullable = false)
+	private Recruitment actor;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User notifier;
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/ReviewNotification.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/ReviewNotification.java
@@ -1,0 +1,19 @@
+package com.ludo.study.studymatchingplatform.notification.domain.notification;
+
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class ReviewNotification extends Notification {
+
+	// TODO: 신뢰도 기능 브랜치 병합 후, Review 엔티티로 수정 필요
+	private Long actor;
+
+	@ManyToOne
+	@JoinColumn(name = "user_id", nullable = false)
+	private User notifier;
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/ReviewNotification.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/ReviewNotification.java
@@ -3,6 +3,7 @@ package com.ludo.study.studymatchingplatform.notification.domain.notification;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
@@ -12,7 +13,7 @@ public class ReviewNotification extends Notification {
 	// TODO: 신뢰도 기능 브랜치 병합 후, Review 엔티티로 수정 필요
 	private Long actor;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User notifier;
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/StudyNotification.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/StudyNotification.java
@@ -1,0 +1,22 @@
+package com.ludo.study.studymatchingplatform.notification.domain.notification;
+
+import com.ludo.study.studymatchingplatform.study.domain.study.Study;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class StudyNotification extends Notification {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "study_id", nullable = false)
+	private Study actor;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User notifier;
+
+}


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

- [x] 알림 기능을 위한 **알림 도메인 엔티티 설계**
  - **관리적 용이함**을 위해 엔티티 연관관계 매핑은 **모두 단방향**으로 설계했습니다.
  - 추 후 **조회 로직에서 객체 그래프 탐색이 필요한 경우에 한하여** 양방향을 도입할 수도 있을 것 같습니다.
  
- comment:
다소 복잡한 `알림 도메인 엔티티 연관 관계`에 대해 피드백을 먼저 받으면 좋을 것 같고, 브랜치 생명 주기를 짧게 가져가는 것이 좋을 것 같아 PR 올립니다. 추 후 수정의 가능성은 있지만, 해당 PR이 approve 되면 큰 틀은 바뀌지 않을 것 같습니다 🙂

<br><br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.
## 모집 공고 알림 키워드
### 엔티티 다이어그램
<img src = "https://github.com/Ludo-SMP/ludo-backend/assets/68291395/43b68817-61dc-4fb3-90d6-6c44770da47f" width = 80%>

### 도메인엔티티: `NotificationKeywordStack`
**요구사항:** 회원은 여러개의 기술스택을 등록할 수 있다.  
**연관관계:**
- **`User -(다)--(다)- Stack`:** 
회원은 여러개의 기술스택 키워드를 등록할 수 있다.
하나의 기술스택은 여러 회원에게 선택될 수 있다.
- **→ 다대다 연관 관계를 일대다, 다대일 연관관계로 풀어냄**
**→ `NotificationKeywordStack`**

### 도메인엔티티: `NotificationKeywordPosition`
**요구사항:** 회원은 여러개의 포지션 키워드를 등록할 수 있다.  
**연관관계:**
- **`User -(다)--(다)- Position`:**
  회원은 여러개의 포지션 키워드를 등록할 수 있다.
  하나의 포지션은 여러 회원에게 선택될 수 있다.
- **→ 다대다 연관 관계를 일대다, 다대일 연관관계로 풀어냄**
**→ `NotificationKeywordPosition`**

### 도메인엔티티: `NotificationKeywordCategory`
**요구사항:** 회원은 여러개의 카테고리 키워드를 등록할 수 있다.
**연관관계:**
- **`User -(다)--(다)- Category`:** 
  회원은 여러개의 카테고리 키워드를 등록할 수 있다.
  하나의 카테고리는 여러 회원에게 선택될 수 있다.
- **→ 다대다 연관 관계를 일대다, 다대일 연관관계로 풀어냄**
**→ `NotificationKeywordCategory`**


<br> <br>

## 알림 설정
### 엔티티 다이어그램
<img src = "https://github.com/Ludo-SMP/ludo-backend/assets/68291395/d47ff3ab-e7ff-45e3-be9c-0160c2f8404a" width = 50%>

### 도메인엔티티: `GlobalNotificationUserConfig`
**요구사항:** 회원은 여러개의 알림 설정을 할 수 있다.
**연관관계:**
- **`User -(1)--(*)- GlobalNotificationUserConfig`:** 
  회원은 여러개의 알림 설정을 할 수 있다.
  하나의 알림 설정은 한명의 회원이 설정한다.
<img src = "https://github.com/Ludo-SMP/ludo-backend/assets/68291395/efc1bc37-f99f-43e9-98e5-9bcd713f8452" width = 40%>


<br> <br>

## 알림
### 엔티티 다이어그램
<img src = "https://github.com/Ludo-SMP/ludo-backend/assets/68291395/41267369-1553-4898-8ebb-c423edc5810d" width = 80%>

### 도메인엔티티:  XXXNotification
**연관 관계:**
- 하나의 actor(알림 발생지)는 여러개의 알림을 발생시킨다.
- 한개의 알림은 한명의 notifer(알림 대상자)에게 전송된다.

### Notification 상속 관계
Join 전략, 단일 테이블 전략 중 **Join 전략으로 선택** 하였습니다.
데이터가 많지 않은 현재 시점에서는 정규화 된 테이블 구조로 가져가고,   
추후 데이터가 쌓였을 때 반 정규화를 논의하는 것이 적합하다고 판단했습니다.

<br><br>

## 💡 변경된 사안이 있어요.
### 기존에 설계했던 `Notification_Event_Type` 테이블을 제거했습니다.
- 이에 따라 기존에 notification_event_type_id 를 외래키로 참조하고 있던 테이블은 `NotificationEventType` Enum(varchar) 컬럼을 갖도록 변경했습니다.

- 기존대로 진행할 경우, 알림을 조회할 때마다 알림유형 테이블을 조인해야할 가능성이 있습니다.
- 알림 데이터의 경우 data growth 비율이 높을 것으로 추정되어 이는 곧 성능에도 좋지 않은 영향이 있을 것으로 예상했습니다.
- 기존 방식의 경우 데이터 정합성을 편리하게 유지할 수 있는 장점이 있습니다. 하지만 알림 유형 컬럼을 자주 바꾸지 않을 것으로 생각됩니다.
- 이러한 이유들을 종합하여 진행하였는데, 관련하여 편하게 코멘트 남겨주시면 좋을 것 같습니다 🙂

<br><br>

## 💡 필요한 후속작업이 있어요.

- 알림 엔티티에 Review 엔티티 반영

<br><br>

### ✅ 셀프 체크리스트

- [o] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [o] 커밋 메세지를 컨벤션에 맞추었습니다.
- [o] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [o] 변경 후 코드는 기존의 테스트를 통과합니다.
- [o] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [o] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
