### PR TITLE
SP-545/test: integrationTest setup 및 test 시간 최적화를 위한 service 구조 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .idea/**/usage.statistics.xml
 .idea/**/dictionaries
 .idea/**/shelf
+.idea/material_theme_project_new.xml
 
 # AWS User-specific
 .idea/**/aws.xml
@@ -167,3 +168,4 @@ src/main/generated/
 front-test-app/
 
 .env*
+

--- a/.idea/modules/study-matching-platform.integrationTest.iml
+++ b/.idea/modules/study-matching-platform.integrationTest.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../src/main/generated">
+      <sourceFolder url="file://$MODULE_DIR$/../../src/main/generated" isTestSource="false" generated="true" />
+    </content>
+    <content url="file://$MODULE_DIR$/../../src/integrationTest" dumb="true">
+      <sourceFolder url="file://$MODULE_DIR$/../../src/integrationTest/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../src/integrationTest/resources" type="java-resource" />
+    </content>
+  </component>
+</module>

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.1'
     id 'io.spring.dependency-management' version '1.1.4'
+    id 'org.unbroken-dome.test-sets' version '4.1.0'
 }
 
 group = 'com.ludo.study'
@@ -80,4 +81,12 @@ clean {
 }
 tasks.withType(JavaCompile) {
     options.generatedSourceOutputDirectory = file(querydslSrcDir)
+}
+
+tasks.withType(Test) {
+    useJUnitPlatform()
+}
+
+testSets {
+    integrationTest
 }

--- a/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/RecruitmentFixture.java
+++ b/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/RecruitmentFixture.java
@@ -1,0 +1,80 @@
+package com.ludo.study.studymatchingplatform.study.fixture.recruitment;
+
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.Contact;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.RecruitmentPosition;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.RecruitmentStack;
+import com.ludo.study.studymatchingplatform.study.domain.study.Study;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+public class RecruitmentFixture {
+
+	public static Recruitment createRecruitment(Study study, String title, String content,
+												int hits, String callUrl,
+												LocalDateTime endDateTime
+	) {
+		endDateTime =
+				endDateTime == null ? LocalDateTime.now().plusDays(5).truncatedTo(ChronoUnit.MICROS) : endDateTime;
+		return Recruitment.builder()
+				.study(study)
+				.contact(Contact.KAKAO)
+				.callUrl(callUrl)
+				.content(content)
+				.applicantCount(3)
+				.recruitmentEndDateTime(endDateTime)
+				.title(title)
+				.hits(hits)
+				.build();
+	}
+
+	public static Recruitment createRecruitmentWithoutStacksAndPositions(Study study, String title, String content,
+																		 String callUrl, LocalDateTime endDateTime) {
+		endDateTime =
+				endDateTime == null ? LocalDateTime.now().plusDays(5).truncatedTo(ChronoUnit.MICROS) : endDateTime;
+		return Recruitment.builder()
+				.study(study)
+				.contact(Contact.KAKAO)
+				.callUrl(callUrl)
+				.applicantCount(3)
+				.content(content)
+				.title(title)
+				.hits(0)
+				.recruitmentEndDateTime(endDateTime)
+				.modifiedDateTime(LocalDateTime.now())
+				.build();
+	}
+
+	public static Recruitment createRecruitment(Study study, String title, String content,
+												String callUrl,
+												List<RecruitmentStack> recruitmentStacks,
+												List<RecruitmentPosition> recruitmentPositions
+	) {
+		return createRecruitment(
+				study,
+				title,
+				content,
+				callUrl,
+				recruitmentStacks,
+				recruitmentPositions
+		);
+	}
+
+	public static Recruitment createRecruitment(Long id, Study study, String title, String content, Integer hits,
+												String callUrl, LocalDateTime endDateTime) {
+		return Recruitment.builder()
+				.id(id)
+				.study(study)
+				.contact(Contact.KAKAO)
+				.callUrl(callUrl)
+				.content(content)
+				.applicantCount(3)
+				.recruitmentEndDateTime(endDateTime.truncatedTo(ChronoUnit.MICROS))
+				.title(title)
+				.hits(hits)
+				.build();
+	}
+
+}

--- a/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/applicant/ApplicantFixture.java
+++ b/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/applicant/ApplicantFixture.java
@@ -1,0 +1,44 @@
+package com.ludo.study.studymatchingplatform.study.fixture.recruitment.applicant;
+
+import com.ludo.study.studymatchingplatform.study.domain.id.ApplicantId;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.applicant.Applicant;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.applicant.ApplicantStatus;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+
+public class ApplicantFixture {
+
+	public static Applicant createApplicant(User user, Recruitment recruitment) {
+		return Applicant.builder()
+				.user(user)
+				.applicantStatus(ApplicantStatus.UNCHECKED)
+				.recruitment(recruitment)
+				.build();
+	}
+
+	public static Applicant createApplicant(Recruitment recruitment,
+											User user,
+											Position position) {
+		return Applicant.builder()
+				.recruitment(recruitment)
+				.user(user)
+				.position(position)
+				.applicantStatus(ApplicantStatus.UNCHECKED)
+				.build();
+	}
+
+	public static Applicant createApplicant(ApplicantId applicantId,
+											Recruitment recruitment,
+											User user,
+											Position position) {
+		return Applicant.builder()
+				.id(applicantId)
+				.recruitment(recruitment)
+				.user(user)
+				.position(position)
+				.applicantStatus(ApplicantStatus.UNCHECKED)
+				.build();
+	}
+
+}

--- a/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/position/PositionFixture.java
+++ b/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/position/PositionFixture.java
@@ -1,0 +1,21 @@
+package com.ludo.study.studymatchingplatform.study.fixture.recruitment.position;
+
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
+
+public class PositionFixture {
+
+	public static Position createPosition(String name) {
+		return Position.builder()
+				.name(name)
+				.build();
+
+	}
+
+	public static Position createPosition(Long id, String name) {
+		return Position.builder()
+				.id(id)
+				.name(name)
+				.build();
+	}
+
+}

--- a/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/position/RecruitmentPositionFixture.java
+++ b/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/position/RecruitmentPositionFixture.java
@@ -1,0 +1,21 @@
+package com.ludo.study.studymatchingplatform.study.fixture.recruitment.position;
+
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.RecruitmentPosition;
+
+public class RecruitmentPositionFixture {
+
+	public static RecruitmentPosition createRecruitmentPosition(Position position) {
+		return RecruitmentPosition.builder()
+				.position(position)
+				.build();
+	}
+
+	public static RecruitmentPosition createRecruitmentPosition(Recruitment recruitment, Position position) {
+		return RecruitmentPosition.builder()
+				.recruitment(recruitment)
+				.position(position)
+				.build();
+	}
+}

--- a/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/stack/RecruitmentStackFixture.java
+++ b/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/stack/RecruitmentStackFixture.java
@@ -1,0 +1,21 @@
+package com.ludo.study.studymatchingplatform.study.fixture.recruitment.stack;
+
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.RecruitmentStack;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.Stack;
+
+public class RecruitmentStackFixture {
+
+	public static RecruitmentStack createRecruitmentStack(Stack stack) {
+		return RecruitmentStack.builder()
+				.stack(stack)
+				.build();
+	}
+
+	public static RecruitmentStack createRecruitmentStack(Recruitment recruitment, Stack stack) {
+		return RecruitmentStack.builder()
+				.recruitment(recruitment)
+				.stack(stack)
+				.build();
+	}
+}

--- a/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/stack/StackCategoryFixture.java
+++ b/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/stack/StackCategoryFixture.java
@@ -1,0 +1,13 @@
+package com.ludo.study.studymatchingplatform.study.fixture.recruitment.stack;
+
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.StackCategory;
+
+public class StackCategoryFixture {
+
+	public static StackCategory createStackCategory(final String name) {
+		return StackCategory.builder()
+				.name(name)
+				.build();
+	}
+
+}

--- a/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/stack/StackFixture.java
+++ b/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/recruitment/stack/StackFixture.java
@@ -1,0 +1,20 @@
+package com.ludo.study.studymatchingplatform.study.fixture.recruitment.stack;
+
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.Stack;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.StackCategory;
+
+public class StackFixture {
+
+	private static Stack createStack(String name, StackCategory stackCategory, int companyCount) {
+		return Stack.builder()
+				.name(name)
+				.stackCategory(stackCategory)
+				.companyCount(companyCount)
+				.build();
+	}
+
+	public static Stack createStack(String name, StackCategory stackCategory) {
+		return createStack(name, stackCategory, 0);
+	}
+
+}

--- a/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/study/StudyFixture.java
+++ b/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/study/StudyFixture.java
@@ -1,0 +1,98 @@
+package com.ludo.study.studymatchingplatform.study.fixture.study;
+
+import com.ludo.study.studymatchingplatform.study.domain.study.Platform;
+import com.ludo.study.studymatchingplatform.study.domain.study.Study;
+import com.ludo.study.studymatchingplatform.study.domain.study.StudyStatus;
+import com.ludo.study.studymatchingplatform.study.domain.study.Way;
+import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
+import com.ludo.study.studymatchingplatform.study.fixture.study.category.CategoryFixture;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+
+import java.time.LocalDateTime;
+
+public class StudyFixture {
+
+	public static Study createStudy(StudyStatus studyStatus, String title, Way way, Category category, User user,
+									int participantCount, int participantLimit, Platform platform, String platformUrl
+	) {
+		return Study.builder()
+				.status(studyStatus)
+				.platform(platform)
+				.platformUrl(platformUrl)
+				.category(category)
+				.owner(user)
+				.title(title)
+				.way(way)
+				.participantCount(participantCount)
+				.participantLimit(participantLimit)
+				.startDateTime(LocalDateTime.now())
+				.endDateTime(LocalDateTime.now())
+				.build();
+	}
+
+	public static Study createStudy(String title, Category category, User user,
+									int participantLimit, Platform platform
+	) {
+		return createStudy(
+				StudyStatus.RECRUITING,
+				title,
+				Way.ONLINE,
+				category,
+				user,
+				0,
+				participantLimit,
+				platform,
+				"www.platformUrl.com"
+		);
+	}
+
+	public static Study createStudy(User user, String title, int participantLimit,
+									StudyStatus studyStatus) {
+		return createStudy(
+				studyStatus,
+				title,
+				Way.ONLINE,
+				CategoryFixture.createCategory(CategoryFixture.PROJECT),
+				user,
+				0,
+				participantLimit,
+				Platform.GATHER,
+				"www.platformUrl.com");
+	}
+
+	public static Study createStudy(Long id, String title, Way way, Category category, User user,
+									Integer participantCount, Integer participantLimit) {
+		return Study.builder()
+				.id(id)
+				.status(StudyStatus.RECRUITING)
+				.platform(Platform.GATHER)
+				.category(category)
+				.owner(user)
+				.title(title)
+				.way(way)
+				.participantCount(participantCount)
+				.participantLimit(participantLimit)
+				.startDateTime(LocalDateTime.now())
+				.endDateTime(LocalDateTime.now().plusDays(5))
+				.build();
+	}
+
+	public static Study createStudy(Long id, String title, Way way, Category category, User user,
+									Integer participantCount, Integer participantLimit,
+									LocalDateTime startDateTime, LocalDateTime endDateTime) {
+		return Study.builder()
+				.id(id)
+				.status(StudyStatus.RECRUITING)
+				.platform(Platform.GATHER)
+				.category(category)
+				.owner(user)
+				.title(title)
+				.way(way)
+				.participantCount(participantCount)
+				.participantLimit(participantLimit)
+				.startDateTime(startDateTime)
+				.endDateTime(endDateTime)
+				.build();
+	}
+
+}

--- a/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/study/category/CategoryFixture.java
+++ b/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/study/category/CategoryFixture.java
@@ -1,0 +1,24 @@
+package com.ludo.study.studymatchingplatform.study.fixture.study.category;
+
+import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
+
+public class CategoryFixture {
+
+	public static final String PROJECT = "프로젝트";
+	public static final String CODING_TEST = "코딩 테스트";
+	public static final String INTERVIEW = "모의 면접";
+
+	public static Category createCategory(String name) {
+		return Category.builder()
+				.name(name)
+				.build();
+	}
+
+	public static Category createCategory(Long id, String name) {
+		return Category.builder()
+				.id(id)
+				.name(name)
+				.build();
+	}
+
+}

--- a/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/study/participant/ParticipantFixture.java
+++ b/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/fixture/study/participant/ParticipantFixture.java
@@ -1,0 +1,20 @@
+package com.ludo.study.studymatchingplatform.study.fixture.study.participant;
+
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
+import com.ludo.study.studymatchingplatform.study.domain.study.Study;
+import com.ludo.study.studymatchingplatform.study.domain.study.participant.Participant;
+import com.ludo.study.studymatchingplatform.study.domain.study.participant.Role;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+
+public class ParticipantFixture {
+
+	public static Participant createParticipant(Study study, User user, Position position, Role role) {
+		return Participant.builder()
+				.study(study)
+				.user(user)
+				.role(role)
+				.position(position)
+				.build();
+	}
+
+}

