### PR TITLE
SP-613/feat: 알림 읽음 API 구현

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/common/utils/CurrentUtcDateTimePicker.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/utils/CurrentUtcDateTimePicker.java
@@ -1,17 +1,18 @@
 package com.ludo.study.studymatchingplatform.common.utils;
 
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Component;
-
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
 
 @Profile("!test")
 @Component
 public class CurrentUtcDateTimePicker implements UtcDateTimePicker {
 
-    public LocalDateTime now() {
-        return LocalDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS);
-    }
+	@Override
+	public LocalDateTime now() {
+		return LocalDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS);
+	}
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/common/utils/UtcDateTimePicker.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/common/utils/UtcDateTimePicker.java
@@ -1,6 +1,7 @@
 package com.ludo.study.studymatchingplatform.common.utils;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 /**
  * <h5>테스트 시, Profile을 "test"로 설정하면 항상 2000-01-01으로 고정된 DateTime 획득 </h5>
@@ -29,5 +30,9 @@ import java.time.LocalDateTime;
  * @see CurrentUtcDateTimePicker
  */
 public interface UtcDateTimePicker {
-    LocalDateTime now();
+	LocalDateTime now();
+
+	default LocalDateTime toMicroSeconds(LocalDateTime dateTime) {
+		return dateTime.truncatedTo(ChronoUnit.MICROS);
+	}
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/controller/NotificationCheckRequest.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/controller/NotificationCheckRequest.java
@@ -1,0 +1,6 @@
+package com.ludo.study.studymatchingplatform.notification.controller;
+
+import java.util.List;
+
+public record NotificationCheckRequest(List<Long> notificationIds) {
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/controller/NotificationController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/controller/NotificationController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -72,6 +73,15 @@ public class NotificationController {
 		notificationService.configNotificationCategoryKeywords(user, notificationKeywordConfigRequest.categoryIds());
 		notificationService.configNotificationPositionKeywords(user, notificationKeywordConfigRequest.positionIds());
 		notificationService.configNotificationStackKeywords(user, notificationKeywordConfigRequest.stackIds());
+
+		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/check")
+	public ResponseEntity<Void> checkNotifications(@AuthUser final User user,
+												   @RequestBody final NotificationCheckRequest notificationCheckRequest
+	) {
+		notificationService.checkNotificationsAsRead(user, notificationCheckRequest.notificationIds());
 
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/controller/NotificationController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/controller/NotificationController.java
@@ -12,9 +12,10 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.ludo.study.studymatchingplatform.auth.common.AuthUser;
-import com.ludo.study.studymatchingplatform.notification.service.NotificationConfigRequest;
+import com.ludo.study.studymatchingplatform.notification.controller.dto.request.NotificationKeywordConfigRequest;
 import com.ludo.study.studymatchingplatform.notification.service.NotificationService;
 import com.ludo.study.studymatchingplatform.notification.service.SseEmitters;
+import com.ludo.study.studymatchingplatform.notification.service.dto.request.NotificationConfigRequest;
 import com.ludo.study.studymatchingplatform.notification.service.dto.response.NotificationResponse;
 import com.ludo.study.studymatchingplatform.notification.service.dto.response.config.NotificationConfigResponse;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/controller/dto/request/NotificationKeywordConfigRequest.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/controller/dto/request/NotificationKeywordConfigRequest.java
@@ -1,4 +1,4 @@
-package com.ludo.study.studymatchingplatform.notification.controller;
+package com.ludo.study.studymatchingplatform.notification.controller.dto.request;
 
 import java.util.List;
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/config/GlobalNotificationUserConfig.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/config/GlobalNotificationUserConfig.java
@@ -115,7 +115,7 @@ public class GlobalNotificationUserConfig {
 	}
 
 	private void updateReviewConfig(boolean enabled) {
-		this.studyParticipantLeaveConfig = enabled;
+		this.reviewConfig = enabled;
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/config/NotificationConfigGroup.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/config/NotificationConfigGroup.java
@@ -19,7 +19,7 @@ public enum NotificationConfigGroup {
 	STUDY_PARTICIPANT_LEAVE_CONFIG(List.of(STUDY_PARTICIPANT_LEAVE, STUDY_PARTICIPANT_LEAVE_APPLY)),
 	REVIEW_CONFIG(List.of(STUDY_REVIEW_START, REVIEW_RECEIVE, REVIEW_PEER_FINISH));
 
-	private List<NotificationEventType> notificationEventTypes;
+	private final List<NotificationEventType> notificationEventTypes;
 
 	NotificationConfigGroup(List<NotificationEventType> notificationEventTypes) {
 		this.notificationEventTypes = notificationEventTypes;

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/Notification.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/Notification.java
@@ -57,4 +57,8 @@ public class Notification {
 		this.notifier = notifier;
 	}
 
+	public boolean isRead() {
+		return read;
+	}
+
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/config/GlobalNotificationUserConfigRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/config/GlobalNotificationUserConfigRepositoryImpl.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 import com.ludo.study.studymatchingplatform.notification.domain.config.GlobalNotificationUserConfig;
+import com.ludo.study.studymatchingplatform.notification.domain.config.NotificationConfigGroup;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -30,4 +32,26 @@ public class GlobalNotificationUserConfigRepositoryImpl {
 						.fetchOne()
 		);
 	}
+
+	public boolean isUserNotificationConfigIsTrue(final Long userId,
+												  final NotificationConfigGroup notificationConfigGroup) {
+		return q.selectOne()
+				.from(globalNotificationUserConfig)
+				.where(globalNotificationUserConfig.user.id.eq(userId),
+						isConfigTrue(notificationConfigGroup))
+				.fetchOne() != null;
+	}
+
+	private BooleanExpression isConfigTrue(final NotificationConfigGroup notificationConfigGroup) {
+		return switch (notificationConfigGroup) {
+			case ALL_CONFIG -> globalNotificationUserConfig.allConfig.isTrue();
+			case RECRUITMENT_CONFIG -> globalNotificationUserConfig.recruitmentConfig.isTrue();
+			case STUDY_APPLICANT_CONFIG -> globalNotificationUserConfig.studyApplicantConfig.isTrue();
+			case STUDY_APPLICANT_RESULT_CONFIG -> globalNotificationUserConfig.studyApplicantResultConfig.isTrue();
+			case STUDY_END_DATE_CONFIG -> globalNotificationUserConfig.studyEndDateConfig.isTrue();
+			case STUDY_PARTICIPANT_LEAVE_CONFIG -> globalNotificationUserConfig.studyParticipantLeaveConfig.isTrue();
+			case REVIEW_CONFIG -> globalNotificationUserConfig.reviewConfig.isTrue();
+		};
+	}
+
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/dto/StudyEndDateNotifierCond.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/dto/StudyEndDateNotifierCond.java
@@ -4,6 +4,6 @@ import java.time.LocalDateTime;
 
 import com.ludo.study.studymatchingplatform.study.domain.study.participant.Role;
 
-public record StudyEndDateNotifierCond(Role role, LocalDateTime startOfDay, LocalDateTime endOfDay) {
+public record StudyEndDateNotifierCond(Role role, LocalDateTime endDateStartOfDay, LocalDateTime endDateEndOfDay) {
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/dto/StudyReviewStartNotifierCond.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/dto/StudyReviewStartNotifierCond.java
@@ -2,9 +2,6 @@ package com.ludo.study.studymatchingplatform.notification.repository.dto;
 
 import java.time.LocalDateTime;
 
-import com.ludo.study.studymatchingplatform.study.domain.study.StudyStatus;
-
-public record StudyReviewStartNotifierCond(LocalDateTime startOfDay,
-										   LocalDateTime endOfDay,
-										   StudyStatus studyStatus) {
+public record StudyReviewStartNotifierCond(LocalDateTime yesterdayStartOfDay,
+										   LocalDateTime yesterdayEndOfDay) {
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/notification/NotificationJpaRepository.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/notification/NotificationJpaRepository.java
@@ -1,0 +1,9 @@
+package com.ludo.study.studymatchingplatform.notification.repository.notification;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ludo.study.studymatchingplatform.notification.domain.notification.Notification;
+
+public interface NotificationJpaRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/notification/NotificationRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/notification/NotificationRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.ludo.study.studymatchingplatform.notification.repository.notification;
+
+import static com.ludo.study.studymatchingplatform.notification.domain.notification.QNotification.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.ludo.study.studymatchingplatform.notification.domain.notification.Notification;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl {
+
+	private final JPAQueryFactory q;
+	private final NotificationJpaRepository notificationJpaRepository;
+	private final EntityManager em;
+
+	public void updateNotificationsAsRead(final Long userId, final List<Long> notificationIds) {
+		q.update(notification)
+				.set(notification.read, true)
+				.where(notification.notifier.id.eq(userId),
+						notification.id.in(notificationIds))
+				.execute();
+
+		em.flush();
+		em.clear();
+	}
+
+	public List<Notification> saveAll(final List<Notification> notifications) {
+		return notificationJpaRepository.saveAll(notifications);
+	}
+
+	public List<Notification> findAllByUserId(final Long userId) {
+		return q.selectFrom(notification)
+				.where(notification.notifier.id.eq(userId))
+				.fetch();
+	}
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationCommandService.java
@@ -18,6 +18,7 @@ import com.ludo.study.studymatchingplatform.notification.domain.notification.Stu
 import com.ludo.study.studymatchingplatform.notification.repository.keyword.NotificationKeywordCategoryRepositoryImpl;
 import com.ludo.study.studymatchingplatform.notification.repository.keyword.NotificationKeywordPositionRepositoryImpl;
 import com.ludo.study.studymatchingplatform.notification.repository.keyword.NotificationKeywordStackRepositoryImpl;
+import com.ludo.study.studymatchingplatform.notification.repository.notification.NotificationRepositoryImpl;
 import com.ludo.study.studymatchingplatform.notification.repository.notification.RecruitmentNotificationRepositoryImpl;
 import com.ludo.study.studymatchingplatform.notification.repository.notification.ReviewNotificationRepositoryImpl;
 import com.ludo.study.studymatchingplatform.notification.repository.notification.StudyNotificationRepositoryImpl;
@@ -29,9 +30,11 @@ import com.ludo.study.studymatchingplatform.study.domain.study.participant.Parti
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class NotificationCommandService {
 
 	private final StudyNotificationRepositoryImpl studyNotificationRepository;
@@ -41,6 +44,8 @@ public class NotificationCommandService {
 	private final NotificationKeywordCategoryRepositoryImpl notificationKeywordCategoryRepository;
 	private final NotificationKeywordStackRepositoryImpl notificationKeywordStackRepository;
 	private final NotificationKeywordPositionRepositoryImpl notificationKeywordPositionRepository;
+
+	private final NotificationRepositoryImpl notificationRepository;
 
 	@Transactional
 	public List<RecruitmentNotification> saveRecruitmentNotifications(final Recruitment actor,
@@ -138,4 +143,9 @@ public class NotificationCommandService {
 	private boolean isNotificationConfigOff(final NotificationConfigGroup configGroup, final boolean enabled) {
 		return configGroup == NotificationConfigGroup.RECRUITMENT_CONFIG && !enabled;
 	}
+
+	public void updateNotificationsAsRead(final User user, final List<Long> notificationIds) {
+		notificationRepository.updateNotificationsAsRead(user.getId(), notificationIds);
+	}
+
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationCommandService.java
@@ -21,6 +21,7 @@ import com.ludo.study.studymatchingplatform.notification.repository.keyword.Noti
 import com.ludo.study.studymatchingplatform.notification.repository.notification.RecruitmentNotificationRepositoryImpl;
 import com.ludo.study.studymatchingplatform.notification.repository.notification.ReviewNotificationRepositoryImpl;
 import com.ludo.study.studymatchingplatform.notification.repository.notification.StudyNotificationRepositoryImpl;
+import com.ludo.study.studymatchingplatform.notification.service.dto.request.NotificationConfigRequest;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
 import com.ludo.study.studymatchingplatform.study.domain.study.Review;
 import com.ludo.study.studymatchingplatform.study.domain.study.Study;

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationService.java
@@ -17,6 +17,7 @@ import com.ludo.study.studymatchingplatform.notification.domain.keyword.Notifica
 import com.ludo.study.studymatchingplatform.notification.domain.notification.RecruitmentNotification;
 import com.ludo.study.studymatchingplatform.notification.domain.notification.ReviewNotification;
 import com.ludo.study.studymatchingplatform.notification.domain.notification.StudyNotification;
+import com.ludo.study.studymatchingplatform.notification.service.dto.request.NotificationConfigRequest;
 import com.ludo.study.studymatchingplatform.notification.service.dto.response.NotificationResponse;
 import com.ludo.study.studymatchingplatform.notification.service.dto.response.config.NotificationConfigResponse;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationService.java
@@ -278,4 +278,8 @@ public class NotificationService {
 		return notificationQueryService.readNotificationConfigAndKeywords(user);
 	}
 
+	public void checkNotificationsAsRead(final User user, final List<Long> notificationIds) {
+		notificationCommandService.updateNotificationsAsRead(user, notificationIds);
+	}
+
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/dto/request/NotificationConfigRequest.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/dto/request/NotificationConfigRequest.java
@@ -1,4 +1,4 @@
-package com.ludo.study.studymatchingplatform.notification.service;
+package com.ludo.study.studymatchingplatform.notification.service.dto.request;
 
 import com.ludo.study.studymatchingplatform.notification.domain.config.NotificationConfigGroup;
 

--- a/src/test/java/com/ludo/study/studymatchingplatform/notification/service/NotificationCommandServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/notification/service/NotificationCommandServiceTest.java
@@ -1,0 +1,162 @@
+package com.ludo.study.studymatchingplatform.notification.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ludo.study.studymatchingplatform.common.utils.UtcDateTimePicker;
+import com.ludo.study.studymatchingplatform.notification.domain.notification.Notification;
+import com.ludo.study.studymatchingplatform.notification.domain.notification.NotificationEventType;
+import com.ludo.study.studymatchingplatform.notification.domain.notification.RecruitmentNotification;
+import com.ludo.study.studymatchingplatform.notification.domain.notification.ReviewNotification;
+import com.ludo.study.studymatchingplatform.notification.domain.notification.StudyNotification;
+import com.ludo.study.studymatchingplatform.notification.repository.notification.NotificationRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.Contact;
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
+import com.ludo.study.studymatchingplatform.study.domain.study.Review;
+import com.ludo.study.studymatchingplatform.study.domain.study.Study;
+import com.ludo.study.studymatchingplatform.study.fixture.study.StudyFixture;
+import com.ludo.study.studymatchingplatform.study.repository.recruitment.RecruitmentRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.study.ReviewRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.study.StudyRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.service.study.FixedUtcDateTimePicker;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import com.ludo.study.studymatchingplatform.user.fixture.user.UserFixture;
+import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
+
+import jakarta.persistence.EntityManager;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class NotificationCommandServiceTest {
+
+	@Autowired
+	NotificationCommandService notificationCommandService;
+
+	@Autowired
+	NotificationRepositoryImpl notificationRepository;
+
+	@Autowired
+	UserRepositoryImpl userRepository;
+
+	User user1;
+	User user2;
+	User user3;
+	User user4;
+
+	@BeforeEach
+	void setup() {
+		user1 = userRepository.save(UserFixture.USER1());
+		user2 = userRepository.save(UserFixture.USER2());
+		user3 = userRepository.save(UserFixture.USER3());
+		user4 = userRepository.save(UserFixture.USER4());
+	}
+
+	@Nested
+	@DisplayName("알림 읽음 처리 메서드는")
+	class Describe_CheckNotificationsAsRead {
+
+		UtcDateTimePicker utcDateTimePicker = new FixedUtcDateTimePicker();
+
+		@Autowired
+		StudyRepositoryImpl studyRepository;
+
+		@Autowired
+		RecruitmentRepositoryImpl recruitmentRepository;
+
+		@Autowired
+		ReviewRepositoryImpl reviewRepository;
+
+		@Autowired
+		EntityManager em;
+
+		@Test
+		@Transactional
+		@DisplayName("특정 사용자의 notification_id에 해당하는 알림을 읽음처리 한다.")
+		void notificationReadUpdateToTrue() {
+			// given
+			LocalDateTime now = utcDateTimePicker.now();
+			LocalDateTime nowPlus = utcDateTimePicker.now().plusDays(5L);
+
+			Study study = studyRepository.save(StudyFixture.STUDY1(user1, now, nowPlus));
+			Recruitment recruitment = recruitmentRepository.save(createRecruitment(study));
+			study.addRecruitment(recruitment);
+
+			Review review = Review.builder()
+					.study(study)
+					.reviewer(user1)
+					.reviewee(user2)
+					.build();
+			reviewRepository.save(review);
+
+			List<Notification> recruitmentNotifications = setupNotificationEvents(now, recruitment, user1);
+			List<Notification> studyNotifications = setupStudyNotificationEvents(now, study, user1);
+			List<Notification> reviewNotifications = setupReviewNotificationEvents(now, review, user1);
+
+			// when
+			notificationCommandService.updateNotificationsAsRead(user1, mapToNotificationIds(recruitmentNotifications));
+			notificationCommandService.updateNotificationsAsRead(user1, mapToNotificationIds(studyNotifications));
+			notificationCommandService.updateNotificationsAsRead(user1, mapToNotificationIds(reviewNotifications));
+
+			// then
+			List<Notification> notifications = notificationRepository.findAllByUserId(user1.getId());
+			assertThat(notifications)
+					.hasSize(10)
+					.allMatch(Notification::isRead);
+		}
+
+		private Recruitment createRecruitment(Study study) {
+			return Recruitment.builder()
+					.study(study)
+					.contact(Contact.KAKAO)
+					.callUrl("callUrl")
+					.title("모집공고1 제목")
+					.content("모집공고1 내용")
+					.applicantCount(5)
+					.recruitmentEndDateTime(LocalDateTime.now().plusDays(10).truncatedTo(ChronoUnit.MICROS))
+					.hits(1)
+					.build();
+		}
+
+		private List<Long> mapToNotificationIds(List<Notification> notifications) {
+			return notifications.stream()
+					.map(Notification::getId)
+					.toList();
+		}
+
+		private List<Notification> setupNotificationEvents(LocalDateTime now, Recruitment actor, User notifier) {
+			return notificationRepository.saveAll(
+					List.of(RecruitmentNotification.of(NotificationEventType.RECRUITMENT, now, actor, notifier)));
+		}
+
+		private List<Notification> setupStudyNotificationEvents(LocalDateTime now, Study actor, User notifier) {
+			return notificationRepository.saveAll(List.of(
+					StudyNotification.of(NotificationEventType.STUDY_APPLICANT, now, actor, notifier),
+					StudyNotification.of(NotificationEventType.STUDY_END_DATE, now, actor, notifier),
+					StudyNotification.of(NotificationEventType.STUDY_APPLICANT_ACCEPT, now, actor, notifier),
+					StudyNotification.of(NotificationEventType.STUDY_PARTICIPANT_LEAVE, now, actor, notifier),
+					StudyNotification.of(NotificationEventType.STUDY_PARTICIPANT_LEAVE_APPLY, now, actor, notifier),
+					StudyNotification.of(NotificationEventType.STUDY_APPLICANT, now, actor, notifier),
+					StudyNotification.of(NotificationEventType.STUDY_REVIEW_START, now, actor, notifier)
+			));
+		}
+
+		private List<Notification> setupReviewNotificationEvents(LocalDateTime now, Review actor, User notifier) {
+			return notificationRepository.saveAll(List.of(
+					ReviewNotification.of(NotificationEventType.REVIEW_RECEIVE, now, actor, notifier),
+					ReviewNotification.of(NotificationEventType.REVIEW_PEER_FINISH, now, actor, notifier)));
+		}
+
+	}
+}

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/fixture/study/StudyFixture.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/fixture/study/StudyFixture.java
@@ -3,44 +3,104 @@ package com.ludo.study.studymatchingplatform.study.fixture.study;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
+import com.ludo.study.studymatchingplatform.common.utils.UtcDateTimePicker;
 import com.ludo.study.studymatchingplatform.study.domain.study.Platform;
 import com.ludo.study.studymatchingplatform.study.domain.study.Study;
 import com.ludo.study.studymatchingplatform.study.domain.study.StudyStatus;
 import com.ludo.study.studymatchingplatform.study.domain.study.Way;
 import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
 import com.ludo.study.studymatchingplatform.study.fixture.study.category.CategoryFixture;
+import com.ludo.study.studymatchingplatform.study.service.study.FixedUtcDateTimePicker;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
-import com.ludo.study.studymatchingplatform.user.fixture.user.UserFixture;
 
 public class StudyFixture {
 
-	public static final Study USER1_PROJECT_ONLINE_STUDY = Study.builder()
-			.title("프로젝트 온라인 스터디 제목")
-			.owner(UserFixture.user1)
-			.category(CategoryFixture.CATEGORY_PROJECT)
-			.status(StudyStatus.RECRUITING)
-			.way(Way.ONLINE)
-			.platform(Platform.GATHER)
-			.platformUrl("platform url")
-			.participantCount(1)
-			.participantLimit(5)
-			.startDateTime(LocalDateTime.now().truncatedTo(ChronoUnit.MICROS))
-			.endDateTime(LocalDateTime.now().plusMonths(1).truncatedTo(ChronoUnit.MICROS))
-			.build();
+	public static Study PROJECT_ONLINE_STUDY(User owner, UtcDateTimePicker utcDateTimePicker) {
 
-	public static final Study study1 = Study.builder()
-			.title("스터디1 제목")
-			.owner(UserFixture.user1)
-			.category(CategoryFixture.CATEGORY_PROJECT)
-			.status(StudyStatus.RECRUITING)
-			.way(Way.ONLINE)
-			.platform(Platform.GATHER)
-			.platformUrl("platform url")
-			.participantCount(1)
-			.participantLimit(5)
-			.startDateTime(LocalDateTime.now().truncatedTo(ChronoUnit.MICROS))
-			.endDateTime(LocalDateTime.now().plusMonths(1).truncatedTo(ChronoUnit.MICROS))
-			.build();
+		return Study.builder()
+				.title("프로젝트 온라인 스터디 제목")
+				.owner(owner)
+				.category(CategoryFixture.CATEGORY_PROJECT)
+				.status(StudyStatus.RECRUITING)
+				.way(Way.ONLINE)
+				.platform(Platform.GATHER)
+				.platformUrl("platform url")
+				.participantCount(1)
+				.participantLimit(5)
+				.startDateTime(utcDateTimePicker.now().truncatedTo(ChronoUnit.MICROS))
+				.endDateTime(utcDateTimePicker.now().plusMonths(1).truncatedTo(ChronoUnit.MICROS))
+				.build();
+	}
+
+	public static Study STUDY1(User owner, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+
+		return Study.builder()
+				.title("스터디1 제목")
+				.owner(owner)
+				.category(CategoryFixture.CATEGORY_PROJECT)
+				.status(StudyStatus.RECRUITING)
+				.way(Way.ONLINE)
+				.platform(Platform.GATHER)
+				.platformUrl("platform url")
+				.participantCount(1)
+				.participantLimit(5)
+				.startDateTime(startDateTime)
+				.endDateTime(endDateTime.truncatedTo(ChronoUnit.MICROS))
+				.build();
+	}
+
+	public static Study STUDY2(User owner, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+
+		return Study.builder()
+				.title("스터디2 제목")
+				.owner(owner)
+				.category(CategoryFixture.CATEGORY_PROJECT)
+				.status(StudyStatus.RECRUITING)
+				.way(Way.ONLINE)
+				.platform(Platform.GATHER)
+				.platformUrl("platform url")
+				.participantCount(1)
+				.participantLimit(5)
+				.startDateTime(startDateTime)
+				.endDateTime(endDateTime.truncatedTo(ChronoUnit.MICROS))
+				.build();
+	}
+
+	public static Study STUDY3(User owner, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+		FixedUtcDateTimePicker fixedUtcDateTimePicker = new FixedUtcDateTimePicker();
+
+		return Study.builder()
+				.title("스터디3 제목")
+				.owner(owner)
+				.category(CategoryFixture.CATEGORY_PROJECT)
+				.status(StudyStatus.RECRUITING)
+				.way(Way.ONLINE)
+				.platform(Platform.GATHER)
+				.platformUrl("platform url")
+				.participantCount(1)
+				.participantLimit(5)
+				.startDateTime(startDateTime)
+				.endDateTime(endDateTime.truncatedTo(ChronoUnit.MICROS))
+				.build();
+	}
+
+	public static Study STUDY4(User owner, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+		FixedUtcDateTimePicker fixedUtcDateTimePicker = new FixedUtcDateTimePicker();
+
+		return Study.builder()
+				.title("스터디4 제목")
+				.owner(owner)
+				.category(CategoryFixture.CATEGORY_PROJECT)
+				.status(StudyStatus.RECRUITING)
+				.way(Way.ONLINE)
+				.platform(Platform.GATHER)
+				.platformUrl("platform url")
+				.participantCount(1)
+				.participantLimit(5)
+				.startDateTime(startDateTime)
+				.endDateTime(endDateTime.truncatedTo(ChronoUnit.MICROS))
+				.build();
+	}
 
 	public static Study createStudy(StudyStatus studyStatus, String title, Way way, Category category, User user,
 									int participantCount, int participantLimit, Platform platform, String platformUrl

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/fixture/study/participant/ParticipantFixture.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/fixture/study/participant/ParticipantFixture.java
@@ -4,29 +4,9 @@ import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Po
 import com.ludo.study.studymatchingplatform.study.domain.study.Study;
 import com.ludo.study.studymatchingplatform.study.domain.study.participant.Participant;
 import com.ludo.study.studymatchingplatform.study.domain.study.participant.Role;
-import com.ludo.study.studymatchingplatform.study.fixture.study.StudyFixture;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
-import com.ludo.study.studymatchingplatform.user.fixture.user.UserFixture;
 
 public class ParticipantFixture {
-
-	public static final Participant study1ParticipantUser1 = Participant.builder()
-			.study(StudyFixture.study1)
-			.user(UserFixture.user1)
-			.role(Role.OWNER)
-			.build();
-
-	public static final Participant study1ParticipantUser2 = Participant.builder()
-			.study(StudyFixture.study1)
-			.user(UserFixture.user2)
-			.role(Role.MEMBER)
-			.build();
-
-	public static final Participant study1ParticipantUser3 = Participant.builder()
-			.study(StudyFixture.study1)
-			.user(UserFixture.user3)
-			.role(Role.MEMBER)
-			.build();
 
 	public static Participant createParticipant(Study study, User user, Position position, Role role) {
 		return Participant.builder()

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentsFindServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentsFindServiceTest.java
@@ -84,8 +84,8 @@ class RecruitmentsFindServiceTest {
 		@BeforeEach
 		void init() {
 			User user = saveUser();
-			Category category = saveCategory();
-			saveRecruitments(category, user);
+			Category project = CategoryFixture.CATEGORY_PROJECT;
+			saveRecruitments(project, user);
 			em.flush();
 			em.clear();
 		}

--- a/src/test/java/com/ludo/study/studymatchingplatform/user/fixture/user/UserFixture.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/user/fixture/user/UserFixture.java
@@ -5,29 +5,37 @@ import com.ludo.study.studymatchingplatform.user.domain.user.User;
 
 public class UserFixture {
 
-	public static final User user1 = User.builder()
-			.social(Social.NAVER)
-			.nickname("user1")
-			.email("user1@naver.com")
-			.build();
+	public static User USER1() {
+		return User.builder()
+				.social(Social.NAVER)
+				.nickname("user1")
+				.email("user1@naver.com")
+				.build();
+	}
 
-	public static final User user2 = User.builder()
-			.social(Social.KAKAO)
-			.nickname("user2")
-			.email("user2@kakao.com")
-			.build();
+	public static User USER2() {
+		return User.builder()
+				.social(Social.KAKAO)
+				.nickname("user2")
+				.email("user2@kakao.com")
+				.build();
+	}
 
-	public static final User user3 = User.builder()
-			.social(Social.GOOGLE)
-			.nickname("user3")
-			.email("user3@google.com")
-			.build();
+	public static User USER3() {
+		return User.builder()
+				.social(Social.GOOGLE)
+				.nickname("user3")
+				.email("user3@google.com")
+				.build();
+	}
 
-	public static final User user4 = User.builder()
-			.social(Social.NAVER)
-			.nickname("user4")
-			.email("user4@naver.com")
-			.build();
+	public static User USER4() {
+		return User.builder()
+				.social(Social.NAVER)
+				.nickname("user4")
+				.email("user4@naver.com")
+				.build();
+	}
 
 	public static User createUser(Social social, String nickname, String email) {
 		return User.builder()


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.
- [x] 알림 읽음 API 구현

<br><br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.
### 알림 읽음을 위한 QueryDSL Update 쿼리 구현
알림 읽음 처리를 위한 update 쿼리에서 JPA 1차 캐시와 DB 데이터간 데이터 동기화 이슈를 방지하기 위해 `em.flush()`, `em.clear()`를 활용했습니다.

<br><br>

## ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [x] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
