### PR TITLE
SP-614/refactor: 알림 대상자 조회에서 알림 설정 필터 로직 추가

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/common/utils/CurrentUtcDateTimePicker.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/utils/CurrentUtcDateTimePicker.java
@@ -1,17 +1,18 @@
 package com.ludo.study.studymatchingplatform.common.utils;
 
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Component;
-
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
 
 @Profile("!test")
 @Component
 public class CurrentUtcDateTimePicker implements UtcDateTimePicker {
 
-    public LocalDateTime now() {
-        return LocalDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS);
-    }
+	@Override
+	public LocalDateTime now() {
+		return LocalDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS);
+	}
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/common/utils/UtcDateTimePicker.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/utils/UtcDateTimePicker.java
@@ -1,6 +1,7 @@
 package com.ludo.study.studymatchingplatform.common.utils;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 /**
  * <h5>테스트 시, Profile을 "test"로 설정하면 항상 2000-01-01으로 고정된 DateTime 획득 </h5>
@@ -29,5 +30,9 @@ import java.time.LocalDateTime;
  * @see CurrentUtcDateTimePicker
  */
 public interface UtcDateTimePicker {
-    LocalDateTime now();
+	LocalDateTime now();
+
+	default LocalDateTime toMicroSeconds(LocalDateTime dateTime) {
+		return dateTime.truncatedTo(ChronoUnit.MICROS);
+	}
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/config/GlobalNotificationUserConfig.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/config/GlobalNotificationUserConfig.java
@@ -115,7 +115,7 @@ public class GlobalNotificationUserConfig {
 	}
 
 	private void updateReviewConfig(boolean enabled) {
-		this.studyParticipantLeaveConfig = enabled;
+		this.reviewConfig = enabled;
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/config/NotificationConfigGroup.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/config/NotificationConfigGroup.java
@@ -19,7 +19,7 @@ public enum NotificationConfigGroup {
 	STUDY_PARTICIPANT_LEAVE_CONFIG(List.of(STUDY_PARTICIPANT_LEAVE, STUDY_PARTICIPANT_LEAVE_APPLY)),
 	REVIEW_CONFIG(List.of(STUDY_REVIEW_START, REVIEW_RECEIVE, REVIEW_PEER_FINISH));
 
-	private List<NotificationEventType> notificationEventTypes;
+	private final List<NotificationEventType> notificationEventTypes;
 
 	NotificationConfigGroup(List<NotificationEventType> notificationEventTypes) {
 		this.notificationEventTypes = notificationEventTypes;

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/config/GlobalNotificationUserConfigRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/config/GlobalNotificationUserConfigRepositoryImpl.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 import com.ludo.study.studymatchingplatform.notification.domain.config.GlobalNotificationUserConfig;
+import com.ludo.study.studymatchingplatform.notification.domain.config.NotificationConfigGroup;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -30,4 +32,26 @@ public class GlobalNotificationUserConfigRepositoryImpl {
 						.fetchOne()
 		);
 	}
+
+	public boolean isUserNotificationConfigIsTrue(final Long userId,
+												  final NotificationConfigGroup notificationConfigGroup) {
+		return q.selectOne()
+				.from(globalNotificationUserConfig)
+				.where(globalNotificationUserConfig.user.id.eq(userId),
+						isConfigTrue(notificationConfigGroup))
+				.fetchOne() != null;
+	}
+
+	private BooleanExpression isConfigTrue(final NotificationConfigGroup notificationConfigGroup) {
+		return switch (notificationConfigGroup) {
+			case ALL_CONFIG -> globalNotificationUserConfig.allConfig.isTrue();
+			case RECRUITMENT_CONFIG -> globalNotificationUserConfig.recruitmentConfig.isTrue();
+			case STUDY_APPLICANT_CONFIG -> globalNotificationUserConfig.studyApplicantConfig.isTrue();
+			case STUDY_APPLICANT_RESULT_CONFIG -> globalNotificationUserConfig.studyApplicantResultConfig.isTrue();
+			case STUDY_END_DATE_CONFIG -> globalNotificationUserConfig.studyEndDateConfig.isTrue();
+			case STUDY_PARTICIPANT_LEAVE_CONFIG -> globalNotificationUserConfig.studyParticipantLeaveConfig.isTrue();
+			case REVIEW_CONFIG -> globalNotificationUserConfig.reviewConfig.isTrue();
+		};
+	}
+
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/dto/StudyEndDateNotifierCond.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/dto/StudyEndDateNotifierCond.java
@@ -4,6 +4,6 @@ import java.time.LocalDateTime;
 
 import com.ludo.study.studymatchingplatform.study.domain.study.participant.Role;
 
-public record StudyEndDateNotifierCond(Role role, LocalDateTime startOfDay, LocalDateTime endOfDay) {
+public record StudyEndDateNotifierCond(Role role, LocalDateTime endDateStartOfDay, LocalDateTime endDateEndOfDay) {
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/dto/StudyReviewStartNotifierCond.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/dto/StudyReviewStartNotifierCond.java
@@ -2,9 +2,6 @@ package com.ludo.study.studymatchingplatform.notification.repository.dto;
 
 import java.time.LocalDateTime;
 
-import com.ludo.study.studymatchingplatform.study.domain.study.StudyStatus;
-
-public record StudyReviewStartNotifierCond(LocalDateTime startOfDay,
-										   LocalDateTime endOfDay,
-										   StudyStatus studyStatus) {
+public record StudyReviewStartNotifierCond(LocalDateTime yesterdayStartOfDay,
+										   LocalDateTime yesterdayEndOfDay) {
 }

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/fixture/study/StudyFixture.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/fixture/study/StudyFixture.java
@@ -3,44 +3,104 @@ package com.ludo.study.studymatchingplatform.study.fixture.study;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
+import com.ludo.study.studymatchingplatform.common.utils.UtcDateTimePicker;
 import com.ludo.study.studymatchingplatform.study.domain.study.Platform;
 import com.ludo.study.studymatchingplatform.study.domain.study.Study;
 import com.ludo.study.studymatchingplatform.study.domain.study.StudyStatus;
 import com.ludo.study.studymatchingplatform.study.domain.study.Way;
 import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
 import com.ludo.study.studymatchingplatform.study.fixture.study.category.CategoryFixture;
+import com.ludo.study.studymatchingplatform.study.service.study.FixedUtcDateTimePicker;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
-import com.ludo.study.studymatchingplatform.user.fixture.user.UserFixture;
 
 public class StudyFixture {
 
-	public static final Study USER1_PROJECT_ONLINE_STUDY = Study.builder()
-			.title("프로젝트 온라인 스터디 제목")
-			.owner(UserFixture.user1)
-			.category(CategoryFixture.CATEGORY_PROJECT)
-			.status(StudyStatus.RECRUITING)
-			.way(Way.ONLINE)
-			.platform(Platform.GATHER)
-			.platformUrl("platform url")
-			.participantCount(1)
-			.participantLimit(5)
-			.startDateTime(LocalDateTime.now().truncatedTo(ChronoUnit.MICROS))
-			.endDateTime(LocalDateTime.now().plusMonths(1).truncatedTo(ChronoUnit.MICROS))
-			.build();
+	public static Study PROJECT_ONLINE_STUDY(User owner, UtcDateTimePicker utcDateTimePicker) {
 
-	public static final Study study1 = Study.builder()
-			.title("스터디1 제목")
-			.owner(UserFixture.user1)
-			.category(CategoryFixture.CATEGORY_PROJECT)
-			.status(StudyStatus.RECRUITING)
-			.way(Way.ONLINE)
-			.platform(Platform.GATHER)
-			.platformUrl("platform url")
-			.participantCount(1)
-			.participantLimit(5)
-			.startDateTime(LocalDateTime.now().truncatedTo(ChronoUnit.MICROS))
-			.endDateTime(LocalDateTime.now().plusMonths(1).truncatedTo(ChronoUnit.MICROS))
-			.build();
+		return Study.builder()
+				.title("프로젝트 온라인 스터디 제목")
+				.owner(owner)
+				.category(CategoryFixture.CATEGORY_PROJECT)
+				.status(StudyStatus.RECRUITING)
+				.way(Way.ONLINE)
+				.platform(Platform.GATHER)
+				.platformUrl("platform url")
+				.participantCount(1)
+				.participantLimit(5)
+				.startDateTime(utcDateTimePicker.now().truncatedTo(ChronoUnit.MICROS))
+				.endDateTime(utcDateTimePicker.now().plusMonths(1).truncatedTo(ChronoUnit.MICROS))
+				.build();
+	}
+
+	public static Study STUDY1(User owner, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+
+		return Study.builder()
+				.title("스터디1 제목")
+				.owner(owner)
+				.category(CategoryFixture.CATEGORY_PROJECT)
+				.status(StudyStatus.RECRUITING)
+				.way(Way.ONLINE)
+				.platform(Platform.GATHER)
+				.platformUrl("platform url")
+				.participantCount(1)
+				.participantLimit(5)
+				.startDateTime(startDateTime)
+				.endDateTime(endDateTime.truncatedTo(ChronoUnit.MICROS))
+				.build();
+	}
+
+	public static Study STUDY2(User owner, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+
+		return Study.builder()
+				.title("스터디2 제목")
+				.owner(owner)
+				.category(CategoryFixture.CATEGORY_PROJECT)
+				.status(StudyStatus.RECRUITING)
+				.way(Way.ONLINE)
+				.platform(Platform.GATHER)
+				.platformUrl("platform url")
+				.participantCount(1)
+				.participantLimit(5)
+				.startDateTime(startDateTime)
+				.endDateTime(endDateTime.truncatedTo(ChronoUnit.MICROS))
+				.build();
+	}
+
+	public static Study STUDY3(User owner, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+		FixedUtcDateTimePicker fixedUtcDateTimePicker = new FixedUtcDateTimePicker();
+
+		return Study.builder()
+				.title("스터디3 제목")
+				.owner(owner)
+				.category(CategoryFixture.CATEGORY_PROJECT)
+				.status(StudyStatus.RECRUITING)
+				.way(Way.ONLINE)
+				.platform(Platform.GATHER)
+				.platformUrl("platform url")
+				.participantCount(1)
+				.participantLimit(5)
+				.startDateTime(startDateTime)
+				.endDateTime(endDateTime.truncatedTo(ChronoUnit.MICROS))
+				.build();
+	}
+
+	public static Study STUDY4(User owner, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+		FixedUtcDateTimePicker fixedUtcDateTimePicker = new FixedUtcDateTimePicker();
+
+		return Study.builder()
+				.title("스터디4 제목")
+				.owner(owner)
+				.category(CategoryFixture.CATEGORY_PROJECT)
+				.status(StudyStatus.RECRUITING)
+				.way(Way.ONLINE)
+				.platform(Platform.GATHER)
+				.platformUrl("platform url")
+				.participantCount(1)
+				.participantLimit(5)
+				.startDateTime(startDateTime)
+				.endDateTime(endDateTime.truncatedTo(ChronoUnit.MICROS))
+				.build();
+	}
 
 	public static Study createStudy(StudyStatus studyStatus, String title, Way way, Category category, User user,
 									int participantCount, int participantLimit, Platform platform, String platformUrl

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/fixture/study/participant/ParticipantFixture.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/fixture/study/participant/ParticipantFixture.java
@@ -4,29 +4,9 @@ import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Po
 import com.ludo.study.studymatchingplatform.study.domain.study.Study;
 import com.ludo.study.studymatchingplatform.study.domain.study.participant.Participant;
 import com.ludo.study.studymatchingplatform.study.domain.study.participant.Role;
-import com.ludo.study.studymatchingplatform.study.fixture.study.StudyFixture;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
-import com.ludo.study.studymatchingplatform.user.fixture.user.UserFixture;
 
 public class ParticipantFixture {
-
-	public static final Participant study1ParticipantUser1 = Participant.builder()
-			.study(StudyFixture.study1)
-			.user(UserFixture.user1)
-			.role(Role.OWNER)
-			.build();
-
-	public static final Participant study1ParticipantUser2 = Participant.builder()
-			.study(StudyFixture.study1)
-			.user(UserFixture.user2)
-			.role(Role.MEMBER)
-			.build();
-
-	public static final Participant study1ParticipantUser3 = Participant.builder()
-			.study(StudyFixture.study1)
-			.user(UserFixture.user3)
-			.role(Role.MEMBER)
-			.build();
 
 	public static Participant createParticipant(Study study, User user, Position position, Role role) {
 		return Participant.builder()

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentsFindServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentsFindServiceTest.java
@@ -84,8 +84,8 @@ class RecruitmentsFindServiceTest {
 		@BeforeEach
 		void init() {
 			User user = saveUser();
-			Category category = saveCategory();
-			saveRecruitments(category, user);
+			Category project = CategoryFixture.CATEGORY_PROJECT;
+			saveRecruitments(project, user);
 			em.flush();
 			em.clear();
 		}

--- a/src/test/java/com/ludo/study/studymatchingplatform/user/fixture/user/UserFixture.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/user/fixture/user/UserFixture.java
@@ -5,29 +5,37 @@ import com.ludo.study.studymatchingplatform.user.domain.user.User;
 
 public class UserFixture {
 
-	public static final User user1 = User.builder()
-			.social(Social.NAVER)
-			.nickname("user1")
-			.email("user1@naver.com")
-			.build();
+	public static User USER1() {
+		return User.builder()
+				.social(Social.NAVER)
+				.nickname("user1")
+				.email("user1@naver.com")
+				.build();
+	}
 
-	public static final User user2 = User.builder()
-			.social(Social.KAKAO)
-			.nickname("user2")
-			.email("user2@kakao.com")
-			.build();
+	public static User USER2() {
+		return User.builder()
+				.social(Social.KAKAO)
+				.nickname("user2")
+				.email("user2@kakao.com")
+				.build();
+	}
 
-	public static final User user3 = User.builder()
-			.social(Social.GOOGLE)
-			.nickname("user3")
-			.email("user3@google.com")
-			.build();
+	public static User USER3() {
+		return User.builder()
+				.social(Social.GOOGLE)
+				.nickname("user3")
+				.email("user3@google.com")
+				.build();
+	}
 
-	public static final User user4 = User.builder()
-			.social(Social.NAVER)
-			.nickname("user4")
-			.email("user4@naver.com")
-			.build();
+	public static User USER4() {
+		return User.builder()
+				.social(Social.NAVER)
+				.nickname("user4")
+				.email("user4@naver.com")
+				.build();
+	}
 
 	public static User createUser(Social social, String nickname, String email) {
 		return User.builder()


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

- [x] 알림 대상자 조회에서 알림 설정 필터 로직 추가
- [x] 알림 대상자 조회 테스트 코드 보강

<br><br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.
### 알림 대상자 조회에서 알림 설정 필터 로직 추가
[feat: 모집공고알림 대상자 조회, 스터디지원알림 대상자 조회, 스터디원탈퇴알림 대상자 조회에 알림 설정 조건 추가](https://github.com/Ludo-SMP/ludo-backend/commit/a0a8ef727e73cbfbb41507020badb0910caefa4a)
[feat: 스터디종료기간 알림 대상자, 스터디리뷰시작 알림 대상자 조회 기능에 알림 설정 조건절 추가](https://github.com/Ludo-SMP/ludo-backend/commit/6c2a8dffb2a3eb8ff099fa83b4bbcbd514a18182)

알림 대상자 조회로직에 `GlobalNotificationUserConfig` Inner Join및 Boolean Config 필드를 확인하는 조건절을 추가했습니다.

한가지 특이사항은 `모집공고 알림 대상자 조회`에서 `Sub Query + In 절`을 사용하돈 로직을 `암시적 Inner Join절`로 수정했습니다.

<br><br>

### 알림 대상자 조회 테스트 코드 보강
[test: 알림 대상자 조회 로직 테스트 보강](https://github.com/Ludo-SMP/ludo-backend/commit/fb76ec6dac5d15a859340457fc272aea35377fe5)
<img width="1512" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/68291395/1908cf75-e882-4f86-9bb8-69172968512b">

<br><br>

<img width="587" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/68291395/47052e62-b9db-405b-bede-af0cef98dfd7">

<br><br>

테스트 코드는 @Nested 애노테이션으로 계층형 클래스 구조를 활용했습니다. 위의 그림과 같이 테스트 클래스를 폴더 형식으로 관리할 수 있고, 알림 기능의 복잡한 비즈니스 요구사항에 대한 테스트를 비교적 추적 용이하다는 점이 장점으로 느껴집니다.

<br>

계층형 클래스 구조와 연계하여 `Describe-Context-It` 패턴의 일부를 차용했습니다. @Nested 클래스는 `Describe`에 해당하며, 각 테스트 메서드는 `Context-It`에 해당합니다.


<br><br>

### 💡 다음 자료를 참고하면 좋아요.

- [테스트코드: Describe-Context-It 패턴](https://johngrib.github.io/wiki/junit5-nested/)

<br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
  - 페이지네이션 쿼리에 대한 테스트가 실패하여, 리팩터링 예정입니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
