### PR TITLE
SP-615/feat: 알림유형에 대응되는 프론트엔드 라우트 파라미터 매핑 및 알림 메시지 컨버터 구현

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/NotificationEventType.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/NotificationEventType.java
@@ -5,6 +5,12 @@ import lombok.Getter;
 @Getter
 public enum NotificationEventType {
 
+	RECRUITMENT(
+			"관심 모집 공고 알림",
+			"[루도가 알려요] 관심 항목에 해당하는 모집공고가 나왔습니다.",
+			"해당 항목으로 검색된 스터디원 모집 공고를 확인하시려면 클릭헤주세요."
+	),
+
 	STUDY_APPLICANT(
 			"스터디 지원 현황 알림",
 			"[스터디원 모집] %s 스터디에 새로운 지원자가 생겼어요.",
@@ -31,54 +37,48 @@ public enum NotificationEventType {
 			"스터디 종료 기간 알림",
 			"[스터디 마감 임박] %s 스터디 마감 기한이 %d일 남았습니다!",
 			"""
-					5일 이후에도 스터디를 진행해야할 시, 팀장은 스터디 수정을 통해 마감 기한을 늘려주시기 바랍니다.
+					%d일 이후에도 스터디를 진행해야할 시, 팀장은 스터디 수정을 통해 마감 기한을 늘려주시기 바랍니다.
 					해당 알림을 클릭하면 해당 스터디 페이지로 이동합니다."""
 	),
 
 	STUDY_PARTICIPANT_LEAVE(
 			"스터디 탈퇴자 알림",
-			"[스터디원 탈퇴] ‘스터디명' 스터디에서 %s이 탈퇴했습니다.",
-			"%s 스터디에서 %s 이 탈퇴했습니다."
+			"[스터디원 탈퇴] %s 스터디에서 %s님이 탈퇴했습니다.",
+			"%s 스터디에서 %s님이 탈퇴했습니다."
 	),
 
 	STUDY_PARTICIPANT_LEAVE_APPLY(
 			"스터디 탈퇴 요청 알림",
-			"스터디 탈퇴 요청 알림 제목 - 임시",
-			"스터디 탈퇴 요청 알림 내용 - 임시"
+			"[스터디 탈퇴 승인] %s 스터디에서 %s님이 탈퇴 요청했습니다!",
+			"%s님의 탈퇴 요청에 답하시려면 클릭해주세요."
 	),
 
 	STUDY_REVIEW_START(
 			"스터디 리뷰 시작 알림",
-			"리뷰 시작 알림 제목 - 임시",
-			"리뷰 시작 알림 내용 - 임시"
-	),
-
-	RECRUITMENT(
-			"관심 모집 공고 알림",
-			"[루도가 알려요] 관심 항목으로 선택한 %s 모집 공고가 나왔습니다.",
-			"해당 항목으로 검색된 스터디원 모집 공고를 확인하시려면 클릭헤주세요."
+			"[스터디원 리뷰] %s 스터디를 완주했습니다! 함께 했던 스터디원들에게 리뷰를 남겨주세요.",
+			"해당 스터디원들의 리뷰를 작성하시려면 클릭해주세요."
 	),
 
 	REVIEW_RECEIVE(
 			"리뷰 받음 알림",
-			"리뷰 받음 알림 제목 - 임시",
-			"리뷰 받음 알림 내용 - 임시"
+			"[스터디원 리뷰] 진행 완료된 %s 스터디에서 %s님이 회원님에 대한 리뷰를 작성했습니다.",
+			"해당 스터디원에 대한 리뷰를 작성하시려면 클릭해주세요."
 	),
 
 	REVIEW_PEER_FINISH(
 			"상호 리뷰 완료 알림",
-			"상호 리뷰 완료 알림 제목 - 임시",
-			"상호 리뷰 완료 알림 내용 - 임시"
+			"[스터디원 리뷰] 진행 완료된 %s 스터디에서 %s님과 주고 받은 리뷰가 업로드 되었습니다.",
+			"해당 리뷰를 보시려면 클릭해주세요."
 	);
 
 	private final String description;
-	private final String title;
-	private final String content;
+	private final String titleFormat;
+	private final String contentFormat;
 
-	NotificationEventType(String description, String title, String content) {
+	NotificationEventType(String description, String titleFormat, String contentFormat) {
 		this.description = description;
-		this.title = title;
-		this.content = content;
+		this.titleFormat = titleFormat;
+		this.contentFormat = contentFormat;
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/RecruitmentNotification.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/RecruitmentNotification.java
@@ -41,4 +41,8 @@ public class RecruitmentNotification extends Notification {
 		return new RecruitmentNotification(notificationEventType, createdOn, actor, notifier);
 	}
 
+	public Long getActorId() {
+		return actor.getId();
+	}
+
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/StudyEndDateNotifyCond.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/StudyEndDateNotifyCond.java
@@ -1,0 +1,38 @@
+package com.ludo.study.studymatchingplatform.notification.domain.notification;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import com.ludo.study.studymatchingplatform.common.utils.UtcDateTimePicker;
+
+import lombok.Getter;
+
+@Getter
+public enum StudyEndDateNotifyCond {
+
+	remainingPeriod(5L);
+
+	private final Long period;
+
+	StudyEndDateNotifyCond(Long period) {
+		this.period = period;
+	}
+
+	public LocalDate getStudyEndDate(final UtcDateTimePicker utcDateTimePicker) {
+		return utcDateTimePicker.now().toLocalDate().plusDays(getPeriod());
+	}
+
+	public LocalDateTime getStudyEndDateStartOfDay(final UtcDateTimePicker utcDateTimePicker,
+												   final LocalDate studyEndDate
+	) {
+		return utcDateTimePicker.toMicroSeconds(studyEndDate.atStartOfDay());
+	}
+
+	public LocalDateTime getStudyEndDateEndOfDay(final UtcDateTimePicker utcDateTimePicker,
+												 final LocalDate studyEndDate
+	) {
+		return utcDateTimePicker.toMicroSeconds(studyEndDate.atTime(LocalTime.MAX));
+	}
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/StudyNotification.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/notification/StudyNotification.java
@@ -39,4 +39,8 @@ public class StudyNotification extends Notification {
 		return new StudyNotification(notificationEventType, createdOn, actor, notifier);
 	}
 
+	public Long getActorId() {
+		return actor.getId();
+	}
+
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationMessageConverter.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationMessageConverter.java
@@ -1,0 +1,141 @@
+package com.ludo.study.studymatchingplatform.notification.service;
+
+import org.springframework.stereotype.Component;
+
+import com.ludo.study.studymatchingplatform.notification.domain.notification.NotificationEventType;
+import com.ludo.study.studymatchingplatform.notification.domain.notification.RecruitmentNotification;
+import com.ludo.study.studymatchingplatform.notification.domain.notification.ReviewNotification;
+import com.ludo.study.studymatchingplatform.notification.domain.notification.StudyEndDateNotifyCond;
+import com.ludo.study.studymatchingplatform.notification.domain.notification.StudyNotification;
+import com.ludo.study.studymatchingplatform.notification.service.dto.response.message.NotificationMessage;
+import com.ludo.study.studymatchingplatform.study.domain.study.Review;
+import com.ludo.study.studymatchingplatform.study.domain.study.Study;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+
+@Component
+public class NotificationMessageConverter {
+
+	public NotificationMessage convertRecruitmentNotifyMessage(final RecruitmentNotification recruitmentNotification) {
+		final NotificationEventType notificationEventType = recruitmentNotification.getNotificationEventType();
+
+		final String titleFormat = notificationEventType.getTitleFormat();
+		final String contentFormat = notificationEventType.getContentFormat();
+
+		return new NotificationMessage(titleFormat, contentFormat);
+	}
+
+	public NotificationMessage convertStudyApplicantNotifyMessage(final StudyNotification studyNotification) {
+		final NotificationEventType notificationEventType = studyNotification.getNotificationEventType();
+
+		final Study actor = studyNotification.getActor();
+		final String titleFormat = notificationEventType.getTitleFormat();
+		final String title = titleFormat.formatted(actor.getTitle());
+
+		final String contentFormat = notificationEventType.getContentFormat();
+		return new NotificationMessage(title, contentFormat);
+	}
+
+	public NotificationMessage convertStudyApplicantAcceptNotifyMessage(final StudyNotification studyNotification) {
+		final NotificationEventType notificationEventType = studyNotification.getNotificationEventType();
+
+		final Study actor = studyNotification.getActor();
+		final String titleFormat = notificationEventType.getTitleFormat();
+		final String title = titleFormat.formatted(actor.getTitle());
+
+		final String contentFormat = notificationEventType.getContentFormat();
+		final String content = contentFormat.formatted(actor.getTitle());
+		return new NotificationMessage(title, content);
+	}
+
+	public NotificationMessage convertStudyApplicantRejectNotifyMessage(final StudyNotification studyNotification) {
+		final NotificationEventType notificationEventType = studyNotification.getNotificationEventType();
+
+		final Study actor = studyNotification.getActor();
+		final String titleFormat = notificationEventType.getTitleFormat();
+		final String title = titleFormat.formatted(actor.getTitle());
+
+		final String contentFormat = notificationEventType.getContentFormat();
+		final String content = contentFormat.formatted(actor.getTitle());
+		return new NotificationMessage(title, content);
+	}
+
+	public NotificationMessage convertStudyEndDateNotifyMessage(final StudyNotification studyNotification) {
+		final NotificationEventType notificationEventType = studyNotification.getNotificationEventType();
+
+		final Study actor = studyNotification.getActor();
+		final Long period = StudyEndDateNotifyCond.remainingPeriod.getPeriod();
+		final String titleFormat = notificationEventType.getTitleFormat();
+		final String title = titleFormat.formatted(actor.getTitle(), period);
+
+		final String contentFormat = notificationEventType.getContentFormat();
+		final String content = contentFormat.formatted(period);
+
+		return new NotificationMessage(title, content);
+	}
+
+	public NotificationMessage convertStudyParticipantLeaveNotifyMessage(final StudyNotification studyNotification,
+																		 final User studyLeaver
+	) {
+		final NotificationEventType notificationEventType = studyNotification.getNotificationEventType();
+
+		final Study actor = studyNotification.getActor();
+		final String titleFormat = notificationEventType.getTitleFormat();
+		final String title = titleFormat.formatted(actor.getTitle(), studyLeaver.getNickname());
+
+		final String contentFormat = notificationEventType.getContentFormat();
+		final String content = contentFormat.formatted(actor.getTitle(), studyLeaver.getNickname());
+
+		return new NotificationMessage(title, content);
+	}
+
+	public NotificationMessage convertStudyParticipantLeaveApplyNotifyMessage(final StudyNotification studyNotification,
+																			  final User studyLeaveApplier
+	) {
+		final NotificationEventType notificationEventType = studyNotification.getNotificationEventType();
+
+		final Study actor = studyNotification.getActor();
+		final String titleFormat = notificationEventType.getTitleFormat();
+		final String title = titleFormat.formatted(actor.getTitle(), studyLeaveApplier.getNickname());
+
+		final String contentFormat = notificationEventType.getContentFormat();
+		final String content = contentFormat.formatted(studyLeaveApplier.getNickname());
+
+		return new NotificationMessage(title, content);
+	}
+
+	public NotificationMessage convertStudyReviewStartNotifyMessage(final StudyNotification studyNotification) {
+		final NotificationEventType notificationEventType = studyNotification.getNotificationEventType();
+
+		final Study actor = studyNotification.getActor();
+		final String titleFormat = notificationEventType.getTitleFormat();
+		final String title = titleFormat.formatted(actor.getTitle());
+
+		final String contentFormat = notificationEventType.getContentFormat();
+
+		return new NotificationMessage(title, contentFormat);
+	}
+
+	public NotificationMessage convertReviewReceiveNotifyMessage(final ReviewNotification reviewNotification) {
+		return convertReviewNotifyMessage(reviewNotification);
+	}
+
+	public NotificationMessage convertReviewPeerFinishNotifyMessage(final ReviewNotification reviewNotification) {
+		return convertReviewNotifyMessage(reviewNotification);
+	}
+
+	private NotificationMessage convertReviewNotifyMessage(final ReviewNotification reviewNotification) {
+		final NotificationEventType notificationEventType = reviewNotification.getNotificationEventType();
+
+		final Review actor = reviewNotification.getActor();
+		final Study study = actor.getStudy();
+		final User reviewer = actor.getReviewer();
+
+		final String titleFormat = notificationEventType.getTitleFormat();
+		final String title = titleFormat.formatted(study.getTitle(), reviewer.getNickname());
+
+		final String contentFormat = notificationEventType.getContentFormat();
+
+		return new NotificationMessage(title, contentFormat);
+	}
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationQueryService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationQueryService.java
@@ -22,6 +22,7 @@ import com.ludo.study.studymatchingplatform.notification.domain.keyword.Notifica
 import com.ludo.study.studymatchingplatform.notification.domain.keyword.NotificationKeywordStack;
 import com.ludo.study.studymatchingplatform.notification.domain.notification.RecruitmentNotification;
 import com.ludo.study.studymatchingplatform.notification.domain.notification.ReviewNotification;
+import com.ludo.study.studymatchingplatform.notification.domain.notification.StudyEndDateNotifyCond;
 import com.ludo.study.studymatchingplatform.notification.domain.notification.StudyNotification;
 import com.ludo.study.studymatchingplatform.notification.repository.config.GlobalNotificationUserConfigRepositoryImpl;
 import com.ludo.study.studymatchingplatform.notification.repository.dto.RecruitmentNotifierCond;
@@ -91,13 +92,15 @@ public class NotificationQueryService {
 	}
 
 	public List<Participant> findStudyEndDateNotifier() {
-		final long remainingPeriod = 5L;
-		final LocalDate endDate = utcDateTimePicker.now().toLocalDate().plusDays(remainingPeriod);
-		final LocalDateTime endDateStartOfDay = utcDateTimePicker.toMicroSeconds(endDate.atStartOfDay());
-		final LocalDateTime endDateEndOfDay = utcDateTimePicker.toMicroSeconds(endDate.atTime(LocalTime.MAX));
+		final LocalDate studyEndDate = StudyEndDateNotifyCond.remainingPeriod.getStudyEndDate(utcDateTimePicker);
+		final LocalDateTime studyEndDateStartOfDay = StudyEndDateNotifyCond.remainingPeriod.getStudyEndDateStartOfDay(
+				utcDateTimePicker, studyEndDate);
+		final LocalDateTime studyEndDateEndOfDay = StudyEndDateNotifyCond.remainingPeriod.getStudyEndDateEndOfDay(
+				utcDateTimePicker, studyEndDate);
 
 		final List<Participant> ownerParticipantsBetweenDateRange = participantRepository.findOwnerParticipantsBetweenDateRange(
-				new StudyEndDateNotifierCond(Role.OWNER, endDateStartOfDay, endDateEndOfDay));
+				new StudyEndDateNotifierCond(Role.OWNER, studyEndDateStartOfDay, studyEndDateEndOfDay));
+
 		log.info("ownerParticipantsBetweenDateRange = {}", ownerParticipantsBetweenDateRange);
 		return ownerParticipantsBetweenDateRange;
 	}
@@ -151,15 +154,15 @@ public class NotificationQueryService {
 
 		final List<NotificationResponse> notificationResponses = new ArrayList<>();
 		recruitmentNotifications.stream()
-				.map(NotificationResponse::new)
+				.map(NotificationResponse::from)
 				.forEach(notificationResponses::add);
 
 		studyNotifications.stream()
-				.map(NotificationResponse::new)
+				.map(NotificationResponse::from)
 				.forEach(notificationResponses::add);
 
 		reviewNotifications.stream()
-				.map(NotificationResponse::new)
+				.map(NotificationResponse::from)
 				.forEach(notificationResponses::add);
 
 		return notificationResponses;

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationService.java
@@ -58,7 +58,7 @@ public class NotificationService {
 
 		recruitmentNotifications.forEach(recruitmentNotification -> {
 			final User notifier = recruitmentNotification.getNotifier();
-			final NotificationResponse notificationResponse = new NotificationResponse(recruitmentNotification);
+			final NotificationResponse notificationResponse = NotificationResponse.from(recruitmentNotification);
 			sseEmitters.sendNotification(notifier, notificationResponse);
 		});
 	}
@@ -73,7 +73,7 @@ public class NotificationService {
 
 		studyNotifications.forEach(studyNotification -> {
 			final User notifier = studyNotification.getNotifier();
-			final NotificationResponse notificationResponse = new NotificationResponse(studyNotification);
+			final NotificationResponse notificationResponse = NotificationResponse.from(studyNotification);
 			sseEmitters.sendNotification(notifier, notificationResponse);
 		});
 	}
@@ -88,7 +88,7 @@ public class NotificationService {
 
 		studyNotifications.forEach(studyNotification -> {
 			final User notifier = studyNotification.getNotifier();
-			final NotificationResponse notificationResponse = new NotificationResponse(studyNotification);
+			final NotificationResponse notificationResponse = NotificationResponse.from(studyNotification);
 			sseEmitters.sendNotification(notifier, notificationResponse);
 		});
 	}
@@ -104,7 +104,7 @@ public class NotificationService {
 
 		studyNotifications.forEach(studyNotification -> {
 			final User notifier = studyNotification.getNotifier();
-			final NotificationResponse notificationResponse = new NotificationResponse(studyNotification);
+			final NotificationResponse notificationResponse = NotificationResponse.from(studyNotification);
 			sseEmitters.sendNotification(notifier, notificationResponse);
 		});
 	}
@@ -119,7 +119,7 @@ public class NotificationService {
 
 		studyNotifications.forEach(studyNotification -> {
 			final User notifier = studyNotification.getNotifier();
-			final NotificationResponse notificationResponse = new NotificationResponse(studyNotification);
+			final NotificationResponse notificationResponse = NotificationResponse.from(studyNotification);
 			sseEmitters.sendNotification(notifier, notificationResponse);
 		});
 	}
@@ -134,7 +134,7 @@ public class NotificationService {
 
 		studyNotifications.forEach(studyNotification -> {
 			final User notifier = studyNotification.getNotifier();
-			final NotificationResponse notificationResponse = new NotificationResponse(studyNotification);
+			final NotificationResponse notificationResponse = NotificationResponse.from(studyNotification);
 			sseEmitters.sendNotification(notifier, notificationResponse);
 		});
 	}
@@ -149,7 +149,7 @@ public class NotificationService {
 
 		studyNotifications.forEach(studyNotification -> {
 			final User notifier = studyNotification.getNotifier();
-			final NotificationResponse notificationResponse = new NotificationResponse(studyNotification);
+			final NotificationResponse notificationResponse = NotificationResponse.from(studyNotification);
 			sseEmitters.sendNotification(notifier, notificationResponse);
 		});
 	}
@@ -164,7 +164,7 @@ public class NotificationService {
 
 		studyNotifications.forEach(studyNotification -> {
 			final User notifier = studyNotification.getNotifier();
-			final NotificationResponse notificationResponse = new NotificationResponse(studyNotification);
+			final NotificationResponse notificationResponse = NotificationResponse.from(studyNotification);
 			sseEmitters.sendNotification(notifier, notificationResponse);
 		});
 	}
@@ -181,7 +181,7 @@ public class NotificationService {
 
 		reviewNotifications.forEach(reviewNotification -> {
 			final User notifier = reviewNotification.getNotifier();
-			final NotificationResponse notificationResponse = new NotificationResponse(reviewNotification);
+			final NotificationResponse notificationResponse = NotificationResponse.from(reviewNotification);
 			sseEmitters.sendNotification(notifier, notificationResponse);
 		});
 	}
@@ -201,7 +201,7 @@ public class NotificationService {
 
 		reviewNotifications.forEach(reviewNotification -> {
 			final User notifier = reviewNotification.getNotifier();
-			final NotificationResponse notificationResponse = new NotificationResponse(reviewNotification);
+			final NotificationResponse notificationResponse = NotificationResponse.from(reviewNotification);
 			sseEmitters.sendNotification(notifier, notificationResponse);
 		});
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/dto/response/NotificationResponse.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/dto/response/NotificationResponse.java
@@ -2,46 +2,55 @@ package com.ludo.study.studymatchingplatform.notification.service.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.ludo.study.studymatchingplatform.notification.domain.notification.Notification;
 import com.ludo.study.studymatchingplatform.notification.domain.notification.RecruitmentNotification;
 import com.ludo.study.studymatchingplatform.notification.domain.notification.ReviewNotification;
 import com.ludo.study.studymatchingplatform.notification.domain.notification.StudyNotification;
+import com.ludo.study.studymatchingplatform.notification.service.dto.response.route.NotificationRouteParameter;
+import com.ludo.study.studymatchingplatform.notification.service.dto.response.route.RecruitmentNotificationRoute;
+import com.ludo.study.studymatchingplatform.notification.service.dto.response.route.ReviewNotificationRoute;
+import com.ludo.study.studymatchingplatform.notification.service.dto.response.route.StudyNotificationRoute;
+import com.ludo.study.studymatchingplatform.study.domain.study.Review;
 
-public record NotificationResponse(
-		Long notificationId,
-		String title,
-		String content,
-		String type,
-		boolean read,
-		LocalDateTime createdAt
-
-		//TODO: API Params 반영
+public record NotificationResponse(Long notificationId,
+								   String title,
+								   String content,
+								   String type,
+								   boolean read,
+								   LocalDateTime createdAt,
+								   NotificationRouteParameter params
 ) {
 
-	public NotificationResponse(final RecruitmentNotification notification) {
-		this(notification.getId(),
-				notification.getNotificationEventType().getTitle(),
-				notification.getNotificationEventType().getContent(),
+	private NotificationResponse(final Notification notification, final NotificationRouteParameter params) {
+		this(
+				notification.getId(),
+				notification.getNotificationEventType().getTitleFormat(),
+				notification.getNotificationEventType().getContentFormat(),
 				notification.getNotificationEventType().toString(),
 				notification.getRead(),
-				notification.getCreatedAt());
+				notification.getCreatedAt(),
+				params
+		);
 	}
 
-	public NotificationResponse(final StudyNotification notification) {
-		this(notification.getId(),
-				notification.getNotificationEventType().getTitle(),
-				notification.getNotificationEventType().getContent(),
-				notification.getNotificationEventType().toString(),
-				notification.getRead(),
-				notification.getCreatedAt());
+	public static NotificationResponse from(final RecruitmentNotification notification) {
+		final NotificationRouteParameter routeParam = new RecruitmentNotificationRoute(notification.getActorId());
+
+		return new NotificationResponse(notification, routeParam);
 	}
 
-	public NotificationResponse(final ReviewNotification notification) {
-		this(notification.getId(),
-				notification.getNotificationEventType().getTitle(),
-				notification.getNotificationEventType().getContent(),
-				notification.getNotificationEventType().toString(),
-				notification.getRead(),
-				notification.getCreatedAt());
+	public static NotificationResponse from(final ReviewNotification notification) {
+		final Review review = notification.getActor();
+		final NotificationRouteParameter routeParam = new ReviewNotificationRoute(review.getStudyId(),
+				review.getReviewerId());
+
+		return new NotificationResponse(notification, routeParam);
+	}
+
+	public static NotificationResponse from(final StudyNotification notification) {
+		final NotificationRouteParameter routeParam = new StudyNotificationRoute(notification.getActorId());
+
+		return new NotificationResponse(notification, routeParam);
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/dto/response/message/NotificationMessage.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/dto/response/message/NotificationMessage.java
@@ -1,0 +1,5 @@
+package com.ludo.study.studymatchingplatform.notification.service.dto.response.message;
+
+public record NotificationMessage(String title,
+								  String content) {
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/dto/response/route/NotificationRouteParameter.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/dto/response/route/NotificationRouteParameter.java
@@ -1,0 +1,4 @@
+package com.ludo.study.studymatchingplatform.notification.service.dto.response.route;
+
+public interface NotificationRouteParameter {
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/dto/response/route/RecruitmentNotificationRoute.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/dto/response/route/RecruitmentNotificationRoute.java
@@ -1,0 +1,4 @@
+package com.ludo.study.studymatchingplatform.notification.service.dto.response.route;
+
+public record RecruitmentNotificationRoute(Long recruitmentId) implements NotificationRouteParameter {
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/dto/response/route/ReviewNotificationRoute.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/dto/response/route/ReviewNotificationRoute.java
@@ -1,0 +1,4 @@
+package com.ludo.study.studymatchingplatform.notification.service.dto.response.route;
+
+public record ReviewNotificationRoute(Long studyId, Long userId) implements NotificationRouteParameter {
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/dto/response/route/StudyNotificationRoute.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/dto/response/route/StudyNotificationRoute.java
@@ -1,0 +1,4 @@
+package com.ludo.study.studymatchingplatform.notification.service.dto.response.route;
+
+public record StudyNotificationRoute(Long studyId) implements NotificationRouteParameter {
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Review.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/Review.java
@@ -1,16 +1,22 @@
 package com.ludo.study.studymatchingplatform.study.domain.study;
 
+import static jakarta.persistence.FetchType.*;
+
 import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
-
-import static jakarta.persistence.FetchType.LAZY;
 
 @Slf4j
 @Entity
@@ -20,39 +26,47 @@ import static jakarta.persistence.FetchType.LAZY;
 @AllArgsConstructor
 public class Review extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "study_id")
-    private Study study;
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "study_id")
+	private Study study;
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "reviewer_id")
-    private User reviewer;
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "reviewer_id")
+	private User reviewer;
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "reviewee_id")
-    private User reviewee;
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "reviewee_id")
+	private User reviewee;
 
-    // 적극성
-    private Long activenessScore;
+	// 적극성
+	private Long activenessScore;
 
-    // 전문성
-    private Long professionalismScore;
+	// 전문성
+	private Long professionalismScore;
 
-    // 의사소통
-    private Long communicationScore;
+	// 의사소통
+	private Long communicationScore;
 
-    // 다시함께
-    private Long togetherScore;
+	// 다시함께
+	private Long togetherScore;
 
-    // 추천 여부
-    private Long recommendScore;
+	// 추천 여부
+	private Long recommendScore;
 
-    public boolean isDuplicateReview(final Long studyId, final Long reviewerId, final Long revieweeId) {
-        return study.getId() == studyId && reviewer.getId() == reviewerId && reviewee.getId() == revieweeId;
-    }
+	public boolean isDuplicateReview(final Long studyId, final Long reviewerId, final Long revieweeId) {
+		return study.getId() == studyId && reviewer.getId() == reviewerId && reviewee.getId() == revieweeId;
+	}
+
+	public Long getStudyId() {
+		return study.getId();
+	}
+
+	public Long getReviewerId() {
+		return reviewer.getId();
+	}
 
 }

--- a/src/test/java/com/ludo/study/studymatchingplatform/notification/service/NotificationMessageConverterTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/notification/service/NotificationMessageConverterTest.java
@@ -1,0 +1,237 @@
+package com.ludo.study.studymatchingplatform.notification.service;
+
+import static com.ludo.study.studymatchingplatform.notification.domain.notification.NotificationEventType.*;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ludo.study.studymatchingplatform.notification.domain.notification.RecruitmentNotification;
+import com.ludo.study.studymatchingplatform.notification.domain.notification.ReviewNotification;
+import com.ludo.study.studymatchingplatform.notification.domain.notification.StudyEndDateNotifyCond;
+import com.ludo.study.studymatchingplatform.notification.domain.notification.StudyNotification;
+import com.ludo.study.studymatchingplatform.notification.service.dto.response.message.NotificationMessage;
+import com.ludo.study.studymatchingplatform.study.domain.study.Review;
+import com.ludo.study.studymatchingplatform.study.domain.study.Study;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+
+class NotificationMessageConverterTest {
+
+	static final String STUDY_TITLE = "스프링 프로젝트 만들기";
+
+	NotificationMessageConverter notificationMessageConverter = new NotificationMessageConverter();
+
+	@Test
+	@DisplayName("관심 모집공고 알림 메시지")
+	void recruitmentMessage() {
+		// given
+		RecruitmentNotification recruitmentNotification = RecruitmentNotification.of(RECRUITMENT, null, null, null);
+		String expectedTitle = "[루도가 알려요] 관심 항목에 해당하는 모집공고가 나왔습니다.";
+		String expectedContent = "해당 항목으로 검색된 스터디원 모집 공고를 확인하시려면 클릭헤주세요.";
+
+		// when
+		NotificationMessage notificationMessage = notificationMessageConverter.convertRecruitmentNotifyMessage(
+				recruitmentNotification);
+
+		// then
+		assertEqualsNotificationMessage(notificationMessage, expectedTitle, expectedContent);
+	}
+
+	@Test
+	@DisplayName("스터디 지원 현황 알림 메시지")
+	void studyApplicantMessage() {
+		// given
+		Study study = Study.builder().title(STUDY_TITLE).build();
+		User user = User.builder().build();
+		StudyNotification studyNotification = StudyNotification.of(STUDY_APPLICANT, null, study, user);
+
+		String expectedTitle = "[스터디원 모집] %s 스터디에 새로운 지원자가 생겼어요.".formatted(STUDY_TITLE);
+		String expectedContent = "해당 지원자를 보려면 클릭해주세요.";
+
+		// when
+		NotificationMessage notificationMessage = notificationMessageConverter
+				.convertStudyApplicantNotifyMessage(studyNotification);
+
+		// then
+		assertEqualsNotificationMessage(notificationMessage, expectedTitle, expectedContent);
+	}
+
+	@Test
+	@DisplayName("스터디 지원 수락 알림 메시지")
+	void studyApplicantAcceptMessage() {
+		// given
+		Study study = Study.builder().title(STUDY_TITLE).build();
+		StudyNotification studyNotification = StudyNotification.of(STUDY_APPLICANT_ACCEPT, null, study, null);
+
+		String expectedTitle = "[스터디 지원] 지원한 %s 스터디에 합류됐습니다.".formatted(STUDY_TITLE);
+		String expectedContent = """
+				지원하신 %s 스터디 지원에 승인되셨습니다.
+				해당 알림을 클릭하면 스터디로 이동합니다.""".formatted(STUDY_TITLE);
+
+		// when
+		NotificationMessage notificationMessage = notificationMessageConverter.convertStudyApplicantAcceptNotifyMessage(
+				studyNotification);
+
+		// then
+		assertEqualsNotificationMessage(notificationMessage, expectedTitle, expectedContent);
+	}
+
+	@Test
+	@DisplayName("스터디 지원 거절 알림 메시지")
+	void studyApplicantRejectMessage() {
+		// given
+		Study study = Study.builder().title(STUDY_TITLE).build();
+		StudyNotification studyNotification = StudyNotification.of(STUDY_APPLICANT_REJECT, null, study, null);
+
+		String expectedTitle = "[스터디 지원] 지원한 %s 스터디에서 거절됐습니다.".formatted(STUDY_TITLE);
+		String expectedContent = """
+				지원하신 %s 스터디 지원에 거절되셨습니다.
+				스터디에 지원해주셔서 감사합니다.""".formatted(STUDY_TITLE);
+
+		// when
+		NotificationMessage notificationMessage = notificationMessageConverter.convertStudyApplicantRejectNotifyMessage(
+				studyNotification);
+
+		// then
+		assertEqualsNotificationMessage(notificationMessage, expectedTitle, expectedContent);
+	}
+
+	@Test
+	@DisplayName("스터디 종료 기간 알림")
+	void studyEndDateMessage() {
+		// given
+		Study study = Study.builder().title(STUDY_TITLE).build();
+		StudyNotification studyNotification = StudyNotification.of(STUDY_END_DATE, null, study, null);
+		Long period = StudyEndDateNotifyCond.remainingPeriod.getPeriod();
+
+		String expectedTitle = String.format("[스터디 마감 임박] %s 스터디 마감 기한이 %d일 남았습니다!", STUDY_TITLE,
+				period);
+		String expectedContent = """
+				%d일 이후에도 스터디를 진행해야할 시, 팀장은 스터디 수정을 통해 마감 기한을 늘려주시기 바랍니다.
+				해당 알림을 클릭하면 해당 스터디 페이지로 이동합니다.""".formatted(period);
+
+		// when
+		NotificationMessage notificationMessage = notificationMessageConverter.convertStudyEndDateNotifyMessage(
+				studyNotification);
+
+		// then
+		assertEqualsNotificationMessage(notificationMessage, expectedTitle, expectedContent);
+	}
+
+	@Test
+	@DisplayName("스터디 탈퇴자 알림 메시지")
+	void studyLeaveMessage() {
+		// given
+		Study study = Study.builder().title(STUDY_TITLE).build();
+		StudyNotification studyNotification = StudyNotification.of(STUDY_PARTICIPANT_LEAVE, null, study, null);
+		String leaverName = "열공러";
+		User studyLeaver = User.builder().nickname(leaverName).build();
+
+		String expectedTitle = "[스터디원 탈퇴] %s 스터디에서 %s님이 탈퇴했습니다.".formatted(STUDY_TITLE, leaverName);
+		String expectedContent = "%s 스터디에서 %s님이 탈퇴했습니다.".formatted(STUDY_TITLE, leaverName);
+
+		// when
+		NotificationMessage notificationMessage = notificationMessageConverter.convertStudyParticipantLeaveNotifyMessage(
+				studyNotification, studyLeaver);
+
+		// then
+		assertEqualsNotificationMessage(notificationMessage, expectedTitle, expectedContent);
+	}
+
+	@Test
+	@DisplayName("스터디 탈퇴 요청 알림 메시지")
+	void studyLeaveApplyMessage() {
+		// given
+		Study study = Study.builder().title(STUDY_TITLE).build();
+		StudyNotification studyNotification = StudyNotification.of(STUDY_PARTICIPANT_LEAVE_APPLY, null, study, null);
+		String leaverName = "열공러";
+		User studyLeaveApplier = User.builder().nickname(leaverName).build();
+
+		String expectedTitle = "[스터디 탈퇴 승인] %s 스터디에서 %s님이 탈퇴 요청했습니다!".formatted(STUDY_TITLE, leaverName);
+		String expectedContent = "%s님의 탈퇴 요청에 답하시려면 클릭해주세요.".formatted(leaverName);
+
+		// when
+		NotificationMessage notificationMessage = notificationMessageConverter.convertStudyParticipantLeaveApplyNotifyMessage(
+				studyNotification, studyLeaveApplier);
+
+		// then
+		assertEqualsNotificationMessage(notificationMessage, expectedTitle, expectedContent);
+	}
+
+	@Test
+	@DisplayName("스터디 리뷰 시작 알림 메시지")
+	void studyReviewStartMessage() {
+		// given
+		Study study = Study.builder().title(STUDY_TITLE).build();
+		StudyNotification studyNotification = StudyNotification.of(STUDY_REVIEW_START, null, study, null);
+
+		String expectedTitle = "[스터디원 리뷰] %s 스터디를 완주했습니다! 함께 했던 스터디원들에게 리뷰를 남겨주세요.".formatted(STUDY_TITLE);
+		String expectedContent = "해당 스터디원들의 리뷰를 작성하시려면 클릭해주세요.";
+
+		// when
+		NotificationMessage notificationMessage = notificationMessageConverter.convertStudyReviewStartNotifyMessage(
+				studyNotification);
+
+		// then
+		assertEqualsNotificationMessage(notificationMessage, expectedTitle, expectedContent);
+	}
+
+	@Test
+	@DisplayName("리뷰 받음 알림 메시지")
+	void reviewReceiveMessage() {
+		// given
+		String reviewerName = "리뷰어 이름";
+		String revieweeName = "리뷰이 이름";
+		User reviewer = User.builder().nickname(reviewerName).build();
+		User reviewee = User.builder().nickname(revieweeName).build();
+
+		Study study = Study.builder().title(STUDY_TITLE).build();
+		Review review = Review.builder().study(study).reviewer(reviewer).reviewee(reviewee).build();
+		ReviewNotification reviewNotification = ReviewNotification.of(REVIEW_RECEIVE, null, review, reviewee);
+
+		String expectedTitle = "[스터디원 리뷰] 진행 완료된 %s 스터디에서 %s님이 회원님에 대한 리뷰를 작성했습니다.".formatted(STUDY_TITLE,
+				reviewerName);
+		String expectedContent = "해당 스터디원에 대한 리뷰를 작성하시려면 클릭해주세요.";
+
+		// when
+		NotificationMessage notificationMessage = notificationMessageConverter.convertReviewReceiveNotifyMessage(
+				reviewNotification);
+
+		// then
+		assertEqualsNotificationMessage(notificationMessage, expectedTitle, expectedContent);
+	}
+
+	@Test
+	@DisplayName("상호 리뷰 완료 알림 메시지")
+	void reviewPeerFinishMessage() {
+		// given
+		String reviewerName = "리뷰어 이름";
+		String revieweeName = "리뷰이 이름";
+		User reviewer = User.builder().nickname(reviewerName).build();
+		User reviewee = User.builder().nickname(revieweeName).build();
+
+		Study study = Study.builder().title(STUDY_TITLE).build();
+		Review review = Review.builder().study(study).reviewer(reviewer).reviewee(reviewee).build();
+		ReviewNotification reviewNotification = ReviewNotification.of(REVIEW_PEER_FINISH, null, review, reviewee);
+
+		String expectedTitle = "[스터디원 리뷰] 진행 완료된 %s 스터디에서 %s님과 주고 받은 리뷰가 업로드 되었습니다.".formatted(STUDY_TITLE,
+				reviewerName);
+		String expectedContent = "해당 리뷰를 보시려면 클릭해주세요.";
+
+		// when
+		NotificationMessage notificationMessage = notificationMessageConverter.convertReviewPeerFinishNotifyMessage(
+				reviewNotification);
+
+		// then
+		assertEqualsNotificationMessage(notificationMessage, expectedTitle, expectedContent);
+	}
+
+	private void assertEqualsNotificationMessage(NotificationMessage notificationMessage,
+												 String expectedTitle,
+												 String expectedContent
+	) {
+		assertThat(notificationMessage.title()).isEqualTo(expectedTitle);
+		assertThat(notificationMessage.content()).isEqualTo(expectedContent);
+	}
+
+}


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

- [x] 알림유형에 대응되는 프론트엔드 라우트 파라미터 매핑 구현
- [x] 알림유형에 대응되는 알림 메시지 컨버터 구현

<br><br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.
### 알림유형에 대응되는 프론트엔드 라우트 파라미터 매핑 구현
**비즈니스 요구 사항:사용자는 알림을 클릭하면, 해당 알림 유형에 맞는 페이지로 이동한다.**

<br>

<img width="1012" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/68291395/b93e4118-e547-4b63-a8cf-174b1c8cbab5">

<br>

`라우트url`을 백엔드에서 관리하는 방법도 고려되었으나, 프론트엔드에서 `라우트url`을 변경 시 백엔드에서도 동기화해주어야 합니다.

이러한 유지보수 저하를 고려하여, `라우트url`에 필요한 `라우트 parameters`만 백엔드에서 알림 유형에 맞게 구분하여 응답을 내려주는 것으로 프론트-백엔드 회의 때 결정되었습니다. 현재 저희 알림은 크게 `모집공고`, `스터디`, `리뷰` 알림 유형으로 나뉩니다. 해당 유형을 기준으로 `param분류`를 분리하였습니다.

**알림 유형에 맞게 `param`을 갈아끼워줘야 하므로, `NotificationRouteParameter` 인터페이스 및 다형성을 활용**했습니다. 또한 **알림 유형에 맞는 params 구현체를 구현해줘야하므로, DTO에서 정적 팩터리 메서드 및 Notification 서브타입 오버라이딩을 활용**했습니다.

참고: [feat: 알림 유형에 대응되는 프론트엔드 라우트 파라미터를 알림 Response 에 추가](https://github.com/Ludo-SMP/ludo-backend/commit/22b91beec69183c3695750108b9d4ddd688437ad)



<br><br>

### 알림유형에 대응되는 알림 메시지 컨버터 구현
**비즈니스 요구 사항: 사용자는 알림 유형에 맞는 알림 제목과 내용을 확인할 수 있다.**

<br>

<img width="397" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/68291395/d01a654d-73fd-4f31-a9cd-2371374bfa57">

<br><br>

1. `알림 제목 포맷 형식`과 `알림 내용 포맷 형식`은 `알림 유형`에 대응되므로, `NotificationEventType Enum`의 인스턴스 필드로 관리하고자 했습니다.
참고: [refactor: 알림 유형에 대응되는 알림 제목 및 내용 포맷에 해당하는 Enum 인스턴스 필드 추가](https://github.com/Ludo-SMP/ludo-backend/commit/75e67e114856f334d80ff5f74ccf568baef6f5a0)

2. 위의 이미지에서 볼 수 있듯, 알림 제목/내용을 적절하게 재가공해줘야하고, 이를 `NotificationMessageConverter` 클래스에서 구현했습니다.
참고: [feat: 알림 메시지 컨버터 구현](https://github.com/Ludo-SMP/ludo-backend/commit/31d73d44caa5b86280f788de325d39beec0e19ab)

<br><br>

## 💡 이런 고민이 있어요.
### 알림 메시지 컨버터에 관하여 ...
**1. 유지보수를 어떻게 더 개선할 수 있을까요?**

현재는 `알림 제목/내용 포맷 형식`은 `NotificationEventType Enum`에서 관리하고, `NotificationMessageConverter`가 `알림 제목/내용 포맷 형식`을 Enum으로부터 가져와서 알림 메시지 가공을 수행하고 있습니다.

<img width="906" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/68291395/9df54f7d-d1a6-4064-b4d7-7e2ab5101978">

<br><br>

`알림 제목/내용 포맷 형식`을 Enum으로부터 가져오는 부분이 문제라고 생각되는데요.

<img width="909" alt="스크린샷 2024-06-11 오후 7 03 28" src="https://github.com/Ludo-SMP/ludo-backend/assets/68291395/15ef1d6a-7344-4ecf-bf7e-7885c6ada18d">

<br><br>

알림 유형에 맞게 메세지를 가공해줘야 하는데, **정확히 어떤 알림 유형인지 알기가 어렵다**고 생각했습니다. 저는 구현자의 입장이라 인지할 수있지만, 다른 팀원이 봤을 때 추적이 어려울 것이라 생각들었어요.

<img width="856" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/68291395/08aa4f1f-bcfd-4b04-aa5b-c4bf2956d401">

<br><br>

**유지보수 과정에서 알림 메세지가 잘못 포맷팅 되는 경우를 방지하기 위해 테스트 코드로 장치를 마련**했지만, 조금 더 좋은 코드는 없을까 고민하는 중이에요.

<br><br>

**2. 확장성을 고려한 메시지 컨버터 설계**
만약 알림 수신 단말기에 대한 요구사항이 추가되었을 때, 확장에 용이한 설계에 대해 고민중이에요.
`NotificationMessageConverter`가 가공한 메시지가 수신 단말기에 호환이 되지 않을 수있고, 추가적인 설정이 필요할 수도 있을 때 유연하게 대처할 수 있는 설계에 대해 고민이 필요해보여요.

<br>

<img width=500 src="https://github.com/Ludo-SMP/ludo-backend/assets/68291395/2d64d355-d109-4b6d-9e6b-acfb01473e29">



<br><br>


## ✅ 셀프 체크리스트

- [o] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [o] 커밋 메세지를 컨벤션에 맞추었습니다.
- [o] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [o] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [o] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