--- a/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewFacadeTest.java
+++ b/src/integrationTest/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewFacadeTest.java
@@ -1,0 +1,781 @@
+package com.ludo.study.studymatchingplatform.study.service.study;
+
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.Stack;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.StackCategory;
+import com.ludo.study.studymatchingplatform.study.domain.study.Platform;
+import com.ludo.study.studymatchingplatform.study.domain.study.Study;
+import com.ludo.study.studymatchingplatform.study.domain.study.StudyStatus;
+import com.ludo.study.studymatchingplatform.study.domain.study.Way;
+import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
+import com.ludo.study.studymatchingplatform.study.domain.study.participant.Participant;
+import com.ludo.study.studymatchingplatform.study.domain.study.participant.Role;
+import com.ludo.study.studymatchingplatform.study.fixture.recruitment.position.PositionFixture;
+import com.ludo.study.studymatchingplatform.study.fixture.recruitment.stack.StackCategoryFixture;
+import com.ludo.study.studymatchingplatform.study.fixture.recruitment.stack.StackFixture;
+import com.ludo.study.studymatchingplatform.study.fixture.study.StudyFixture;
+import com.ludo.study.studymatchingplatform.study.fixture.study.category.CategoryFixture;
+import com.ludo.study.studymatchingplatform.study.repository.recruitment.RecruitmentRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.recruitment.position.PositionRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.recruitment.stack.StackCategoryRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.recruitment.stack.StackRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.study.StudyRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.study.category.CategoryRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.study.participant.ParticipantRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.service.dto.request.study.WriteReviewRequest;
+import com.ludo.study.studymatchingplatform.study.service.dto.response.study.ReviewResponse;
+import com.ludo.study.studymatchingplatform.study.service.exception.InvalidReviewPeriodException;
+import com.ludo.study.studymatchingplatform.study.service.recruitment.RecruitmentService;
+import com.ludo.study.studymatchingplatform.study.service.recruitment.applicant.StudyApplicantDecisionService;
+import com.ludo.study.studymatchingplatform.study.service.study.participant.ParticipantService;
+import com.ludo.study.studymatchingplatform.user.domain.user.Social;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class ReviewFacadeTest {
+
+    @Autowired
+    private ReviewService reviewService;
+
+    @Autowired
+    private UserRepositoryImpl userRepository;
+
+    @Autowired
+    private CategoryRepositoryImpl categoryRepository;
+
+    @Autowired
+    private StudyRepositoryImpl studyRepository;
+
+    @Autowired
+    private PositionRepositoryImpl positionRepository;
+
+    @Autowired
+    private StackRepositoryImpl stackRepository;
+
+    @Autowired
+    private StackCategoryRepositoryImpl stackCategoryRepository;
+
+    @Autowired
+    private RecruitmentRepositoryImpl recruitmentRepository;
+
+    @Autowired
+    private RecruitmentService recruitmentService;
+
+    @Autowired
+    private ParticipantRepositoryImpl participantRepository;
+
+    @Autowired
+    private StudyApplicantDecisionService studyApplicantDecisionService;
+
+    @Autowired
+    private ParticipantService participantService;
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private ReviewFacade reviewFacade;
+
+    // FIXME: mocking
+//
+//    @DisplayName("[Exception] 이미 리뷰를 작성한 스터디원에게는 재작성이 불가능하다.")
+//    @Test
+//    void writeDuplicateReview() {
+//        // given
+//        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+//        final LocalDateTime endDateTime = now.minusDays(3);
+//
+//        final User reviewer = User.builder()
+//                .id(1L)
+//                .nickname("reviewer")
+//                .email("reviewer@aa.aa")
+//                .build();
+//        final User reviewee = User.builder()
+//                .id(2L)
+//                .nickname("reviewee")
+//                .email("reviewee@aa.aa")
+//                .build();
+//        final Study study = Study.builder()
+//                .owner(reviewer)
+//                .endDateTime(endDateTime)
+//                .build();
+//        final Position position = Position.builder()
+//                .name("position")
+//                .build();
+//        study.addParticipant(reviewer, position, Role.OWNER);
+//        study.addParticipant(reviewee, position, Role.MEMBER);
+//
+//        final WriteReviewRequest request = WriteReviewRequest.builder()
+//                .revieweeId(reviewee.getId())
+//                .activenessScore(5L)
+//                .professionalismScore(5L)
+//                .communicationScore(5L)
+//                .togetherScore(5L)
+//                .recommendScore(5L)
+//                .build();
+//
+//        // when
+//        // then
+//        reviewFacade.write(request, study.getId(), userA);
+//        assertThatThrownBy(() -> reviewFacade.write(request, study.getId(), userA))
+//                .isInstanceOf(IllegalArgumentException.class)
+//                .hasMessage("이미 리뷰를 작성 하셨습니다.");
+//
+//
+//    }
+//
+//    @DisplayName("[Exception] 존재하지 않는 스터디의 리뷰 작성은 불가능하다.")
+//    @Test
+//    void writeReviewForStudyNotExist() {
+//        final User userA = userRepository.save(
+//                User.builder()
+//                        .nickname("userA")
+//                        .email("userA@aa.aa")
+//                        .social(Social.KAKAO)
+//                        .build());
+//        final User userB = userRepository.save(
+//                User.builder()
+//                        .nickname("userB")
+//                        .email("userB@aa.aa")
+//                        .social(Social.KAKAO)
+//                        .build());
+//        final WriteReviewRequest request = WriteReviewRequest.builder()
+//                .revieweeId(userB.getId())
+//                .activenessScore(5L)
+//                .professionalismScore(5L)
+//                .communicationScore(5L)
+//                .togetherScore(5L)
+//                .recommendScore(5L)
+//                .build();
+//
+//        assertThatThrownBy(() -> reviewFacade.write(request, 2147483647L, userA))
+//                .isInstanceOf(IllegalArgumentException.class)
+//                .hasMessage("존재하지 않는 스터디입니다. 리뷰를 작성할 수 없습니다.");
+//    }
+
+    @DisplayName("[Success] 스터디가 종료된지 3일 ~ 14일 내에 리뷰를 작성할 수 있다.")
+    @ParameterizedTest
+    @MethodSource("validEndDateTimes")
+    void writeReview(final LocalDateTime endDateTime) {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+
+        final LocalDateTime startDateTime = now.minusDays(20);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final Participant participantB = study.getParticipant(userB);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(participantB.getUser().getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+
+        // when
+        final ReviewResponse review = reviewFacade.write(request, study.getId(), userA);
+
+        // then
+        assertThat(review.reviewer().email())
+                .isEqualTo(userA.getEmail());
+
+    }
+
+    private static Stream<LocalDateTime> validEndDateTimes() {
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        return Stream.of(
+                now.minusDays(3),
+                now.minusDays(13),
+                now.minusDays(14)
+        );
+
+    }
+
+
+    @DisplayName("[Exception] 스터디가 종료된지 3일 ~ 14일 내가 아니라면 리뷰를 작성할 수 없다.")
+    @ParameterizedTest
+    @MethodSource("invalidEndDateTimes")
+    void writeReviewFailure(final LocalDateTime endDateTime) {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final Participant participantB = study.getParticipant(userB);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(participantB.getUser().getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        // when
+        // then
+        assertThatThrownBy(() -> reviewFacade.write(request, study.getId(), userA))
+                .isInstanceOf(InvalidReviewPeriodException.class);
+    }
+
+    @DisplayName("[Exception] 스터디가 종료된 후 3일이 지나기 전에는 리뷰를 작성할 수 없으며, 사용자에게 이를 인지하기 위한 적절한 안내 메세지를 보여준다.")
+    @Test
+    void writeReviewFailureBeforeThreeDaysAfterStudyDone() {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(3).plusSeconds(1);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final Participant participantB = study.getParticipant(userB);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(participantB.getUser().getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        // when
+        // then
+        assertThatThrownBy(() -> reviewFacade.write(request, study.getId(), userA))
+                .isInstanceOf(InvalidReviewPeriodException.class)
+                .hasMessage("아직 리뷰 작성 기간이 되지 않았습니다.\n리뷰 작성은 스터디 완료 3일 후인 2000년 01월 01일 00시 00분부터 14일 후인 2000년 01월 12일 00시 00분까지 가능합니다.");
+
+    }
+
+    @DisplayName("[Exception] 스터디가 종료된 후 14일이 지난 후에는 리뷰를 작성할 수 없으며, 사용자에게 이를 인지하기 위한 적절한 안내 메세지를 보여준다.")
+    @Test
+    void writeReviewFailureAfterFourteenDaysAfterStudyDone() {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(14).minusSeconds(1);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final Participant participantB = study.getParticipant(userB);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(participantB.getUser().getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        // when
+        // then
+        assertThatThrownBy(() -> reviewFacade.write(request, study.getId(), userA))
+                .isInstanceOf(InvalidReviewPeriodException.class)
+                .hasMessage("리뷰 작성 기간이 지났습니다.\n리뷰 작성은 스터디 완료 3일 후인 1999년 12월 20일 23시 59분부터 14일 후인 2000년 01월 01일 00시 00분까지 가능합니다.");
+
+    }
+
+    private static Stream<LocalDateTime> invalidEndDateTimes() {
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        return Stream.of(
+                now.minusDays(3).plusSeconds(1),
+                now.minusDays(14).minusSeconds(1)
+        );
+
+    }
+
+    @DisplayName("[Exception] 이미 리뷰를 작성한 스터디원에게는 재작성이 불가능하다.")
+    @Test
+    void writeDuplicateReview() {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(3);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final Participant participantB = study.getParticipant(userB);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(participantB.getUser().getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        reviewFacade.write(request, study.getId(), userA);
+        assertThatThrownBy(() -> reviewFacade.write(request, study.getId(), userA))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 리뷰를 작성 하셨습니다.");
+
+
+    }
+
+    @DisplayName("[Exception] 존재하지 않는 스터디의 리뷰 작성은 불가능하다.")
+    @Test
+    void writeReviewForStudyNotExist() {
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(userB.getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        assertThatThrownBy(() -> reviewFacade.write(request, 2147483647L, userA))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 스터디입니다. 리뷰를 작성할 수 없습니다.");
+    }
+
+    @DisplayName("[Exception] Reviewee가 스터디원이 아닌 경우, 리뷰 작성이 불가능하다.")
+    @Test
+    void writeReviewToNonParticipants() {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(3);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(userB.getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        assertThatThrownBy(() -> reviewFacade.write(request, study.getId(), userA))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("스터디에 참여 중인 사용자에게만 리뷰를 작성할 수 있습니다.");
+    }
+
+    @DisplayName("[Exception] Reviewer가 스터디원이 아닌 경우, 리뷰 작성이 불가능하다.")
+    @Test
+    void writeReviewIfNotParticipating() {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(3);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(userB.getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        assertThatThrownBy(() -> reviewFacade.write(request, study.getId(), userA))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("참여 중인 스터디가 아닙니다. 리뷰를 작성할 수 없습니다.");
+    }
+
+    @DisplayName("[Exception] 자기 자신에게는 리뷰 작성이 불가능하다.")
+    @Test
+    void writeReviewForSelf() {
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(3);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(userA.getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        assertThatThrownBy(() -> reviewFacade.write(request, study.getId(), userA))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("자기 자신에게는 리뷰를 작성할 수 없습니다.");
+    }
+
+
+    private Study saveStudy(Category category, User owner) {
+        return studyRepository.save(
+                StudyFixture.createStudy(
+                        "study",
+                        category,
+                        owner,
+                        4,
+                        Platform.GATHER
+                )
+        );
+    }
+
+    private Study saveStudy(Category category, User owner, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        return studyRepository.save(
+                Study.builder()
+                        .title("study")
+                        .category(category)
+                        .owner(owner)
+                        .platform(Platform.GATHER)
+                        .startDateTime(startDateTime)
+                        .endDateTime(endDateTime)
+                        .way(Way.ONLINE)
+                        .status(StudyStatus.COMPLETED)
+                        .participantLimit(4)
+                        .participantCount(1)
+                        .build()
+        );
+    }
+
+
+    private User saveOwner() {
+        return userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build()
+        );
+    }
+}

--- a/src/integrationTest/java/com/ludo/study/studymatchingplatform/user/fixture/user/UserFixture.java
+++ b/src/integrationTest/java/com/ludo/study/studymatchingplatform/user/fixture/user/UserFixture.java
@@ -1,0 +1,25 @@
+package com.ludo.study.studymatchingplatform.user.fixture.user;
+
+import com.ludo.study.studymatchingplatform.user.domain.user.Social;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+
+public class UserFixture {
+
+	public static User createUser(Social social, String nickname, String email) {
+		return User.builder()
+				.social(social)
+				.nickname(nickname)
+				.email(email)
+				.build();
+	}
+
+	public static User createUserWithId(Long userId, Social social, String nickname, String email) {
+		return User.builder()
+				.id(userId)
+				.social(social)
+				.nickname(nickname)
+				.email(email)
+				.build();
+	}
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/common/utils/LocalDateTimePicker.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/utils/LocalDateTimePicker.java
@@ -1,0 +1,7 @@
+package com.ludo.study.studymatchingplatform.common.utils;
+
+import java.time.LocalDateTime;
+
+public interface LocalDateTimePicker {
+    LocalDateTime now();
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/common/utils/LocalDateTimePickerImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/utils/LocalDateTimePickerImpl.java
@@ -1,0 +1,15 @@
+package com.ludo.study.studymatchingplatform.common.utils;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Profile("!test")
+@Component
+public class LocalDateTimePickerImpl implements LocalDateTimePicker {
+
+    public LocalDateTime now() {
+        return LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/controller/ReviewController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/controller/ReviewController.java
@@ -1,0 +1,39 @@
+package com.ludo.study.studymatchingplatform.study.controller;
+
+import com.ludo.study.studymatchingplatform.auth.common.AuthUser;
+import com.ludo.study.studymatchingplatform.common.annotation.DataFieldName;
+import com.ludo.study.studymatchingplatform.study.service.dto.request.study.WriteReviewRequest;
+import com.ludo.study.studymatchingplatform.study.service.dto.response.study.ReviewResponse;
+import com.ludo.study.studymatchingplatform.study.service.study.ReviewService;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+@Validated
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @PostMapping("/studies/{studyId}/reviews")
+    @ResponseStatus(HttpStatus.CREATED)
+    @DataFieldName("review")
+    @Operation(description = "리뷰 작성")
+    @ApiResponse(description = "리뷰 작성 성공", responseCode = "201", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
+    public ReviewResponse write(@Parameter(hidden = true) @AuthUser final User user, @PathVariable("studyId") Long studyId, @Valid @RequestBody WriteReviewRequest request) {
+        return reviewService.write(request, studyId, user);
+    }
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/controller/ReviewController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/controller/ReviewController.java
@@ -4,7 +4,7 @@ import com.ludo.study.studymatchingplatform.auth.common.AuthUser;
 import com.ludo.study.studymatchingplatform.common.annotation.DataFieldName;
 import com.ludo.study.studymatchingplatform.study.service.dto.request.study.WriteReviewRequest;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.study.ReviewResponse;
-import com.ludo.study.studymatchingplatform.study.service.study.ReviewService;
+import com.ludo.study.studymatchingplatform.study.service.study.ReviewFacade;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.*;
 @Validated
 public class ReviewController {
 
-    private final ReviewService reviewService;
+    private final ReviewFacade reviewFacade;
 
     @PostMapping("/studies/{studyId}/reviews")
     @ResponseStatus(HttpStatus.CREATED)
@@ -33,7 +33,7 @@ public class ReviewController {
     @Operation(description = "리뷰 작성")
     @ApiResponse(description = "리뷰 작성 성공", responseCode = "201", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
     public ReviewResponse write(@Parameter(hidden = true) @AuthUser final User user, @PathVariable("studyId") Long studyId, @Valid @RequestBody WriteReviewRequest request) {
-        return reviewService.write(request, studyId, user);
+        return reviewFacade.write(request, studyId, user);
     }
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Review.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Review.java
@@ -1,0 +1,58 @@
+package com.ludo.study.studymatchingplatform.study.domain.study;
+
+import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Slf4j
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "study_id")
+    private Study study;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "reviewer_id")
+    private User reviewer;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "reviewee_id")
+    private User reviewee;
+
+    // 적극성
+    private Long activenessScore;
+
+    // 전문성
+    private Long professionalismScore;
+
+    // 의사소통
+    private Long communicationScore;
+
+    // 다시함께
+    private Long togetherScore;
+
+    // 추천 여부
+    private Long recommendScore;
+
+    public boolean isDuplicateReview(final Long studyId, final Long reviewerId, final Long revieweeId) {
+        return study.getId() == studyId && reviewer.getId() == reviewerId && reviewee.getId() == revieweeId;
+    }
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Study.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Study.java
@@ -1,41 +1,26 @@
 package com.ludo.study.studymatchingplatform.study.domain.study;
 
-import static jakarta.persistence.FetchType.*;
-
-import java.time.LocalDateTime;
-import java.time.Period;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
 import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
+import com.ludo.study.studymatchingplatform.common.utils.LocalDateTimePicker;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.applicant.Applicant;
 import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
 import com.ludo.study.studymatchingplatform.study.domain.study.participant.Participant;
 import com.ludo.study.studymatchingplatform.study.domain.study.participant.Role;
+import com.ludo.study.studymatchingplatform.study.service.exception.InvalidReviewPeriodException;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.Size;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
 @Getter
@@ -45,294 +30,339 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class Study extends BaseEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "study_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "study_id")
+    private Long id;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, columnDefinition = "char(10)")
-	private StudyStatus status;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "char(10)")
+    private StudyStatus status;
 
-	@ManyToOne(fetch = LAZY)
-	@JoinColumn(name = "category_id", nullable = false)
-	private Category category;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
 
-	@ManyToOne(fetch = LAZY)
-	@JoinColumn(name = "owner_id", nullable = false)
-	private User owner;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "owner_id", nullable = false)
+    private User owner;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, columnDefinition = "char(20)")
-	private Platform platform;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "char(20)")
+    private Platform platform;
 
-	@Column(nullable = true, length = 2048)
-	@Size(max = 2048)
-	private String platformUrl;
+    @Column(nullable = true, length = 2048)
+    @Size(max = 2048)
+    private String platformUrl;
 
-	@Column(nullable = false, length = 50)
-	private String title;
+    @Column(nullable = false, length = 50)
+    private String title;
 
-	@OneToOne(mappedBy = "study", fetch = LAZY)
-	private Recruitment recruitment;
+    @OneToOne(mappedBy = "study", fetch = LAZY)
+    private Recruitment recruitment;
 
-	@OneToMany(mappedBy = "study", fetch = LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-	@Builder.Default
-	private List<Participant> participants = new ArrayList<>();
+    @OneToMany(mappedBy = "study", fetch = LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Participant> participants = new ArrayList<>();
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, columnDefinition = "char(10)")
-	private Way way;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "char(10)")
+    private Way way;
 
-	@Column(nullable = false)
-	private Integer participantLimit;
+    @Column(nullable = false)
+    private Integer participantLimit;
 
-	// null 제거 필요
-	@Column(nullable = false)
-	private Integer participantCount;
+    // null 제거 필요
+    @Column(nullable = false)
+    private Integer participantCount;
 
-	@Column(nullable = false)
-	private LocalDateTime startDateTime;
+    @Column(nullable = false)
+    private LocalDateTime startDateTime;
 
-	@Column(nullable = false)
-	private LocalDateTime endDateTime;
+    @Column(nullable = false)
+    private LocalDateTime endDateTime;
 
-	public void addParticipant(final Participant participant) {
-		this.participants.add(participant);
-		this.participantCount = this.participants.size();
-	}
+    public void addParticipant(final Participant participant) {
+        this.participants.add(participant);
+        this.participantCount = this.participants.size();
+    }
 
-	public void registerRecruitment(final Recruitment recruitment) {
-		this.recruitment = recruitment;
-		this.recruitment.connectToStudy(this);
-	}
+    public void registerRecruitment(final Recruitment recruitment) {
+        this.recruitment = recruitment;
+        this.recruitment.connectToStudy(this);
+    }
 
-	public void changeStatus(final StudyStatus status) {
-		this.status = status;
-	}
+    public void changeStatus(final StudyStatus status) {
+        this.status = status;
+    }
 
-	public void addRecruitment(Recruitment recruitment) {
-		this.recruitment = recruitment;
-	}
+    public void addRecruitment(Recruitment recruitment) {
+        this.recruitment = recruitment;
+    }
 
-	public Integer getParticipantCount() {
-		return participants.size();
-	}
+    public Integer getParticipantCount() {
+        return participants.size();
+    }
 
-	public String getCategoryByName() {
-		return category.getName();
-	}
+    public String getCategoryByName() {
+        return category.getName();
+    }
 
-	public Long getCategoryId() {
-		return category.getId();
-	}
+    public Long getCategoryId() {
+        return category.getId();
+    }
 
-	public Long getOwnerId() {
-		return owner.getId();
-	}
+    public Long getOwnerId() {
+        return owner.getId();
+    }
 
-	public String getOwnerNickname() {
-		return owner.getNickname();
-	}
+    public String getOwnerNickname() {
+        return owner.getNickname();
+    }
 
-	public String getOwnerEmail() {
-		return owner.getEmail();
-	}
+    public String getOwnerEmail() {
+        return owner.getEmail();
+    }
 
-	public String getCategoryName() {
-		return category.getName();
-	}
+    public String getCategoryName() {
+        return category.getName();
+    }
 
-	public void ensureRecruitmentWritableBy(final User user) {
-		if (recruitment != null && !recruitment.isDeleted()) {
-			throw new IllegalArgumentException("이미 작성된 모집 공고가 존재합니다.");
-		}
+    public void ensureRecruitmentWritableBy(final User user) {
+        if (recruitment != null && !recruitment.isDeleted()) {
+            throw new IllegalArgumentException("이미 작성된 모집 공고가 존재합니다.");
+        }
 
-		if (!isOwner(user)) {
-			throw new IllegalArgumentException("모집 공고를 작성할 권한이 없습니다.");
-		}
-	}
+        if (!isOwner(user)) {
+            throw new IllegalArgumentException("모집 공고를 작성할 권한이 없습니다.");
+        }
+    }
 
-	public Recruitment ensureRecruitmentEditable(final User user) {
-		if (!owner.getId().equals(user.getId())) {
-			throw new IllegalArgumentException("모집 공고를 수정할 권한이 없습니다.");
-		}
-		if (recruitment == null || recruitment.isDeleted()) {
-			throw new IllegalArgumentException("존재하지 않는 모집 공고입니다.");
-		}
-		return recruitment;
-	}
+    public Recruitment ensureRecruitmentEditable(final User user) {
+        if (!owner.getId().equals(user.getId())) {
+            throw new IllegalArgumentException("모집 공고를 수정할 권한이 없습니다.");
+        }
+        if (recruitment == null || recruitment.isDeleted()) {
+            throw new IllegalArgumentException("존재하지 않는 모집 공고입니다.");
+        }
+        return recruitment;
+    }
 
-	public void ensureStudyEditable(final User user) {
-		if (!owner.getId().equals(user.getId())) {
-			throw new IllegalArgumentException("스터디를 수정할 권한이 없습니다.");
-		}
-	}
+    public void ensureStudyEditable(final User user) {
+        if (!owner.getId().equals(user.getId())) {
+            throw new IllegalArgumentException("스터디를 수정할 권한이 없습니다.");
+        }
+    }
 
-	public Boolean isOwner(final User user) {
-		return Objects.equals(owner.getId(), user.getId());
-	}
+    public Boolean isOwner(final User user) {
+        return Objects.equals(owner.getId(), user.getId());
+    }
 
-	public Boolean isOwner(final Participant participant) {
-		return participant.matchesUser(owner);
-	}
+    public Boolean isOwner(final Participant participant) {
+        return participant.matchesUser(owner);
+    }
 
-	public void ensureRecruiting() {
-		if (status != StudyStatus.RECRUITING) {
-			throw new IllegalStateException("현재 모집 중인 스터디가 아닙니다.");
-		}
-	}
+    public void ensureRecruiting() {
+        if (status != StudyStatus.RECRUITING) {
+            throw new IllegalStateException("현재 모집 중인 스터디가 아닙니다.");
+        }
+    }
 
-	public void acceptApplicant(final User owner, final User applicantUser) {
-		ensureAcceptApplicant(owner, applicantUser);
-		accept(applicantUser);
-		if (isMaxParticipantCount()) {
-			changeStatus(StudyStatus.RECRUITED);
-		}
-	}
+    public void acceptApplicant(final User owner, final User applicantUser) {
+        ensureAcceptApplicant(owner, applicantUser);
+        accept(applicantUser);
+        if (isMaxParticipantCount()) {
+            changeStatus(StudyStatus.RECRUITED);
+        }
+    }
 
-	public void rejectApplicant(final User owner, final User applicantUser) {
-		ensureRejectApplicant(owner, applicantUser);
-		recruitment.rejectApplicant(applicantUser);
-	}
+    public void rejectApplicant(final User owner, final User applicantUser) {
+        ensureRejectApplicant(owner, applicantUser);
+        recruitment.rejectApplicant(applicantUser);
+    }
 
-	private void ensureRejectApplicant(final User owner, final User applicantUser) {
-		ensureCorrectOwner(owner);
-		ensureApplicantUserIsNotOwner(owner, applicantUser);
-		recruitment.ensureCorrectApplicantUser(applicantUser);
-	}
+    private void ensureRejectApplicant(final User owner, final User applicantUser) {
+        ensureCorrectOwner(owner);
+        ensureApplicantUserIsNotOwner(owner, applicantUser);
+        recruitment.ensureCorrectApplicantUser(applicantUser);
+    }
 
-	private void ensureApplicantUserIsNotOwner(final User owner, final User applicantUser) {
-		if (owner.equals(applicantUser)) {
-			throw new IllegalArgumentException("스터디 장과 지원자가 같습니다.");
-		}
-	}
+    private void ensureApplicantUserIsNotOwner(final User owner, final User applicantUser) {
+        if (owner.equals(applicantUser)) {
+            throw new IllegalArgumentException("스터디 장과 지원자가 같습니다.");
+        }
+    }
 
-	private void ensureAcceptApplicant(final User owner, final User applicantUser) {
-		ensureCorrectOwner(owner);
-		ensureApplicantUserIsNotOwner(owner, applicantUser);
-		ensureRecruiting();
-		ensureRemainParticipantLimit();
-		recruitment.ensureCorrectApplicantUser(applicantUser);
-	}
+    private void ensureAcceptApplicant(final User owner, final User applicantUser) {
+        ensureCorrectOwner(owner);
+        ensureApplicantUserIsNotOwner(owner, applicantUser);
+        ensureRecruiting();
+        ensureRemainParticipantLimit();
+        recruitment.ensureCorrectApplicantUser(applicantUser);
+    }
 
-	private void ensureCorrectOwner(final User owner) {
-		log.info("스터디장 = {}", this.owner.getId());
-		log.info("파라미터 = {}", owner.getId());
-		if (!isOwner(owner)) {
-			throw new IllegalStateException(
-					String.format("스터디 장이 아닙니다. 스터디 장 id = %s, 잘못된 id = %s", this.owner, owner));
-		}
-	}
+    private void ensureCorrectOwner(final User owner) {
+        log.info("스터디장 = {}", this.owner.getId());
+        log.info("파라미터 = {}", owner.getId());
+        if (!isOwner(owner)) {
+            throw new IllegalStateException(
+                    String.format("스터디 장이 아닙니다. 스터디 장 id = %s, 잘못된 id = %s", this.owner, owner));
+        }
+    }
 
-	private void ensureRemainParticipantLimit() {
-		if (Objects.equals(getParticipantCount(), participantLimit)) {
-			throw new IllegalStateException("남아있는 자리가 없습니다.");
-		}
-	}
+    private void ensureRemainParticipantLimit() {
+        if (Objects.equals(getParticipantCount(), participantLimit)) {
+            throw new IllegalStateException("남아있는 자리가 없습니다.");
+        }
+    }
 
-	private void accept(final User applicantUser) {
-		recruitment.acceptApplicant(applicantUser);
-		final Applicant applicant = recruitment.getApplicant(applicantUser);
-		addParticipant(Participant.from(this, applicantUser, applicant.getPosition(), Role.MEMBER));
-	}
+    private void accept(final User applicantUser) {
+        recruitment.acceptApplicant(applicantUser);
+        final Applicant applicant = recruitment.getApplicant(applicantUser);
+        addParticipant(Participant.from(this, applicantUser, applicant.getPosition(), Role.MEMBER));
+    }
 
-	private Boolean isMaxParticipantCount() {
-		return Objects.equals(participantCount, participantLimit);
-	}
+    private Boolean isMaxParticipantCount() {
+        return Objects.equals(participantCount, participantLimit);
+    }
 
-	public Boolean isParticipating(final User user) {
-		return participants.stream()
-				.anyMatch(p -> p.matchesUser(user));
-	}
+    public Boolean allParticipating(final Long... userIds) {
+        return Arrays.stream(userIds).allMatch(this::isParticipating);
+    }
 
-	public Integer getDday() {
-		return Period.between(startDateTime.toLocalDate(), endDateTime.toLocalDate()).getDays();
-	}
+    public Boolean isParticipating(final User user) {
+        return isParticipating(user.getId());
+    }
 
-	public Participant getParticipant(final User user) {
-		return participants.stream()
-				.filter(p -> p.matchesUser(user))
-				.findFirst()
-				.orElseThrow(() -> new IllegalStateException("현재 참여 중인 스터디원이 아닙니다."));
-	}
+    public Boolean isParticipating(final Long userId) {
+        return participants.stream()
+                .anyMatch(p -> p.matchesUser(userId));
+    }
 
-	public void removeParticipant(final Participant participant) {
-		participants.removeIf(p -> Objects.equals(p, participant));
-	}
+    public Integer getDday() {
+        return Period.between(startDateTime.toLocalDate(), endDateTime.toLocalDate()).getDays();
+    }
 
-	public void modifyStatus(final StudyStatus status, final LocalDateTime now) {
-		// 모집 마감 상태는 시간에 따라 다른 결과 반영
-		if (status == StudyStatus.RECRUITED) {
-			modifyStatusToRecruited(now);
-			modifyStatusToProgress(now);
-		}
-	}
+    public Participant getParticipant(final User user) {
+        return getParticipant(user.getId());
+    }
 
-	public void modifyStatusToRecruiting() {
-		this.status = StudyStatus.RECRUITING;
-	}
+    public Optional<Participant> findParticipant(final Long userId) {
+        return participants.stream()
+                .filter(p -> p.matchesUser(userId))
+                .findFirst();
+    }
 
-	private void modifyStatusToRecruited(final LocalDateTime now) {
-		if (this.startDateTime.isAfter(now)) {
-			this.status = StudyStatus.RECRUITED;
-		}
-	}
+    public Participant getParticipant(final Long userId) {
+        return findParticipant(userId)
+                .orElseThrow(() -> new IllegalStateException("현재 참여 중인 스터디원이 아닙니다."));
+    }
 
-	private void modifyStatusToProgress(final LocalDateTime now) {
-		if (this.startDateTime.isBefore(now) && this.endDateTime.isAfter(now)) {
-			this.status = StudyStatus.PROGRESS;
-		}
-	}
+    public void removeParticipant(final Participant participant) {
+        participants.removeIf(p -> Objects.equals(p, participant));
+    }
 
-	public void modifyStatusToCompleted(final LocalDateTime now) {
-		if (this.endDateTime.isBefore(now)) {
-			this.status = StudyStatus.COMPLETED;
-		}
-	}
+    public void modifyStatus(final StudyStatus status, final LocalDateTime now) {
+        // 모집 마감 상태는 시간에 따라 다른 결과 반영
+        if (status == StudyStatus.RECRUITED) {
+            modifyStatusToRecruited(now);
+            modifyStatusToProgress(now);
+        }
+    }
 
-	public void deactivateForRecruitment() {
-		this.recruitment.softDelete();
-	}
+    public void modifyStatusToRecruiting() {
+        this.status = StudyStatus.RECRUITING;
+    }
 
-	public void activateForRecruitment() {
-		this.recruitment.activate();
-	}
+    private void modifyStatusToRecruited(final LocalDateTime now) {
+        if (this.startDateTime.isAfter(now)) {
+            this.status = StudyStatus.RECRUITED;
+        }
+    }
 
-	public Boolean ensureHasRecruitment() {
-		if (this.recruitment != null && !this.recruitment.isDeleted()) {
-			return Boolean.TRUE;
-		}
-		return Boolean.FALSE;
-	}
+    private void modifyStatusToProgress(final LocalDateTime now) {
+        if (this.startDateTime.isBefore(now) && this.endDateTime.isAfter(now)) {
+            this.status = StudyStatus.PROGRESS;
+        }
+    }
 
-	public void update(final String title, final Category category, final Integer participantLimit,
-					   final Way way, final Platform platform, final String platformUrl,
-					   final LocalDateTime startDateTime, final LocalDateTime endDateTime) {
-		if (title != null) {
-			this.title = title;
-		}
-		if (category != null) {
-			this.category = category;
-		}
-		if (participantLimit != null) {
-			this.participantLimit = participantLimit;
-		}
-		if (way != null) {
-			this.way = way;
-		}
-		if (platform != null) {
-			this.platform = platform;
-		}
-		if (platformUrl != null) {
-			this.platformUrl = platformUrl;
-		}
-		if (startDateTime != null) {
-			this.startDateTime = startDateTime;
-		}
-		if (endDateTime != null) {
-			this.endDateTime = endDateTime;
-		}
-	}
+    public void modifyStatusToCompleted(final LocalDateTime now) {
+        if (this.endDateTime.isBefore(now)) {
+            this.status = StudyStatus.COMPLETED;
+        }
+    }
 
+    public void deactivateForRecruitment() {
+        this.recruitment.softDelete();
+    }
+
+    public void activateForRecruitment() {
+        this.recruitment.activate();
+    }
+
+    public Boolean ensureHasRecruitment() {
+        if (this.recruitment != null && !this.recruitment.isDeleted()) {
+            return Boolean.TRUE;
+        }
+        return Boolean.FALSE;
+    }
+
+    public void update(final String title, final Category category, final Integer participantLimit,
+                       final Way way, final Platform platform, final String platformUrl,
+                       final LocalDateTime startDateTime, final LocalDateTime endDateTime) {
+        if (title != null) {
+            this.title = title;
+        }
+        if (category != null) {
+            this.category = category;
+        }
+        if (participantLimit != null) {
+            this.participantLimit = participantLimit;
+        }
+        if (way != null) {
+            this.way = way;
+        }
+        if (platform != null) {
+            this.platform = platform;
+        }
+        if (platformUrl != null) {
+            this.platformUrl = platformUrl;
+        }
+        if (startDateTime != null) {
+            this.startDateTime = startDateTime;
+        }
+        if (endDateTime != null) {
+            this.endDateTime = endDateTime;
+        }
+    }
+
+    public void ensureReviewPeriodAvailable(final LocalDateTimePicker localDateTimePicker) {
+        final LocalDateTime now = localDateTimePicker.now();
+        final LocalDateTime reviewAvailStartTime = endDateTime.plusDays(3).minusSeconds(1);
+        final LocalDateTime reviewAvailEndTime = endDateTime.plusDays(14).plusSeconds(1);
+
+        // Order Specific
+        if (isReviewPeriodElapsed(now)) {
+            throw new InvalidReviewPeriodException("리뷰 작성 기간이 지났습니다.", reviewAvailStartTime, reviewAvailEndTime);
+        }
+
+        if (isNotReviewPeriodYet(now)) {
+            throw new InvalidReviewPeriodException("아직 리뷰 작성 기간이 되지 않았습니다.", reviewAvailStartTime, reviewAvailEndTime);
+        }
+
+        System.out.println("min avail: " + reviewAvailStartTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        System.out.println("max avail: " + reviewAvailEndTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+        System.out.println("now : " + now.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+
+    }
+
+    public boolean isNotReviewPeriodYet(final LocalDateTime now) {
+        final LocalDateTime reviewAvailStartTime = endDateTime.plusDays(3);
+        return now.isBefore(reviewAvailStartTime);
+    }
+
+    public boolean isReviewPeriodElapsed(final LocalDateTime now) {
+        final LocalDateTime reviewAvailEndTime = endDateTime.plusDays(14);
+        return now.isAfter(reviewAvailEndTime);
+    }
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Study.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Study.java
@@ -4,6 +4,7 @@ import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
 import com.ludo.study.studymatchingplatform.common.utils.LocalDateTimePicker;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.applicant.Applicant;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
 import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
 import com.ludo.study.studymatchingplatform.study.domain.study.participant.Participant;
 import com.ludo.study.studymatchingplatform.study.domain.study.participant.Role;
@@ -81,6 +82,11 @@ public class Study extends BaseEntity {
 
     @Column(nullable = false)
     private LocalDateTime endDateTime;
+
+    public void addParticipant(final User user, final Position position, final Role role) {
+        final Participant participant = Participant.from(this, user, position, role);
+        addParticipant(participant);
+    }
 
     public void addParticipant(final Participant participant) {
         this.participants.add(participant);

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/UserReviewStatistics.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/UserReviewStatistics.java
@@ -1,0 +1,44 @@
+package com.ludo.study.studymatchingplatform.study.domain.study;
+
+import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserReviewStatistics extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // review count
+    private Long totalActivenessReviewCount;
+    private Long totalProfessionalismReviewCount;
+    private Long totalCommunicationReviewCount;
+    private Long totalTogetherReviewScore;
+    private Long totalRecommendReviewScore;
+
+    // scores
+    private Long totalActivenessScore;
+    private Long totalProfessionalismScore;
+    private Long totalCommunicationScore;
+    private Long totalTogetherScore;
+    private Long totalRecommendScore;
+
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/UserStudyStatistics.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/UserStudyStatistics.java
@@ -1,0 +1,50 @@
+package com.ludo.study.studymatchingplatform.study.domain.study;
+
+
+import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserStudyStatistics extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private int totalTeammateCount;
+
+    // 진행 완료 스터디(진행도 100%)
+    private int totalCompletedStudyCount;
+
+    // 완주 스터디(진행도 80% 이상)
+    private int totalFinishedStudyCount;
+
+    // 총 무단 탈주 스터디
+    private int totalLeftStudyCount;
+
+    // 총 누적 출석
+    private int totalAttendance;
+
+    // 총 유효 출석
+    private int totalValidAttendance;
+
+    // TODO: 동시에 여러 스터디를 진행하는 경우, 중복 count? 일수?
+    // 전체 스터디 진행 기간
+    private int totalStudyDays;
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/participant/Participant.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/participant/Participant.java
@@ -1,30 +1,18 @@
 package com.ludo.study.studymatchingplatform.study.domain.study.participant;
 
-import static jakarta.persistence.FetchType.*;
-
-import java.util.Objects;
-
 import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
 import com.ludo.study.studymatchingplatform.study.domain.id.ParticipantId;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
 import com.ludo.study.studymatchingplatform.study.domain.study.Study;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.EmbeddedId;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapsId;
-import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
 @Getter
@@ -34,59 +22,75 @@ import lombok.experimental.SuperBuilder;
 @Table(name = "study_user_lnk")
 public class Participant extends BaseEntity {
 
-	@EmbeddedId
-	@Builder.Default
-	private ParticipantId id = new ParticipantId();
+    @EmbeddedId
+    @Builder.Default
+    private ParticipantId id = new ParticipantId();
 
-	@ManyToOne(fetch = LAZY)
-	@MapsId("studyId")
-	@JoinColumn(name = "study_id", nullable = false)
-	private Study study;
+    @ManyToOne(fetch = LAZY)
+    @MapsId("studyId")
+    @JoinColumn(name = "study_id", nullable = false)
+    private Study study;
 
-	@ManyToOne(fetch = LAZY)
-	@MapsId("userId")
-	@JoinColumn(name = "user_id", nullable = false)
-	private User user;
+    @ManyToOne(fetch = LAZY)
+    @MapsId("userId")
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
-	@Enumerated(EnumType.STRING)
-	@Column(nullable = false, columnDefinition = "char(10)")
-	private Role role;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "char(10)")
+    private Role role;
 
-	@ManyToOne
-	@JoinColumn(name = "position_id")
-	private Position position;
+    @ManyToOne
+    @JoinColumn(name = "position_id")
+    private Position position;
 
-	public static Participant from(final Study study, final User user, final Position position, final Role role) {
-		final Participant participant = new Participant();
-		participant.study = study;
-		participant.user = user;
-		participant.role = role;
-		participant.position = position;
-		return participant;
-	}
+    // 누적 출석
+    @Builder.Default
+    private int attendance = 0;
 
-	public Role getRole() {
-		// TODO: Role spec not determined clearly
-		// TODO: First of all, I reflected it in my own way
-		if (study.isOwner(this)) {
-			return Role.OWNER;
-		}
-		return Role.MEMBER;
-	}
+    // 누적 유효 출석
+    @Builder.Default
+    private int validAttendance = 0;
 
-	public boolean matchesUser(final User user) {
-		final boolean isMatchesUser = Objects.equals(this.user.getId(), user.getId());
-		return isMatchesUser && !isDeleted();
-	}
+    // 스터디 합류일
+    @Builder.Default
+    private LocalDateTime enrollmentDateTime = LocalDateTime.now();
 
-	public void leave(final Study study) {
-		study.removeParticipant(this);
-		this.study = null;
-		this.softDelete();
-	}
+    public static Participant from(final Study study, final User user, final Position position, final Role role) {
+        final Participant participant = new Participant();
+        participant.study = study;
+        participant.user = user;
+        participant.role = role;
+        participant.position = position;
+        return participant;
+    }
 
-	public void updatePosition(final Position position) {
-		this.position = position;
-	}
+    public Role getRole() {
+        // TODO: Role spec not determined clearly
+        // TODO: First of all, I reflected it in my own way
+        if (study.isOwner(this)) {
+            return Role.OWNER;
+        }
+        return Role.MEMBER;
+    }
+
+    public boolean matchesUser(final User user) {
+        return matchesUser(user.getId());
+    }
+
+    public boolean matchesUser(final Long userId) {
+        final boolean isMatchesUser = Objects.equals(this.user.getId(), userId);
+        return isMatchesUser && !isDeleted();
+    }
+
+    public void leave(final Study study) {
+        study.removeParticipant(this);
+        this.study = null;
+        this.softDelete();
+    }
+
+    public void updatePosition(final Position position) {
+        this.position = position;
+    }
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/repository/study/ReviewJpaRepository.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/repository/study/ReviewJpaRepository.java
@@ -1,0 +1,7 @@
+package com.ludo.study.studymatchingplatform.study.repository.study;
+
+import com.ludo.study.studymatchingplatform.study.domain.study.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewJpaRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/repository/study/ReviewRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/repository/study/ReviewRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.ludo.study.studymatchingplatform.study.repository.study;
+
+import com.ludo.study.studymatchingplatform.study.domain.study.Review;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.ludo.study.studymatchingplatform.study.domain.study.QReview.review;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewRepositoryImpl {
+
+    private final JPAQueryFactory q;
+
+    private final ReviewJpaRepository reviewJpaRepository;
+
+    public List<Review> findAllByStudyId(final Long studyId) {
+        return q.selectFrom(review)
+                .where(review.study.id.eq(studyId)
+                        .and(review.deletedDateTime.isNull()))
+                .fetch();
+    }
+
+    public Review save(final Review review) {
+        return reviewJpaRepository.save(review);
+    }
+
+    public boolean existsBy(final Long studyId, final Long reviewerId, final Long revieweeId) {
+//        q.select(review)
+//                .fetchFirst();
+        return false;
+    }
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/repository/study/ReviewRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/repository/study/ReviewRepositoryImpl.java
@@ -28,10 +28,14 @@ public class ReviewRepositoryImpl {
         return reviewJpaRepository.save(review);
     }
 
-    public boolean existsBy(final Long studyId, final Long reviewerId, final Long revieweeId) {
-//        q.select(review)
-//                .fetchFirst();
-        return false;
+    public boolean exists(final Long studyId, final Long reviewerId, final Long revieweeId) {
+        return q.selectOne()
+                .from(review)
+                .where(review.study.id.eq(studyId)
+                        .and(review.reviewer.id.eq(reviewerId))
+                        .and(review.reviewee.id.eq(revieweeId))
+                )
+                .fetchFirst() != null;
     }
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/request/study/WriteReviewRequest.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/request/study/WriteReviewRequest.java
@@ -1,0 +1,30 @@
+package com.ludo.study.studymatchingplatform.study.service.dto.request.study;
+
+import com.ludo.study.studymatchingplatform.study.domain.study.Review;
+import com.ludo.study.studymatchingplatform.study.domain.study.Study;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import lombok.Builder;
+
+@Builder
+public record WriteReviewRequest(
+        Long revieweeId,
+        Long activenessScore,
+        Long professionalismScore,
+        Long communicationScore,
+        Long togetherScore,
+        Long recommendScore
+) {
+
+    public Review toReviewWithStudy(final Study study, final User reviewer, final User reviewee) {
+        return Review.builder()
+                .study(study)
+                .reviewer(reviewer)
+                .reviewee(reviewee)
+                .activenessScore(activenessScore)
+                .professionalismScore(professionalismScore)
+                .communicationScore(communicationScore)
+                .togetherScore(togetherScore)
+                .recommendScore(recommendScore)
+                .build();
+    }
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/study/ReviewResponse.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/study/ReviewResponse.java
@@ -1,0 +1,36 @@
+package com.ludo.study.studymatchingplatform.study.service.dto.response.study;
+
+import com.ludo.study.studymatchingplatform.study.domain.study.Review;
+import com.ludo.study.studymatchingplatform.user.service.dto.response.UserResponse;
+
+public record ReviewResponse(
+        Long id,
+        Long studyId,
+        UserResponse reviewer,
+        UserResponse reviewee,
+        // 적극성
+        Long activenessScore,
+        // 전문성
+        Long professionalismScore,
+        // 의사소통
+        Long communicationScore,
+        // 다시함께
+        Long togetherScore,
+        // 추천 여부
+        Long recommendScore
+) {
+
+    public static ReviewResponse from(final Review review) {
+        return new ReviewResponse(
+                review.getId(),
+                review.getStudy().getId(),
+                UserResponse.from(review.getReviewer()),
+                UserResponse.from(review.getReviewee()),
+                review.getActivenessScore(),
+                review.getProfessionalismScore(),
+                review.getCommunicationScore(),
+                review.getTogetherScore(),
+                review.getRecommendScore()
+        );
+    }
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/exception/InvalidReviewPeriodException.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/exception/InvalidReviewPeriodException.java
@@ -1,0 +1,18 @@
+package com.ludo.study.studymatchingplatform.study.service.exception;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+public final class InvalidReviewPeriodException extends IllegalArgumentException {
+
+    private static final String MESSAGE = "%s\n리뷰 작성은 스터디 완료 3일 후인 %s부터 14일 후인 %s까지 가능합니다.";
+
+    public InvalidReviewPeriodException(final String message, final LocalDateTime reviewAvailStartTime, final LocalDateTime reviewAvailEndTime) {
+        super(MESSAGE.formatted(message, formatAvailTime(reviewAvailStartTime), formatAvailTime((reviewAvailEndTime))));
+    }
+
+    private static String formatAvailTime(final LocalDateTime localDateTime) {
+        return localDateTime.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분", Locale.KOREA));
+    }
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/FixedLocalDateTimePicker.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/FixedLocalDateTimePicker.java
@@ -1,0 +1,22 @@
+package com.ludo.study.studymatchingplatform.study.service.study;
+
+import com.ludo.study.studymatchingplatform.common.utils.LocalDateTimePicker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Profile("test")
+@Component
+@RequiredArgsConstructor
+public class FixedLocalDateTimePicker implements LocalDateTimePicker {
+
+    public static final LocalDateTime DEFAULT_FIXED_LOCAL_DATE_TIME = LocalDateTime.of(2000, 1, 1, 0, 0, 0);
+    private final LocalDateTime fixedLocalDateTime = DEFAULT_FIXED_LOCAL_DATE_TIME;
+
+    @Override
+    public LocalDateTime now() {
+        return fixedLocalDateTime;
+    }
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewFacade.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewFacade.java
@@ -1,0 +1,38 @@
+package com.ludo.study.studymatchingplatform.study.service.study;
+
+import com.ludo.study.studymatchingplatform.study.domain.study.Review;
+import com.ludo.study.studymatchingplatform.study.domain.study.Study;
+import com.ludo.study.studymatchingplatform.study.repository.study.ReviewRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.study.StudyRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.service.dto.request.study.WriteReviewRequest;
+import com.ludo.study.studymatchingplatform.study.service.dto.response.study.ReviewResponse;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReviewFacade {
+
+    private final ReviewRepositoryImpl reviewRepository;
+    private final StudyRepositoryImpl studyRepository;
+    private final ReviewService reviewService;
+
+    public ReviewResponse write(WriteReviewRequest request, Long studyId, User reviewer) {
+        final Study study = studyRepository.findByIdWithParticipants(studyId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디입니다. 리뷰를 작성할 수 없습니다."));
+
+        boolean b = reviewRepository.exists(studyId, reviewer.getId(), request.revieweeId());
+        System.out.println(b);
+        if (b) {
+            throw new IllegalArgumentException("이미 리뷰를 작성 하셨습니다.");
+        }
+
+        final Review review = reviewService.write(request, study, reviewer);
+        return ReviewResponse.from(reviewRepository.save(review));
+
+    }
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewService.java
@@ -1,0 +1,53 @@
+package com.ludo.study.studymatchingplatform.study.service.study;
+
+import com.ludo.study.studymatchingplatform.common.utils.LocalDateTimePicker;
+import com.ludo.study.studymatchingplatform.study.domain.study.Review;
+import com.ludo.study.studymatchingplatform.study.domain.study.Study;
+import com.ludo.study.studymatchingplatform.study.domain.study.participant.Participant;
+import com.ludo.study.studymatchingplatform.study.repository.study.ReviewRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.study.StudyRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.service.dto.request.study.WriteReviewRequest;
+import com.ludo.study.studymatchingplatform.study.service.dto.response.study.ReviewResponse;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepositoryImpl reviewRepository;
+    private final StudyRepositoryImpl studyRepository;
+    private final LocalDateTimePicker localDateTimePicker;
+
+    public ReviewResponse write(WriteReviewRequest request, Long studyId, User reviewer) {
+        final Study study = studyRepository.findByIdWithParticipants(studyId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디입니다. 리뷰를 작성할 수 없습니다."));
+
+        final Participant participantingReviewer = study.findParticipant(reviewer.getId())
+                .orElseThrow(() -> new IllegalArgumentException("참여 중인 스터디가 아닙니다. 리뷰를 작성할 수 없습니다."));
+        final Participant participantingReviewee = study.findParticipant(request.revieweeId())
+                .orElseThrow(() -> new IllegalArgumentException("스터디에 참여 중인 사용자에게만 리뷰를 작성할 수 있습니다."));
+        if (participantingReviewer == participantingReviewee) {
+            throw new IllegalArgumentException("자기 자신에게는 리뷰를 작성할 수 없습니다.");
+        }
+
+        // 명세 - [스터디가 진행 완료 상태로 바뀐 후 3일 후 부터, 14일 간 리뷰 작성 가능]
+        // 진행 완료 상태로 바뀐 뒤 날짜를 정확히 추적하기 위해서는 추가적인 state 및 논의 필요할듯
+        // -> 일단 EndDateTime 기반으로 작성
+        study.ensureReviewPeriodAvailable(localDateTimePicker);
+
+        final boolean isDuplicateReview = reviewRepository.findAllByStudyId(studyId)
+                .stream().anyMatch(review -> review.isDuplicateReview(studyId, reviewer.getId(), request.revieweeId()));
+        if (isDuplicateReview) {
+            throw new IllegalArgumentException("이미 리뷰를 작성 하셨습니다.");
+        }
+
+        final Review review = request.toReviewWithStudy(study, participantingReviewer.getUser(), participantingReviewee.getUser());
+        return ReviewResponse.from(reviewRepository.save(review));
+
+    }
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewService.java
@@ -10,6 +10,7 @@ import com.ludo.study.studymatchingplatform.study.service.dto.request.study.Writ
 import com.ludo.study.studymatchingplatform.study.service.dto.response.study.ReviewResponse;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,14 +19,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ReviewService {
 
-    private final ReviewRepositoryImpl reviewRepository;
-    private final StudyRepositoryImpl studyRepository;
     private final LocalDateTimePicker localDateTimePicker;
 
-    public ReviewResponse write(WriteReviewRequest request, Long studyId, User reviewer) {
-        final Study study = studyRepository.findByIdWithParticipants(studyId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디입니다. 리뷰를 작성할 수 없습니다."));
-
+    public Review write(WriteReviewRequest request, Study study, User reviewer) {
         final Participant participantingReviewer = study.findParticipant(reviewer.getId())
                 .orElseThrow(() -> new IllegalArgumentException("참여 중인 스터디가 아닙니다. 리뷰를 작성할 수 없습니다."));
         final Participant participantingReviewee = study.findParticipant(request.revieweeId())
@@ -35,18 +31,8 @@ public class ReviewService {
         }
 
         // 명세 - [스터디가 진행 완료 상태로 바뀐 후 3일 후 부터, 14일 간 리뷰 작성 가능]
-        // 진행 완료 상태로 바뀐 뒤 날짜를 정확히 추적하기 위해서는 추가적인 state 및 논의 필요할듯
-        // -> 일단 EndDateTime 기반으로 작성
         study.ensureReviewPeriodAvailable(localDateTimePicker);
-
-        final boolean isDuplicateReview = reviewRepository.findAllByStudyId(studyId)
-                .stream().anyMatch(review -> review.isDuplicateReview(studyId, reviewer.getId(), request.revieweeId()));
-        if (isDuplicateReview) {
-            throw new IllegalArgumentException("이미 리뷰를 작성 하셨습니다.");
-        }
-
-        final Review review = request.toReviewWithStudy(study, participantingReviewer.getUser(), participantingReviewee.getUser());
-        return ReviewResponse.from(reviewRepository.save(review));
+        return request.toReviewWithStudy(study, participantingReviewer.getUser(), participantingReviewee.getUser());
 
     }
 

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewServiceTest.java
@@ -3,10 +3,7 @@ package com.ludo.study.studymatchingplatform.study.service.study;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.Stack;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.StackCategory;
-import com.ludo.study.studymatchingplatform.study.domain.study.Platform;
-import com.ludo.study.studymatchingplatform.study.domain.study.Study;
-import com.ludo.study.studymatchingplatform.study.domain.study.StudyStatus;
-import com.ludo.study.studymatchingplatform.study.domain.study.Way;
+import com.ludo.study.studymatchingplatform.study.domain.study.*;
 import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
 import com.ludo.study.studymatchingplatform.study.domain.study.participant.Participant;
 import com.ludo.study.studymatchingplatform.study.domain.study.participant.Role;
@@ -47,128 +44,37 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-@SpringBootTest
-@Transactional
-@ActiveProfiles("test")
-public class ReviewServiceTest {
+public final class ReviewServiceTest {
 
-    @Autowired
-    private ReviewService reviewService;
-
-    @Autowired
-    private UserRepositoryImpl userRepository;
-
-    @Autowired
-    private CategoryRepositoryImpl categoryRepository;
-
-    @Autowired
-    private StudyRepositoryImpl studyRepository;
-
-    @Autowired
-    private PositionRepositoryImpl positionRepository;
-
-    @Autowired
-    private StackRepositoryImpl stackRepository;
-
-    @Autowired
-    private StackCategoryRepositoryImpl stackCategoryRepository;
-
-    @Autowired
-    private RecruitmentRepositoryImpl recruitmentRepository;
-
-    @Autowired
-    private RecruitmentService recruitmentService;
-
-    @Autowired
-    private ParticipantRepositoryImpl participantRepository;
-
-    @Autowired
-    private StudyApplicantDecisionService studyApplicantDecisionService;
-
-    @Autowired
-    private ParticipantService participantService;
-
-    @Autowired
-    private EntityManager em;
-
+    private final ReviewService reviewService = new ReviewService(new FixedLocalDateTimePicker());
 
     @DisplayName("[Success] 스터디가 종료된지 3일 ~ 14일 내에 리뷰를 작성할 수 있다.")
     @ParameterizedTest
     @MethodSource("validEndDateTimes")
     void writeReview(final LocalDateTime endDateTime) {
-
         // given
-        final User owner = userRepository.save(
-                User.builder()
-                        .nickname("owner")
-                        .email("a@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
+        final User reviewer = User.builder().id(1L).nickname("reviewer").email("reviewer@aa.aa").build();
+        final User reviewee = User.builder().id(2L).nickname("reviewee").email("reviewee@aa.aa").build();
+        final Study study = Study.builder().owner(reviewer).endDateTime(endDateTime).build();
+        final Position position = Position.builder().name("position").build();
+        study.addParticipant(reviewer, position, Role.OWNER);
+        study.addParticipant(reviewee, position, Role.MEMBER);
 
-        final Category category = categoryRepository.save(
-                CategoryFixture.createCategory("category1"));
-
-        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
-
-        final LocalDateTime startDateTime = now.minusDays(20);
-
-        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
-        final StackCategory stackCategory = stackCategoryRepository.save(
-                StackCategoryFixture.createStackCategory("stackCategory")
-        );
-
-        final Stack stack = stackRepository.save(
-                StackFixture.createStack("stack", stackCategory)
-        );
-        final Position position = positionRepository.save(
-                PositionFixture.createPosition("position")
-        );
-
-        final User userA = userRepository.save(
-                User.builder()
-                        .nickname("userA")
-                        .email("userA@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-        final User userB = userRepository.save(
-                User.builder()
-                        .nickname("userB")
-                        .email("userB@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-
-
-        participantService.add(study, userA, position, Role.MEMBER);
-        participantService.add(study, userB, position, Role.MEMBER);
-
-        final Participant participantB = study.getParticipant(userB);
-
-        final WriteReviewRequest request = WriteReviewRequest.builder()
-                .revieweeId(participantB.getUser().getId())
-                .activenessScore(5L)
-                .professionalismScore(5L)
-                .communicationScore(5L)
-                .togetherScore(5L)
-                .recommendScore(5L)
-                .build();
+        final WriteReviewRequest request = WriteReviewRequest.builder().revieweeId(reviewee.getId()).activenessScore(5L).professionalismScore(5L).communicationScore(5L).togetherScore(5L).recommendScore(5L).build();
 
 
         // when
-        final ReviewResponse review = reviewService.write(request, study.getId(), userA);
+        final Review review = reviewService.write(request, study, reviewer);
 
         // then
-        assertThat(review.reviewer().email())
-                .isEqualTo(userA.getEmail());
+        assertThat(review.getReviewer()).isEqualTo(reviewer);
+        assertThat(review.getReviewee()).isEqualTo(reviewee);
 
     }
 
     private static Stream<LocalDateTime> validEndDateTimes() {
         final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
-        return Stream.of(
-                now.minusDays(3),
-                now.minusDays(13),
-                now.minusDays(14)
-        );
+        return Stream.of(now.minusDays(3), now.minusDays(13), now.minusDays(14));
 
     }
 
@@ -177,526 +83,131 @@ public class ReviewServiceTest {
     @ParameterizedTest
     @MethodSource("invalidEndDateTimes")
     void writeReviewFailure(final LocalDateTime endDateTime) {
-
         // given
-        final User owner = userRepository.save(
-                User.builder()
-                        .nickname("owner")
-                        .email("a@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
+        final User reviewer = User.builder().id(1L).nickname("reviewer").email("reviewer@aa.aa").build();
+        final User reviewee = User.builder().id(2L).nickname("reviewee").email("reviewee@aa.aa").build();
+        final Study study = Study.builder().owner(reviewer).endDateTime(endDateTime).build();
+        final Position position = Position.builder().name("position").build();
+        study.addParticipant(reviewer, position, Role.OWNER);
+        study.addParticipant(reviewee, position, Role.MEMBER);
 
-        final Category category = categoryRepository.save(
-                CategoryFixture.createCategory("category1"));
-
-        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
-        final LocalDateTime startDateTime = now.minusDays(20);
-
-        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
-        final StackCategory stackCategory = stackCategoryRepository.save(
-                StackCategoryFixture.createStackCategory("stackCategory")
-        );
-
-        final Stack stack = stackRepository.save(
-                StackFixture.createStack("stack", stackCategory)
-        );
-        final Position position = positionRepository.save(
-                PositionFixture.createPosition("position")
-        );
-
-        final User userA = userRepository.save(
-                User.builder()
-                        .nickname("userA")
-                        .email("userA@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-        final User userB = userRepository.save(
-                User.builder()
-                        .nickname("userB")
-                        .email("userB@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-
-
-        participantService.add(study, userA, position, Role.MEMBER);
-        participantService.add(study, userB, position, Role.MEMBER);
-
-        final Participant participantB = study.getParticipant(userB);
-
-        final WriteReviewRequest request = WriteReviewRequest.builder()
-                .revieweeId(participantB.getUser().getId())
-                .activenessScore(5L)
-                .professionalismScore(5L)
-                .communicationScore(5L)
-                .togetherScore(5L)
-                .recommendScore(5L)
-                .build();
+        final WriteReviewRequest request = WriteReviewRequest.builder().revieweeId(reviewee.getId()).activenessScore(5L).professionalismScore(5L).communicationScore(5L).togetherScore(5L).recommendScore(5L).build();
 
         // when
         // then
-        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
-                .isInstanceOf(InvalidReviewPeriodException.class);
+        assertThatThrownBy(() -> reviewService.write(request, study, reviewer)).isInstanceOf(InvalidReviewPeriodException.class);
     }
 
     @DisplayName("[Exception] 스터디가 종료된 후 3일이 지나기 전에는 리뷰를 작성할 수 없으며, 사용자에게 이를 인지하기 위한 적절한 안내 메세지를 보여준다.")
     @Test
     void writeReviewFailureBeforeThreeDaysAfterStudyDone() {
-
         // given
-        final User owner = userRepository.save(
-                User.builder()
-                        .nickname("owner")
-                        .email("a@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-
-        final Category category = categoryRepository.save(
-                CategoryFixture.createCategory("category1"));
-
         final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
-        final LocalDateTime startDateTime = now.minusDays(20);
         final LocalDateTime endDateTime = now.minusDays(3).plusSeconds(1);
 
-        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
-        final StackCategory stackCategory = stackCategoryRepository.save(
-                StackCategoryFixture.createStackCategory("stackCategory")
-        );
+        final User reviewer = User.builder().id(1L).nickname("reviewer").email("reviewer@aa.aa").build();
+        final User reviewee = User.builder().id(2L).nickname("reviewee").email("reviewee@aa.aa").build();
+        final Study study = Study.builder().owner(reviewer).endDateTime(endDateTime).build();
+        final Position position = Position.builder().name("position").build();
+        study.addParticipant(reviewer, position, Role.OWNER);
+        study.addParticipant(reviewee, position, Role.MEMBER);
 
-        final Stack stack = stackRepository.save(
-                StackFixture.createStack("stack", stackCategory)
-        );
-        final Position position = positionRepository.save(
-                PositionFixture.createPosition("position")
-        );
-
-        final User userA = userRepository.save(
-                User.builder()
-                        .nickname("userA")
-                        .email("userA@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-        final User userB = userRepository.save(
-                User.builder()
-                        .nickname("userB")
-                        .email("userB@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-
-
-        participantService.add(study, userA, position, Role.MEMBER);
-        participantService.add(study, userB, position, Role.MEMBER);
-
-        final Participant participantB = study.getParticipant(userB);
-
-        final WriteReviewRequest request = WriteReviewRequest.builder()
-                .revieweeId(participantB.getUser().getId())
-                .activenessScore(5L)
-                .professionalismScore(5L)
-                .communicationScore(5L)
-                .togetherScore(5L)
-                .recommendScore(5L)
-                .build();
+        final WriteReviewRequest request = WriteReviewRequest.builder().revieweeId(reviewee.getId()).activenessScore(5L).professionalismScore(5L).communicationScore(5L).togetherScore(5L).recommendScore(5L).build();
 
         // when
         // then
-        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
-                .isInstanceOf(InvalidReviewPeriodException.class)
-                .hasMessage("아직 리뷰 작성 기간이 되지 않았습니다.\n리뷰 작성은 스터디 완료 3일 후인 2000년 01월 01일 00시 00분부터 14일 후인 2000년 01월 12일 00시 00분까지 가능합니다.");
+        assertThatThrownBy(() -> reviewService.write(request, study, reviewer)).isInstanceOf(InvalidReviewPeriodException.class).hasMessage("아직 리뷰 작성 기간이 되지 않았습니다.\n리뷰 작성은 스터디 완료 3일 후인 2000년 01월 01일 00시 00분부터 14일 후인 2000년 01월 12일 00시 00분까지 가능합니다.");
 
     }
 
     @DisplayName("[Exception] 스터디가 종료된 후 14일이 지난 후에는 리뷰를 작성할 수 없으며, 사용자에게 이를 인지하기 위한 적절한 안내 메세지를 보여준다.")
     @Test
     void writeReviewFailureAfterFourteenDaysAfterStudyDone() {
-
-        // given
-        final User owner = userRepository.save(
-                User.builder()
-                        .nickname("owner")
-                        .email("a@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-
-        final Category category = categoryRepository.save(
-                CategoryFixture.createCategory("category1"));
-
+// given
         final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
-        final LocalDateTime startDateTime = now.minusDays(20);
         final LocalDateTime endDateTime = now.minusDays(14).minusSeconds(1);
 
-        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
-        final StackCategory stackCategory = stackCategoryRepository.save(
-                StackCategoryFixture.createStackCategory("stackCategory")
-        );
+        final User reviewer = User.builder().id(1L).nickname("reviewer").email("reviewer@aa.aa").build();
+        final User reviewee = User.builder().id(2L).nickname("reviewee").email("reviewee@aa.aa").build();
+        final Study study = Study.builder().owner(reviewer).endDateTime(endDateTime).build();
+        final Position position = Position.builder().name("position").build();
+        study.addParticipant(reviewer, position, Role.OWNER);
+        study.addParticipant(reviewee, position, Role.MEMBER);
 
-        final Stack stack = stackRepository.save(
-                StackFixture.createStack("stack", stackCategory)
-        );
-        final Position position = positionRepository.save(
-                PositionFixture.createPosition("position")
-        );
-
-        final User userA = userRepository.save(
-                User.builder()
-                        .nickname("userA")
-                        .email("userA@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-        final User userB = userRepository.save(
-                User.builder()
-                        .nickname("userB")
-                        .email("userB@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-
-
-        participantService.add(study, userA, position, Role.MEMBER);
-        participantService.add(study, userB, position, Role.MEMBER);
-
-        final Participant participantB = study.getParticipant(userB);
-
-        final WriteReviewRequest request = WriteReviewRequest.builder()
-                .revieweeId(participantB.getUser().getId())
-                .activenessScore(5L)
-                .professionalismScore(5L)
-                .communicationScore(5L)
-                .togetherScore(5L)
-                .recommendScore(5L)
-                .build();
+        final WriteReviewRequest request = WriteReviewRequest.builder().revieweeId(reviewee.getId()).activenessScore(5L).professionalismScore(5L).communicationScore(5L).togetherScore(5L).recommendScore(5L).build();
 
         // when
         // then
-        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
-                .isInstanceOf(InvalidReviewPeriodException.class)
-                .hasMessage("리뷰 작성 기간이 지났습니다.\n리뷰 작성은 스터디 완료 3일 후인 1999년 12월 20일 23시 59분부터 14일 후인 2000년 01월 01일 00시 00분까지 가능합니다.");
+        assertThatThrownBy(() -> reviewService.write(request, study, reviewer)).isInstanceOf(InvalidReviewPeriodException.class).hasMessage("리뷰 작성 기간이 지났습니다.\n리뷰 작성은 스터디 완료 3일 후인 1999년 12월 20일 23시 59분부터 14일 후인 2000년 01월 01일 00시 00분까지 가능합니다.");
 
     }
 
     private static Stream<LocalDateTime> invalidEndDateTimes() {
         final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
-        return Stream.of(
-                now.minusDays(3).plusSeconds(1),
-                now.minusDays(14).minusSeconds(1)
-        );
+        return Stream.of(now.minusDays(3).plusSeconds(1), now.minusDays(14).minusSeconds(1));
 
     }
 
-    @DisplayName("[Exception] 이미 리뷰를 작성한 스터디원에게는 재작성이 불가능하다.")
-    @Test
-    void writeDuplicateReview() {
-
-        // given
-        final User owner = userRepository.save(
-                User.builder()
-                        .nickname("owner")
-                        .email("a@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-
-        final Category category = categoryRepository.save(
-                CategoryFixture.createCategory("category1"));
-
-        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
-        final LocalDateTime startDateTime = now.minusDays(20);
-        final LocalDateTime endDateTime = now.minusDays(3);
-
-        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
-        final StackCategory stackCategory = stackCategoryRepository.save(
-                StackCategoryFixture.createStackCategory("stackCategory")
-        );
-
-        final Stack stack = stackRepository.save(
-                StackFixture.createStack("stack", stackCategory)
-        );
-        final Position position = positionRepository.save(
-                PositionFixture.createPosition("position")
-        );
-
-        final User userA = userRepository.save(
-                User.builder()
-                        .nickname("userA")
-                        .email("userA@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-        final User userB = userRepository.save(
-                User.builder()
-                        .nickname("userB")
-                        .email("userB@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-
-
-        participantService.add(study, userA, position, Role.MEMBER);
-        participantService.add(study, userB, position, Role.MEMBER);
-
-        final Participant participantB = study.getParticipant(userB);
-
-        final WriteReviewRequest request = WriteReviewRequest.builder()
-                .revieweeId(participantB.getUser().getId())
-                .activenessScore(5L)
-                .professionalismScore(5L)
-                .communicationScore(5L)
-                .togetherScore(5L)
-                .recommendScore(5L)
-                .build();
-
-        reviewService.write(request, study.getId(), userA);
-        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미 리뷰를 작성 하셨습니다.");
-
-
-    }
-
-    @DisplayName("[Exception] 존재하지 않는 스터디의 리뷰 작성은 불가능하다.")
-    @Test
-    void writeReviewForStudyNotExist() {
-        final User userA = userRepository.save(
-                User.builder()
-                        .nickname("userA")
-                        .email("userA@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-        final User userB = userRepository.save(
-                User.builder()
-                        .nickname("userB")
-                        .email("userB@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-        final WriteReviewRequest request = WriteReviewRequest.builder()
-                .revieweeId(userB.getId())
-                .activenessScore(5L)
-                .professionalismScore(5L)
-                .communicationScore(5L)
-                .togetherScore(5L)
-                .recommendScore(5L)
-                .build();
-
-        assertThatThrownBy(() -> reviewService.write(request, 2147483647L, userA))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("존재하지 않는 스터디입니다. 리뷰를 작성할 수 없습니다.");
-    }
 
     @DisplayName("[Exception] Reviewee가 스터디원이 아닌 경우, 리뷰 작성이 불가능하다.")
     @Test
     void writeReviewToNonParticipants() {
-
-        // given
-        final User owner = userRepository.save(
-                User.builder()
-                        .nickname("owner")
-                        .email("a@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-
-        final Category category = categoryRepository.save(
-                CategoryFixture.createCategory("category1"));
-
         final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
-        final LocalDateTime startDateTime = now.minusDays(20);
-        final LocalDateTime endDateTime = now.minusDays(3);
+        final LocalDateTime endDateTime = now.minusDays(10);
 
-        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
-        final StackCategory stackCategory = stackCategoryRepository.save(
-                StackCategoryFixture.createStackCategory("stackCategory")
-        );
+        final User reviewer = User.builder().id(1L).nickname("reviewer").email("reviewer@aa.aa").build();
+        final User notParticipantingReviewee = User.builder().id(2L).nickname("reviewee").email("reviewee@aa.aa").build();
+        final Study study = Study.builder().owner(reviewer).endDateTime(endDateTime).build();
+        final Position position = Position.builder().name("position").build();
+        study.addParticipant(reviewer, position, Role.OWNER);
 
-        final Stack stack = stackRepository.save(
-                StackFixture.createStack("stack", stackCategory)
-        );
-        final Position position = positionRepository.save(
-                PositionFixture.createPosition("position")
-        );
-
-        final User userA = userRepository.save(
-                User.builder()
-                        .nickname("userA")
-                        .email("userA@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-        final User userB = userRepository.save(
-                User.builder()
-                        .nickname("userB")
-                        .email("userB@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
+        final WriteReviewRequest request = WriteReviewRequest.builder().revieweeId(notParticipantingReviewee.getId()).activenessScore(5L).professionalismScore(5L).communicationScore(5L).togetherScore(5L).recommendScore(5L).build();
 
 
-        participantService.add(study, userA, position, Role.MEMBER);
+        // when
+        // then
 
-        final WriteReviewRequest request = WriteReviewRequest.builder()
-                .revieweeId(userB.getId())
-                .activenessScore(5L)
-                .professionalismScore(5L)
-                .communicationScore(5L)
-                .togetherScore(5L)
-                .recommendScore(5L)
-                .build();
-
-        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("스터디에 참여 중인 사용자에게만 리뷰를 작성할 수 있습니다.");
+        assertThatThrownBy(() -> reviewService.write(request, study, reviewer)).isInstanceOf(IllegalArgumentException.class).hasMessage("스터디에 참여 중인 사용자에게만 리뷰를 작성할 수 있습니다.");
     }
 
     @DisplayName("[Exception] Reviewer가 스터디원이 아닌 경우, 리뷰 작성이 불가능하다.")
     @Test
     void writeReviewIfNotParticipating() {
 
-        // given
-        final User owner = userRepository.save(
-                User.builder()
-                        .nickname("owner")
-                        .email("a@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-
-        final Category category = categoryRepository.save(
-                CategoryFixture.createCategory("category1"));
-
         final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
-        final LocalDateTime startDateTime = now.minusDays(20);
-        final LocalDateTime endDateTime = now.minusDays(3);
+        final LocalDateTime endDateTime = now.minusDays(10);
 
-        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
-        final StackCategory stackCategory = stackCategoryRepository.save(
-                StackCategoryFixture.createStackCategory("stackCategory")
-        );
+        final User notParticipatingReviewer = User.builder().id(1L).nickname("reviewer").email("reviewer@aa.aa").build();
+        final User reviewee = User.builder().id(2L).nickname("reviewee").email("reviewee@aa.aa").build();
+        final Study study = Study.builder().owner(notParticipatingReviewer).endDateTime(endDateTime).build();
+        final Position position = Position.builder().name("position").build();
+        study.addParticipant(reviewee, position, Role.MEMBER);
 
-        final Stack stack = stackRepository.save(
-                StackFixture.createStack("stack", stackCategory)
-        );
-        final Position position = positionRepository.save(
-                PositionFixture.createPosition("position")
-        );
+        final WriteReviewRequest request = WriteReviewRequest.builder().revieweeId(reviewee.getId()).activenessScore(5L).professionalismScore(5L).communicationScore(5L).togetherScore(5L).recommendScore(5L).build();
 
-        final User userA = userRepository.save(
-                User.builder()
-                        .nickname("userA")
-                        .email("userA@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-        final User userB = userRepository.save(
-                User.builder()
-                        .nickname("userB")
-                        .email("userB@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-
-
-        participantService.add(study, userB, position, Role.MEMBER);
-
-        final WriteReviewRequest request = WriteReviewRequest.builder()
-                .revieweeId(userB.getId())
-                .activenessScore(5L)
-                .professionalismScore(5L)
-                .communicationScore(5L)
-                .togetherScore(5L)
-                .recommendScore(5L)
-                .build();
-
-        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("참여 중인 스터디가 아닙니다. 리뷰를 작성할 수 없습니다.");
+        // when
+        // then
+        assertThatThrownBy(() -> reviewService.write(request, study, notParticipatingReviewer)).isInstanceOf(IllegalArgumentException.class).hasMessage("참여 중인 스터디가 아닙니다. 리뷰를 작성할 수 없습니다.");
     }
+
 
     @DisplayName("[Exception] 자기 자신에게는 리뷰 작성이 불가능하다.")
     @Test
     void writeReviewForSelf() {
-        // given
-        final User owner = userRepository.save(
-                User.builder()
-                        .nickname("owner")
-                        .email("a@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-
-        final Category category = categoryRepository.save(
-                CategoryFixture.createCategory("category1"));
 
         final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
-        final LocalDateTime startDateTime = now.minusDays(20);
-        final LocalDateTime endDateTime = now.minusDays(3);
+        final LocalDateTime endDateTime = now.minusDays(10);
 
-        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
-        final StackCategory stackCategory = stackCategoryRepository.save(
-                StackCategoryFixture.createStackCategory("stackCategory")
-        );
+        final User reviewer = User.builder().id(1L).nickname("reviewer").email("reviewer@aa.aa").build();
+        final Study study = Study.builder().owner(reviewer).endDateTime(endDateTime).build();
+        final Position position = Position.builder().name("position").build();
+        study.addParticipant(reviewer, position, Role.OWNER);
 
-        final Stack stack = stackRepository.save(
-                StackFixture.createStack("stack", stackCategory)
-        );
-        final Position position = positionRepository.save(
-                PositionFixture.createPosition("position")
-        );
+        final WriteReviewRequest request = WriteReviewRequest.builder().revieweeId(reviewer.getId()).activenessScore(5L).professionalismScore(5L).communicationScore(5L).togetherScore(5L).recommendScore(5L).build();
 
-        final User userA = userRepository.save(
-                User.builder()
-                        .nickname("userA")
-                        .email("userA@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-        final User userB = userRepository.save(
-                User.builder()
-                        .nickname("userB")
-                        .email("userB@aa.aa")
-                        .social(Social.KAKAO)
-                        .build());
-
-
-        participantService.add(study, userA, position, Role.MEMBER);
-
-        final WriteReviewRequest request = WriteReviewRequest.builder()
-                .revieweeId(userA.getId())
-                .activenessScore(5L)
-                .professionalismScore(5L)
-                .communicationScore(5L)
-                .togetherScore(5L)
-                .recommendScore(5L)
-                .build();
-
-        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("자기 자신에게는 리뷰를 작성할 수 없습니다.");
+        // when
+        // then
+        assertThatThrownBy(() -> reviewService.write(request, study, reviewer)).isInstanceOf(IllegalArgumentException.class).hasMessage("자기 자신에게는 리뷰를 작성할 수 없습니다.");
     }
 
-
-    private Study saveStudy(Category category, User owner) {
-        return studyRepository.save(
-                StudyFixture.createStudy(
-                        "study",
-                        category,
-                        owner,
-                        4,
-                        Platform.GATHER
-                )
-        );
-    }
-
-    private Study saveStudy(Category category, User owner, LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        return studyRepository.save(
-                Study.builder()
-                        .title("study")
-                        .category(category)
-                        .owner(owner)
-                        .platform(Platform.GATHER)
-                        .startDateTime(startDateTime)
-                        .endDateTime(endDateTime)
-                        .way(Way.ONLINE)
-                        .status(StudyStatus.COMPLETED)
-                        .participantLimit(4)
-                        .participantCount(1)
-                        .build()
-        );
-    }
-
-
-    private User saveOwner() {
-        return userRepository.save(
-                User.builder()
-                        .nickname("owner")
-                        .email("a@aa.aa")
-                        .social(Social.KAKAO)
-                        .build()
-        );
-    }
 }

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewServiceTest.java
@@ -1,0 +1,702 @@
+package com.ludo.study.studymatchingplatform.study.service.study;
+
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.Stack;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.StackCategory;
+import com.ludo.study.studymatchingplatform.study.domain.study.Platform;
+import com.ludo.study.studymatchingplatform.study.domain.study.Study;
+import com.ludo.study.studymatchingplatform.study.domain.study.StudyStatus;
+import com.ludo.study.studymatchingplatform.study.domain.study.Way;
+import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
+import com.ludo.study.studymatchingplatform.study.domain.study.participant.Participant;
+import com.ludo.study.studymatchingplatform.study.domain.study.participant.Role;
+import com.ludo.study.studymatchingplatform.study.fixture.recruitment.position.PositionFixture;
+import com.ludo.study.studymatchingplatform.study.fixture.recruitment.stack.StackCategoryFixture;
+import com.ludo.study.studymatchingplatform.study.fixture.recruitment.stack.StackFixture;
+import com.ludo.study.studymatchingplatform.study.fixture.study.StudyFixture;
+import com.ludo.study.studymatchingplatform.study.fixture.study.category.CategoryFixture;
+import com.ludo.study.studymatchingplatform.study.repository.recruitment.RecruitmentRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.recruitment.position.PositionRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.recruitment.stack.StackCategoryRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.recruitment.stack.StackRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.study.StudyRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.study.category.CategoryRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.study.participant.ParticipantRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.service.dto.request.study.WriteReviewRequest;
+import com.ludo.study.studymatchingplatform.study.service.dto.response.study.ReviewResponse;
+import com.ludo.study.studymatchingplatform.study.service.exception.InvalidReviewPeriodException;
+import com.ludo.study.studymatchingplatform.study.service.recruitment.RecruitmentService;
+import com.ludo.study.studymatchingplatform.study.service.recruitment.applicant.StudyApplicantDecisionService;
+import com.ludo.study.studymatchingplatform.study.service.study.participant.ParticipantService;
+import com.ludo.study.studymatchingplatform.user.domain.user.Social;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class ReviewServiceTest {
+
+    @Autowired
+    private ReviewService reviewService;
+
+    @Autowired
+    private UserRepositoryImpl userRepository;
+
+    @Autowired
+    private CategoryRepositoryImpl categoryRepository;
+
+    @Autowired
+    private StudyRepositoryImpl studyRepository;
+
+    @Autowired
+    private PositionRepositoryImpl positionRepository;
+
+    @Autowired
+    private StackRepositoryImpl stackRepository;
+
+    @Autowired
+    private StackCategoryRepositoryImpl stackCategoryRepository;
+
+    @Autowired
+    private RecruitmentRepositoryImpl recruitmentRepository;
+
+    @Autowired
+    private RecruitmentService recruitmentService;
+
+    @Autowired
+    private ParticipantRepositoryImpl participantRepository;
+
+    @Autowired
+    private StudyApplicantDecisionService studyApplicantDecisionService;
+
+    @Autowired
+    private ParticipantService participantService;
+
+    @Autowired
+    private EntityManager em;
+
+
+    @DisplayName("[Success] 스터디가 종료된지 3일 ~ 14일 내에 리뷰를 작성할 수 있다.")
+    @ParameterizedTest
+    @MethodSource("validEndDateTimes")
+    void writeReview(final LocalDateTime endDateTime) {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+
+        final LocalDateTime startDateTime = now.minusDays(20);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final Participant participantB = study.getParticipant(userB);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(participantB.getUser().getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+
+        // when
+        final ReviewResponse review = reviewService.write(request, study.getId(), userA);
+
+        // then
+        assertThat(review.reviewer().email())
+                .isEqualTo(userA.getEmail());
+
+    }
+
+    private static Stream<LocalDateTime> validEndDateTimes() {
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        return Stream.of(
+                now.minusDays(3),
+                now.minusDays(13),
+                now.minusDays(14)
+        );
+
+    }
+
+
+    @DisplayName("[Exception] 스터디가 종료된지 3일 ~ 14일 내가 아니라면 리뷰를 작성할 수 없다.")
+    @ParameterizedTest
+    @MethodSource("invalidEndDateTimes")
+    void writeReviewFailure(final LocalDateTime endDateTime) {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final Participant participantB = study.getParticipant(userB);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(participantB.getUser().getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        // when
+        // then
+        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
+                .isInstanceOf(InvalidReviewPeriodException.class);
+    }
+
+    @DisplayName("[Exception] 스터디가 종료된 후 3일이 지나기 전에는 리뷰를 작성할 수 없으며, 사용자에게 이를 인지하기 위한 적절한 안내 메세지를 보여준다.")
+    @Test
+    void writeReviewFailureBeforeThreeDaysAfterStudyDone() {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(3).plusSeconds(1);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final Participant participantB = study.getParticipant(userB);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(participantB.getUser().getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        // when
+        // then
+        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
+                .isInstanceOf(InvalidReviewPeriodException.class)
+                .hasMessage("아직 리뷰 작성 기간이 되지 않았습니다.\n리뷰 작성은 스터디 완료 3일 후인 2000년 01월 01일 00시 00분부터 14일 후인 2000년 01월 12일 00시 00분까지 가능합니다.");
+
+    }
+
+    @DisplayName("[Exception] 스터디가 종료된 후 14일이 지난 후에는 리뷰를 작성할 수 없으며, 사용자에게 이를 인지하기 위한 적절한 안내 메세지를 보여준다.")
+    @Test
+    void writeReviewFailureAfterFourteenDaysAfterStudyDone() {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(14).minusSeconds(1);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final Participant participantB = study.getParticipant(userB);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(participantB.getUser().getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        // when
+        // then
+        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
+                .isInstanceOf(InvalidReviewPeriodException.class)
+                .hasMessage("리뷰 작성 기간이 지났습니다.\n리뷰 작성은 스터디 완료 3일 후인 1999년 12월 20일 23시 59분부터 14일 후인 2000년 01월 01일 00시 00분까지 가능합니다.");
+
+    }
+
+    private static Stream<LocalDateTime> invalidEndDateTimes() {
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        return Stream.of(
+                now.minusDays(3).plusSeconds(1),
+                now.minusDays(14).minusSeconds(1)
+        );
+
+    }
+
+    @DisplayName("[Exception] 이미 리뷰를 작성한 스터디원에게는 재작성이 불가능하다.")
+    @Test
+    void writeDuplicateReview() {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(3);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final Participant participantB = study.getParticipant(userB);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(participantB.getUser().getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        reviewService.write(request, study.getId(), userA);
+        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 리뷰를 작성 하셨습니다.");
+
+
+    }
+
+    @DisplayName("[Exception] 존재하지 않는 스터디의 리뷰 작성은 불가능하다.")
+    @Test
+    void writeReviewForStudyNotExist() {
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(userB.getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        assertThatThrownBy(() -> reviewService.write(request, 2147483647L, userA))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 스터디입니다. 리뷰를 작성할 수 없습니다.");
+    }
+
+    @DisplayName("[Exception] Reviewee가 스터디원이 아닌 경우, 리뷰 작성이 불가능하다.")
+    @Test
+    void writeReviewToNonParticipants() {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(3);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(userB.getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("스터디에 참여 중인 사용자에게만 리뷰를 작성할 수 있습니다.");
+    }
+
+    @DisplayName("[Exception] Reviewer가 스터디원이 아닌 경우, 리뷰 작성이 불가능하다.")
+    @Test
+    void writeReviewIfNotParticipating() {
+
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(3);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userB, position, Role.MEMBER);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(userB.getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("참여 중인 스터디가 아닙니다. 리뷰를 작성할 수 없습니다.");
+    }
+
+    @DisplayName("[Exception] 자기 자신에게는 리뷰 작성이 불가능하다.")
+    @Test
+    void writeReviewForSelf() {
+        // given
+        final User owner = userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+        final Category category = categoryRepository.save(
+                CategoryFixture.createCategory("category1"));
+
+        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;
+        final LocalDateTime startDateTime = now.minusDays(20);
+        final LocalDateTime endDateTime = now.minusDays(3);
+
+        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
+        final StackCategory stackCategory = stackCategoryRepository.save(
+                StackCategoryFixture.createStackCategory("stackCategory")
+        );
+
+        final Stack stack = stackRepository.save(
+                StackFixture.createStack("stack", stackCategory)
+        );
+        final Position position = positionRepository.save(
+                PositionFixture.createPosition("position")
+        );
+
+        final User userA = userRepository.save(
+                User.builder()
+                        .nickname("userA")
+                        .email("userA@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+        final User userB = userRepository.save(
+                User.builder()
+                        .nickname("userB")
+                        .email("userB@aa.aa")
+                        .social(Social.KAKAO)
+                        .build());
+
+
+        participantService.add(study, userA, position, Role.MEMBER);
+
+        final WriteReviewRequest request = WriteReviewRequest.builder()
+                .revieweeId(userA.getId())
+                .activenessScore(5L)
+                .professionalismScore(5L)
+                .communicationScore(5L)
+                .togetherScore(5L)
+                .recommendScore(5L)
+                .build();
+
+        assertThatThrownBy(() -> reviewService.write(request, study.getId(), userA))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("자기 자신에게는 리뷰를 작성할 수 없습니다.");
+    }
+
+
+    private Study saveStudy(Category category, User owner) {
+        return studyRepository.save(
+                StudyFixture.createStudy(
+                        "study",
+                        category,
+                        owner,
+                        4,
+                        Platform.GATHER
+                )
+        );
+    }
+
+    private Study saveStudy(Category category, User owner, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        return studyRepository.save(
+                Study.builder()
+                        .title("study")
+                        .category(category)
+                        .owner(owner)
+                        .platform(Platform.GATHER)
+                        .startDateTime(startDateTime)
+                        .endDateTime(endDateTime)
+                        .way(Way.ONLINE)
+                        .status(StudyStatus.COMPLETED)
+                        .participantLimit(4)
+                        .participantCount(1)
+                        .build()
+        );
+    }
+
+
+    private User saveOwner() {
+        return userRepository.save(
+                User.builder()
+                        .nickname("owner")
+                        .email("a@aa.aa")
+                        .social(Social.KAKAO)
+                        .build()
+        );
+    }
+}


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

# 1. 테스트 속도 최적화(실험적)

- 직전까지는 Service Layer 테스트 시, Infrastructure Layer를 의존하고 있기 때문에, `SpringBootTest`를 통해 `ApplicationContext`를 로드하는 시간 + 외부 Node에 접근할 필요가 있었기 때문에 로딩 및 I/O 비용이 크게 소모 되는 구조였습니다.

```java
// ReviewServiceTest.java
@SpringBootTest // ApplicationContext 로드 필요
@Transactional
@ActiveProfiles("test")
public class ReviewServiceTest {
    // 다양한 Infrastructure에 대한 의존성 주입 필요
    @Autowired
    private ReviewService reviewService;

    @Autowired
    private UserRepositoryImpl userRepository;

    @Autowired
    private CategoryRepositoryImpl categoryRepository;

    @Autowired
    private StudyRepositoryImpl studyRepository;

    @Autowired
    private PositionRepositoryImpl positionRepository;

    @Autowired
    private StackRepositoryImpl stackRepository;

    @Autowired
    private StackCategoryRepositoryImpl stackCategoryRepository;

    @Autowired
    private RecruitmentRepositoryImpl recruitmentRepository;

    @Autowired
    private RecruitmentService recruitmentService;

    @Autowired
    private ParticipantRepositoryImpl participantRepository;

    @Autowired
    private StudyApplicantDecisionService studyApplicantDecisionService;

}
```

![integrationTest](https://github.com/Ludo-SMP/ludo-backend/assets/121966058/861d6b2d-c2ab-44e4-a14b-dff2faf6332d)

이 시점에서 `ReviewServiceTest`를 테스트하는 데 약 17초 정도 소요됩니다.

<img width="741" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/121966058/57d7d681-fa31-40b4-8034-1ea2b0b2ddbc">

대략 이러한 형태이기 때문에 unit test가 아닌 integration test로 분류되어야 하며, 속도가 느릴 수밖에 없는 구조입니다.

여기서 mocking을 사용하여 실제 I/O를 제거하면 테스트 시간이 다음과 같이 줄어들었습니다.

![unit_springbootall](https://github.com/Ludo-SMP/ludo-backend/assets/121966058/db367c8f-3097-4ea4-b1e2-e5b2c955c2a6)

Test Results 결과만 보면 I/O 수행 시는 1.318sec,  이를 배제하면 454ms로 거의 3분의 1 수준이 되었지만,
Context load 시간은 그대로이기 때문에 14초에 가까운 시간이 소요되었습니다. (17, 14초는 손으로 타이머를 start, stop 하면서 재서 정확하지 않고 수행 시간만 비교하면 사실상 1초 정도 차이인 것 같습니다.)

여기까지가 어제 이야기를 나눴던 부분 중 ApplicationContext load로 인한 테스트 비용을 측정한 것이며, 아카님이 염려하던 부분이라고 생각됩니다.

실제 의존성을 필요로 하는 mocking의 단점이라고 볼 수도 있겠지만, 이를 위해 fake stub을 만드는 것은 또 다른 시간적 비용이 들기 때문에 둘 다 사용하지 않고 load 시간을 줄이는 방법을 생각해봤습니다.

해결 방법에 대해서 생각하다가 클린 아키텍처에서 영감을 받았는데,
Clean Architecture던, Hexagonal Architecture던 Domain을 외부와 완전히 격리하여 전혀 영향을 받지 않고 독립적인 모듈로서 사용될 수 있다는 부분은 동일합니다.

즉, 이 부분이 비슷하지만 조금은 다른 두 아키텍쳐의 핵심이라고 볼 수 있습니다.

현재 저희 Service는 전부 Infrastructure Layer에 의존하는 형태이며, Service나 Infrastructure를 interface로 만드는 DIP를 적용하지 않았기 때문에 mocking 이외에는 infrastructure를 의존하지 않을 방법이 존재하지 않습니다.

`ReviewService`를 보면 그러한 구조가 여실히 드러납니다.

```java
// ReviewService.java
@Service
@Transactional
@RequiredArgsConstructor
public class ReviewService {

    // infrastructure의 구현체에 직접적으로 의존
    private final ReviewRepositoryImpl reviewRepository;
    private final StudyRepositoryImpl studyRepository;
    private final LocalDateTimePicker localDateTimePicker;

    public ReviewResponse write(WriteReviewRequest request, Long studyId, User reviewer) {
        // infra 접근1
        final Study study = studyRepository.findByIdWithParticipants(studyId)
                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디입니다. 리뷰를 작성할 수 없습니다."));

        final Participant participantingReviewer = study.findParticipant(reviewer.getId())
                .orElseThrow(() -> new IllegalArgumentException("참여 중인 스터디가 아닙니다. 리뷰를 작성할 수 없습니다."));
        final Participant participantingReviewee = study.findParticipant(request.revieweeId())
                .orElseThrow(() -> new IllegalArgumentException("스터디에 참여 중인 사용자에게만 리뷰를 작성할 수 있습니다."));
        if (participantingReviewer == participantingReviewee) {
            throw new IllegalArgumentException("자기 자신에게는 리뷰를 작성할 수 없습니다.");
        }

        // 명세 - [스터디가 진행 완료 상태로 바뀐 후 3일 후 부터, 14일 간 리뷰 작성 가능]
        // 진행 완료 상태로 바뀐 뒤 날짜를 정확히 추적하기 위해서는 추가적인 state 및 논의 필요할듯
        // -> 일단 EndDateTime 기반으로 작성
        study.ensureReviewPeriodAvailable(localDateTimePicker);

        // infra 접근2
        final boolean isDuplicateReview = reviewRepository.findAllByStudyId(studyId)
                .stream().anyMatch(review -> review.isDuplicateReview(studyId, reviewer.getId(), request.revieweeId()));
        if (isDuplicateReview) {
            throw new IllegalArgumentException("이미 리뷰를 작성 하셨습니다.");
        }

        final Review review = request.toReviewWithStudy(study, participantingReviewer.getUser(), participantingReviewee.getUser());
        // infra 접근3
        return ReviewResponse.from(reviewRepository.save(review));

    }

}
```

이런식으로 infra에 의존하는 코드가 로직 속에 혼재되어 있기 때문에 테스트 시 다음과 같이 수많은 의존성을 필요로 합니다.

```java
// ReviewServiceTest.java
@SpringBootTest
@Transactional
@ActiveProfiles("test")
public class ReviewServiceTest {

    @Autowired
    private ReviewService reviewService;

    @Autowired
    private UserRepositoryImpl userRepository;

    @Autowired
    private CategoryRepositoryImpl categoryRepository;

    @Autowired
    private StudyRepositoryImpl studyRepository;

    @Autowired
    private PositionRepositoryImpl positionRepository;

    @Autowired
    private StackRepositoryImpl stackRepository;

    @Autowired
    private StackCategoryRepositoryImpl stackCategoryRepository;

    @Autowired
    private RecruitmentRepositoryImpl recruitmentRepository;

    @Autowired
    private RecruitmentService recruitmentService;

    @Autowired
    private ParticipantRepositoryImpl participantRepository;

    @Autowired
    private StudyApplicantDecisionService studyApplicantDecisionService;

    @Autowired
    private ParticipantService participantService;

{
  // ... 생략
}
```

그리고  각 테스트 케이스에서도 다음과 같이 JPA 엔티티가 복잡하게 연관된 경우 이들 다수를 적절히 초기화 해야 합니다.

```java
// ReviewServiceTest.java
@DisplayName("[Success] 스터디가 종료된지 3일 ~ 14일 내에 리뷰를 작성할 수 있다.")
    @ParameterizedTest
    @MethodSource("validEndDateTimes")
    void writeReview(final LocalDateTime endDateTime) {

        // given
        final User owner = userRepository.save(
                User.builder()
                        .nickname("owner")
                        .email("a@aa.aa")
                        .social(Social.KAKAO)
                        .build());

        final Category category = categoryRepository.save(
                CategoryFixture.createCategory("category1"));

        final LocalDateTime now = FixedLocalDateTimePicker.DEFAULT_FIXED_LOCAL_DATE_TIME;

        final LocalDateTime startDateTime = now.minusDays(20);

        final Study study = saveStudy(category, owner, startDateTime, endDateTime);
        final StackCategory stackCategory = stackCategoryRepository.save(
                StackCategoryFixture.createStackCategory("stackCategory")
        );

        final Stack stack = stackRepository.save(
                StackFixture.createStack("stack", stackCategory)
        );
        final Position position = positionRepository.save(
                PositionFixture.createPosition("position")
        );

        final User userA = userRepository.save(
                User.builder()
                        .nickname("userA")
                        .email("userA@aa.aa")
                        .social(Social.KAKAO)
                        .build());
        final User userB = userRepository.save(
                User.builder()
                        .nickname("userB")
                        .email("userB@aa.aa")
                        .social(Social.KAKAO)
                        .build());


        participantService.add(study, userA, position, Role.MEMBER);
        participantService.add(study, userB, position, Role.MEMBER);

        final Participant participantB = study.getParticipant(userB);

        final WriteReviewRequest request = WriteReviewRequest.builder()
                .revieweeId(participantB.getUser().getId())
                .activenessScore(5L)
                .professionalismScore(5L)
                .communicationScore(5L)
                .togetherScore(5L)
                .recommendScore(5L)
                .build();


        // when
        final ReviewResponse review = reviewService.write(request, study.getId(), userA);

        // then
        assertThat(review.reviewer().email())
                .isEqualTo(userA.getEmail());

    }
```

덕분에 load 시간 및 I/O 시간이 모두 극한으로 소요되는 형태입니다.

I/O 시간은 mock으로 줄인다고 치고, load 시간을 줄일 방법은 간단합니다.

로드할 모든 의존성을 명시해주면 됩니다.

이러면 필요 없는 의존성들은 가져오지 않을 것입니다.

물론 내부적으로 사용되는 JPA 관련 의존성 등도 알아서 잘 명시해줘야 할 것입니다.

```java
// ReviewServiceTest.java
@SpringBootTest(classes={
  ReviewService.class,
  UserRepositoryImpl.class,
  CategoryRepositoryImpl.class,
  StudyRepositoryImpl.class,
  PositionRepositoryImpl.class,
  StackRepositoryImpl.class,
  StackCategoryRepositoryImpl.class,
  RecruitmentRepositoryImpl.class,
  RecruitmentService.class,
  ParticipantRepositoryImpl.class,
  StudyApplicantDecisionService.class,
  ParticipantService.class
})
```

mock으로 I/O 시간을 잡고, 이 방법으로 로딩 시간까지 잡을 수 있겠지만, 의존성이 많아질수록 사용하기 불편해질 것이라는 생각이 들었습니다.

그래서 앞서 언급했던 clean, hexagonal architecture에서 핵심으로 내세우는 Domain 격리를 시험삼아 적용해보았습니다.

아이디어는 간단합니다.

현재 `ReviewService`에서 infrastructure 접근 로직과 비즈니스 로직을 2개의 클래스로 분리합니다.

비즈니스 로직을 처리하는 클래스를 `ReviewService`로 만들고,
infra 접근 로직을 담당하는 클래스는 실제 로직은 위임한다고 하여 Facade라 명명했습니다.

코드는 다음과 같습니다.

```java
// ReviewFacade.java
@Service
@Transactional
@RequiredArgsConstructor
public class ReviewFacade {

    // infra layer 관련 의존성
    private final ReviewRepositoryImpl reviewRepository;
    private final StudyRepositoryImpl studyRepository;
    private final LocalDateTimePicker localDateTimePicker;
    private final ReviewService reviewService;

    public ReviewResponse write(WriteReviewRequest request, Long studyId, User reviewer) {
        // 모든 infra 관련 로직은 facade에서 처리
        final Study study = studyRepository.findByIdWithParticipants(studyId)
                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디입니다. 리뷰를 작성할 수 없습니다."));

        if (reviewRepository.existsBy(studyId, reviewer.getId(), request.revieweeId())) {
            throw new IllegalArgumentException("이미 리뷰를 작성 하셨습니다.");
        }

        // 실제 비즈니스 로직은 ReviewService에 위임
        final Review review = reviewService.write(request, study, reviewer);
        return ReviewResponse.from(reviewRepository.save(review));

    }

}

// 실제 비즈니스 로직 담당
// ReviewService.java
@Service
@Profile("test")
@Transactional
@RequiredArgsConstructor
public class ReviewService {

    private final LocalDateTimePicker localDateTimePicker;

    public Review write(WriteReviewRequest request, Study study, User reviewer) {
        final Participant participantingReviewer = study.findParticipant(reviewer.getId())
                .orElseThrow(() -> new IllegalArgumentException("참여 중인 스터디가 아닙니다. 리뷰를 작성할 수 없습니다."));
        final Participant participantingReviewee = study.findParticipant(request.revieweeId())
                .orElseThrow(() -> new IllegalArgumentException("스터디에 참여 중인 사용자에게만 리뷰를 작성할 수 있습니다."));
        if (participantingReviewer == participantingReviewee) {
            throw new IllegalArgumentException("자기 자신에게는 리뷰를 작성할 수 없습니다.");
        }

        // 명세 - [스터디가 진행 완료 상태로 바뀐 후 3일 후 부터, 14일 간 리뷰 작성 가능]
        study.ensureReviewPeriodAvailable(localDateTimePicker);
        return request.toReviewWithStudy(study, participantingReviewer.getUser(), participantingReviewee.getUser());

    }

}
```

이렇게 두 부분으로 나눈 뒤, `ReviewService`의 Test를 다음과 같이 작성할 수 있습니다.

`ReviewService`는 이제 infra와 전혀 관련이 없는 순수 자바코드이기 때문에, 의존성을 대폭 줄일 수 있습니다.

persist조차 하지 않기 때문에 JPA 관련 의존성 및 트랜잭션을 고려할 필요가 없어집니다.

이러한 구성을 시험해보면서 Persistence Context 자체를 코드와 머릿속에서 지워버리니, JPA Entity를 순수한 Domain Entity처럼 다루는 느낌이었습니다.

```java
// 실제로 사용할 의존성만 로드
@SpringBootTest(classes = {ReviewService.class, FixedLocalDateTimePicker.class})
@ActiveProfiles("test")
public final class ReviewServiceTest {
    // 수많은 모든 의존성이 필요 없어짐
    @Autowired
    private ReviewService reviewService;

 @DisplayName("[Success] 스터디가 종료된지 3일 ~ 14일 내에 리뷰를 작성할 수 있다.")
    @ParameterizedTest
    @MethodSource("validEndDateTimes")
    void writeReview(final LocalDateTime endDateTime) {
        // given
        final User reviewer = User.builder()
                .id(1L)
                .nickname("reviewer")
                .email("reviewer@aa.aa")
                .build();
        final User reviewee = User.builder()
                .id(2L)
                .nickname("reviewee")
                .email("reviewee@aa.aa")
                .build();
        final Study study = Study.builder()
                .owner(reviewer)
                .endDateTime(endDateTime)
                .build();
        final Position position = Position.builder()
                .name("position")
                .build();
        study.addParticipant(reviewer, position, Role.OWNER);
        study.addParticipant(reviewee, position, Role.MEMBER);

        final WriteReviewRequest request = WriteReviewRequest.builder()
                .revieweeId(reviewee.getId())
                .activenessScore(5L)
                .professionalismScore(5L)
                .communicationScore(5L)
                .togetherScore(5L)
                .recommendScore(5L)
                .build();


        // when
        final Review review = reviewService.write(request, study, reviewer);

        // then
        assertThat(review.getReviewer()).isEqualTo(reviewer);
        assertThat(review.getReviewee()).isEqualTo(reviewee);

    }

}
```

여기서 약간의 변경으로 Application Context 자체를 지워버릴 수도 있습니다.

이러면 Junit의 `@Test` 등을 제외하면 어떠한 Annotation도 필요하지 않게 됩니다.

test 환경과 그 외 환경에서 구현체가 교체되어야 하는 경우에도 ActiveProfile를 설정할 필요 없이 직접 `FixedLocalDateTimePicker`를 넣어주면 됩니다.

```java
public final class ReviewServiceTest {

    private final ReviewService reviewService = new ReviewService(new FixedLocalDateTimePicker());

}
```

![unit_nodeps](https://github.com/Ludo-SMP/ludo-backend/assets/121966058/4381c677-6ad7-476e-8757-657557208e73)

이를 적용한 결과, 테스트 시간은 1초 이내로 완료 되었습니다.

실험적인 방법이기는 하나 `ReviewTest`에 적용하는 데는 문제가 없었습니다. 이와 비슷한 류의 좀 더 정제된 방법론이 있다면 좀 더 찾아보는 것이 좋을 것 같습니다.

만약 이러한 구조를 적용한다면, Service를 순수 Domain, Infra Access 2가지 역할로 나누고, Infra에 Access하는 Facade에서만 mocking을 적용하면 괜찮지 않을까 싶네요.

<br><br>

---

# 2. IntegrationTest 프로젝트에 적용

어제 이야기를 나눴던 대로 src 폴더 밑에 integrationTest를 두었습니다.

폴더명은 휴님이 올리신 참고 자료를 그대로 차용했습니다.

<img width="264" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/121966058/6d744da6-b900-49fd-84ed-bab078f0e926">

플러그인 및 명령어를 추가했습니다.

```
// build.gradle
plugins {
    id 'java'
    id 'org.springframework.boot' version '3.2.1'
    id 'io.spring.dependency-management' version '1.1.4'
    // 플러그인 추가
    id 'org.unbroken-dome.test-sets' version '4.1.0'
}

// ... 생략

// 명령어 추가
tasks.withType(Test) {
    useJUnitPlatform()
}

testSets {
    integrationTest
}
```

### 💡 다음 자료를 참고하면 좋아요.

![image](https://github.com/Ludo-SMP/ludo-backend/assets/121966058/cac283e5-05cb-43c7-8821-98ea1d9e62db)


<br><br>

### ✅ 셀프 체크리스트

- [O] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [O] 커밋 메세지를 컨벤션에 맞추었습니다.
- [O] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [O] 변경 후 코드는 기존의 테스트를 통과합니다.
- [O] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [O] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
