### PR TITLE
hotfix: `/studies/{study-id}/applicants` API에 신뢰도 정보 추가 및 Test

### DIFF
--- a/src/e2e/__tests__/review.test.ts
+++ b/src/e2e/__tests__/review.test.ts
@@ -9,10 +9,7 @@ import { fakeWriteReviewRequest } from "../fixtures/review-fixture";
 import { fakeCreateStudyRequest } from "../fixtures/study-fixture";
 import { login, signup } from "../helpers/auth-api-helper";
 import { utcNow } from "../helpers/datetime-helper";
-import {
-  applyRecruitment,
-  writeRecruitment,
-} from "../helpers/recruitment-api-helper";
+import { applyRecruitment, writeRecruitment } from "../helpers/recruitment-api-helper";
 import { getPeerReviews, writeReview } from "../helpers/review-api-helper";
 import { acceptApplicant, createStudy } from "../helpers/study-api-helper";
 import { updateStudyEndDateTime } from "../helpers/study-db-helper";
@@ -130,16 +127,16 @@ describe("리뷰 작성", () => {
     expect(status).toBe(HttpStatusCode.Ok);
     expect(reviews.length).toBeGreaterThan(0);
     expect(reviews[0].selfReview.activenessScore).toEqual(
-      request.activenessScore
+      request.activenessScore,
     );
     expect(reviews[0].selfReview.communicationScore).toEqual(
-      request.communicationScore
+      request.communicationScore,
     );
     expect(reviews[0].selfReview.professionalismScore).toEqual(
-      request.professionalismScore
+      request.professionalismScore,
     );
     expect(reviews[0].selfReview.recommendScore).toEqual(
-      request.recommendScore
+      request.recommendScore,
     );
     expect(reviews[0].selfReview.togetherScore).toEqual(request.togetherScore);
     expect(reviews[0].selfReview.reviewerId).toEqual(ownerId);
@@ -212,16 +209,16 @@ describe("리뷰 작성", () => {
     expect(status).toBe(HttpStatusCode.Ok);
     expect(reviews.length).toBeGreaterThan(0);
     expect(reviews[0].peerReview.activenessScore).toEqual(
-      request.activenessScore
+      request.activenessScore,
     );
     expect(reviews[0].peerReview.communicationScore).toEqual(
-      request.communicationScore
+      request.communicationScore,
     );
     expect(reviews[0].peerReview.professionalismScore).toEqual(
-      request.professionalismScore
+      request.professionalismScore,
     );
     expect(reviews[0].peerReview.recommendScore).toEqual(
-      request.recommendScore
+      request.recommendScore,
     );
     expect(reviews[0].peerReview.togetherScore).toEqual(request.togetherScore);
     expect(reviews[0].peerReview.reviewerId).toEqual(applicantUserId);
@@ -324,44 +321,44 @@ describe("리뷰 작성", () => {
     expect(status).toBe(HttpStatusCode.Ok);
     expect(latestReviews.length).toBe(1);
     expect(latestReviews[0].selfReview.activenessScore).toEqual(
-      lastestRequest.activenessScore
+      lastestRequest.activenessScore,
     );
     expect(latestReviews[0].selfReview.communicationScore).toEqual(
-      lastestRequest.communicationScore
+      lastestRequest.communicationScore,
     );
     expect(latestReviews[0].selfReview.professionalismScore).toEqual(
-      lastestRequest.professionalismScore
+      lastestRequest.professionalismScore,
     );
     expect(latestReviews[0].selfReview.recommendScore).toEqual(
-      lastestRequest.recommendScore
+      lastestRequest.recommendScore,
     );
     expect(latestReviews[0].selfReview.togetherScore).toEqual(
-      lastestRequest.togetherScore
+      lastestRequest.togetherScore,
     );
     expect(latestReviews[0].selfReview.reviewerId).toEqual(applicantUserId);
     expect(latestReviews[0].selfReview.revieweeId).toEqual(
-      lastestRequest.revieweeId
+      lastestRequest.revieweeId,
     );
     expect(latestReviews[0].peerReview).toBeNull();
 
     expect(prevReviews[0].selfReview.activenessScore).toEqual(
-      prevRequest.activenessScore
+      prevRequest.activenessScore,
     );
     expect(prevReviews[0].selfReview.communicationScore).toEqual(
-      prevRequest.communicationScore
+      prevRequest.communicationScore,
     );
     expect(prevReviews[0].selfReview.professionalismScore).toEqual(
-      prevRequest.professionalismScore
+      prevRequest.professionalismScore,
     );
     expect(prevReviews[0].selfReview.recommendScore).toEqual(
-      prevRequest.recommendScore
+      prevRequest.recommendScore,
     );
     expect(prevReviews[0].selfReview.togetherScore).toEqual(
-      prevRequest.togetherScore
+      prevRequest.togetherScore,
     );
     expect(prevReviews[0].selfReview.reviewerId).toEqual(applicantUserId);
     expect(prevReviews[0].selfReview.revieweeId).toEqual(
-      prevRequest.revieweeId
+      prevRequest.revieweeId,
     );
     expect(prevReviews[0].peerReview).toBeNull();
   });
@@ -470,40 +467,40 @@ describe("리뷰 작성", () => {
     expect(status).toBe(HttpStatusCode.Ok);
     expect(latestReview.length).toBe(1);
     expect(latestReview[0].peerReview.activenessScore).toEqual(
-      lastestRequest.activenessScore
+      lastestRequest.activenessScore,
     );
     expect(latestReview[0].peerReview.communicationScore).toEqual(
-      lastestRequest.communicationScore
+      lastestRequest.communicationScore,
     );
     expect(latestReview[0].peerReview.professionalismScore).toEqual(
-      lastestRequest.professionalismScore
+      lastestRequest.professionalismScore,
     );
     expect(latestReview[0].peerReview.recommendScore).toEqual(
-      lastestRequest.recommendScore
+      lastestRequest.recommendScore,
     );
     expect(latestReview[0].peerReview.togetherScore).toEqual(
-      lastestRequest.togetherScore
+      lastestRequest.togetherScore,
     );
     expect(latestReview[0].peerReview.reviewerId).toEqual(owner2Id);
     expect(latestReview[0].peerReview.revieweeId).toEqual(
-      lastestRequest.revieweeId
+      lastestRequest.revieweeId,
     );
     expect(latestReview[0].selfReview).toBeNull();
 
     expect(prevReview[0].peerReview.activenessScore).toEqual(
-      prevRequest.activenessScore
+      prevRequest.activenessScore,
     );
     expect(prevReview[0].peerReview.communicationScore).toEqual(
-      prevRequest.communicationScore
+      prevRequest.communicationScore,
     );
     expect(prevReview[0].peerReview.professionalismScore).toEqual(
-      prevRequest.professionalismScore
+      prevRequest.professionalismScore,
     );
     expect(prevReview[0].peerReview.recommendScore).toEqual(
-      prevRequest.recommendScore
+      prevRequest.recommendScore,
     );
     expect(prevReview[0].peerReview.togetherScore).toEqual(
-      prevRequest.togetherScore
+      prevRequest.togetherScore,
     );
     expect(prevReview[0].peerReview.reviewerId).toEqual(ownerId);
     expect(prevReview[0].peerReview.revieweeId).toEqual(prevRequest.revieweeId);
@@ -619,6 +616,7 @@ describe("리뷰 작성", () => {
     const prevPeerReview = prevReview[0].peerReview;
     const prevMyReview = prevReview[0].selfReview;
 
+    console.log(studies);
     // // then
     expect(status).toBe(HttpStatusCode.Ok);
 
@@ -627,54 +625,54 @@ describe("리뷰 작성", () => {
 
     // latesty Study peer review
     expect(latestPeerReview.activenessScore).toEqual(
-      lastestPeerRequest.activenessScore
+      lastestPeerRequest.activenessScore,
     );
     expect(latestPeerReview.communicationScore).toEqual(
-      lastestPeerRequest.communicationScore
+      lastestPeerRequest.communicationScore,
     );
     expect(latestPeerReview.professionalismScore).toEqual(
-      lastestPeerRequest.professionalismScore
+      lastestPeerRequest.professionalismScore,
     );
     expect(latestPeerReview.recommendScore).toEqual(
-      lastestPeerRequest.recommendScore
+      lastestPeerRequest.recommendScore,
     );
     expect(latestPeerReview.togetherScore).toEqual(
-      lastestPeerRequest.togetherScore
+      lastestPeerRequest.togetherScore,
     );
     expect(latestPeerReview.reviewerId).toEqual(owner2Id);
     expect(latestPeerReview.revieweeId).toEqual(applicantUserId);
 
     // latest study my review
     expect(latestMyReview.activenessScore).toEqual(
-      lastestMyRequest.activenessScore
+      lastestMyRequest.activenessScore,
     );
     expect(latestMyReview.communicationScore).toEqual(
-      lastestMyRequest.communicationScore
+      lastestMyRequest.communicationScore,
     );
     expect(latestMyReview.professionalismScore).toEqual(
-      lastestMyRequest.professionalismScore
+      lastestMyRequest.professionalismScore,
     );
     expect(latestMyReview.recommendScore).toEqual(
-      lastestMyRequest.recommendScore
+      lastestMyRequest.recommendScore,
     );
     expect(latestMyReview.togetherScore).toEqual(
-      lastestMyRequest.togetherScore
+      lastestMyRequest.togetherScore,
     );
     expect(latestMyReview.reviewerId).toEqual(applicantUserId);
     expect(latestMyReview.revieweeId).toEqual(owner2Id);
 
     // prev study peer review
     expect(prevPeerReview.activenessScore).toEqual(
-      prevPeerRequest.activenessScore
+      prevPeerRequest.activenessScore,
     );
     expect(prevPeerReview.communicationScore).toEqual(
-      prevPeerRequest.communicationScore
+      prevPeerRequest.communicationScore,
     );
     expect(prevPeerReview.professionalismScore).toEqual(
-      prevPeerRequest.professionalismScore
+      prevPeerRequest.professionalismScore,
     );
     expect(prevPeerReview.recommendScore).toEqual(
-      prevPeerRequest.recommendScore
+      prevPeerRequest.recommendScore,
     );
     expect(prevPeerReview.togetherScore).toEqual(prevPeerRequest.togetherScore);
     expect(prevPeerReview.reviewerId).toEqual(ownerId);
@@ -683,10 +681,10 @@ describe("리뷰 작성", () => {
     // prev study my review
     expect(prevMyReview.activenessScore).toEqual(prevMyRequest.activenessScore);
     expect(prevMyReview.communicationScore).toEqual(
-      prevMyRequest.communicationScore
+      prevMyRequest.communicationScore,
     );
     expect(prevMyReview.professionalismScore).toEqual(
-      prevMyRequest.professionalismScore
+      prevMyRequest.professionalismScore,
     );
     expect(prevMyReview.recommendScore).toEqual(prevMyRequest.recommendScore);
     expect(prevMyReview.togetherScore).toEqual(prevMyRequest.togetherScore);
@@ -795,7 +793,7 @@ describe("리뷰 작성", () => {
 
       expect(e.response?.status).toBe(HttpStatusCode.BadRequest);
       expect(e.response?.data.message).toEqual(
-        "리뷰 작성 기간이 지났습니다. 리뷰 작성은 스터디 완료 후 최대 14일까지 가능합니다."
+        "리뷰 작성 기간이 지났습니다. 리뷰 작성은 스터디 완료 후 최대 14일까지 가능합니다.",
       );
       expect(e.response?.data.data).toBeNull();
     }
@@ -857,7 +855,7 @@ describe("리뷰 작성", () => {
 
       expect(e.response?.status).toBe(HttpStatusCode.BadRequest);
       expect(e.response?.data.message).toEqual(
-        "자기 자신에게는 리뷰를 작성할 수 없습니다."
+        "자기 자신에게는 리뷰를 작성할 수 없습니다.",
       );
       expect(e.response?.data.data).toBeNull();
     }
@@ -906,7 +904,7 @@ describe("리뷰 작성", () => {
 
       expect(e.response?.status).toBe(HttpStatusCode.Forbidden);
       expect(e.response?.data.message).toEqual(
-        "참여 중인 스터디가 아닙니다. 리뷰를 작성할 수 없습니다."
+        "참여 중인 스터디가 아닙니다. 리뷰를 작성할 수 없습니다.",
       );
       expect(e.response?.data.data).toBeNull();
     }
@@ -954,7 +952,7 @@ describe("리뷰 작성", () => {
 
       expect(e.response?.status).toBe(HttpStatusCode.Forbidden);
       expect(e.response?.data.message).toEqual(
-        "참여 중인 스터디가 아닙니다. 리뷰를 작성할 수 없습니다."
+        "참여 중인 스터디가 아닙니다. 리뷰를 작성할 수 없습니다.",
       );
       expect(e.response?.data.data).toBeNull();
     }
@@ -985,7 +983,7 @@ describe("리뷰 작성", () => {
 
       expect(e.response?.status).toBe(HttpStatusCode.NotFound);
       expect(e.response?.data.message).toEqual(
-        "존재하지 않는 스터디입니다. 리뷰를 작성할 수 없습니다."
+        "존재하지 않는 스터디입니다. 리뷰를 작성할 수 없습니다.",
       );
       expect(e.response?.data.data).toBeNull();
     }

--- a/src/e2e/__tests__/statistics.test.ts
+++ b/src/e2e/__tests__/statistics.test.ts
@@ -12,13 +12,13 @@ import { fakeCreateStudyRequest } from "../fixtures/study-fixture";
 import { login, signup } from "../helpers/auth-api-helper";
 import { utcNow } from "../helpers/datetime-helper";
 import {
-  applyRecruitment,
-  writeRecruitment,
+    applyRecruitment,
+    writeRecruitment,
 } from "../helpers/recruitment-api-helper";
 import { getPeerReviews, writeReview } from "../helpers/review-api-helper";
 import {
-  getMyReviewStatistics,
-  getMyStudyStatistics,
+    getMyReviewStatistics,
+    getMyStudyStatistics,
 } from "../helpers/statistics-api-helper";
 import { acceptApplicant, createStudy } from "../helpers/study-api-helper";
 import { updateStudyEndDateTime } from "../helpers/study-db-helper";
@@ -59,11 +59,11 @@ describe("statistics Api", () => {
     // // when
 
     expect(status).toEqual(HttpStatusCode.Ok);
-    expect(reviewStatistics.activenessScore).toEqual(0);
-    expect(reviewStatistics.communicationScore).toEqual(0);
-    expect(reviewStatistics.professionalismScore).toEqual(0);
-    expect(reviewStatistics.recommendScore).toEqual(0);
-    expect(reviewStatistics.togetherScore).toEqual(0);
+    expect(reviewStatistics.activeness).toEqual(0);
+    expect(reviewStatistics.communication).toEqual(0);
+    expect(reviewStatistics.professionalism).toEqual(0);
+    expect(reviewStatistics.recommend).toEqual(0);
+    expect(reviewStatistics.together).toEqual(0);
   });
 
   it("[200 OK] 사용자 리뷰 통계 조회 가능", async () => {
@@ -81,11 +81,11 @@ describe("statistics Api", () => {
     // // when
 
     expect(status).toEqual(HttpStatusCode.Ok);
-    expect(reviewStatistics.activenessScore).toEqual(0);
-    expect(reviewStatistics.communicationScore).toEqual(0);
-    expect(reviewStatistics.professionalismScore).toEqual(0);
-    expect(reviewStatistics.recommendScore).toEqual(0);
-    expect(reviewStatistics.togetherScore).toEqual(0);
+    expect(reviewStatistics.activeness).toEqual(0);
+    expect(reviewStatistics.communication).toEqual(0);
+    expect(reviewStatistics.professionalism).toEqual(0);
+    expect(reviewStatistics.recommend).toEqual(0);
+    expect(reviewStatistics.together).toEqual(0);
   });
 
   it("[201 CREATED] 로그인 시, 스터디 생성 가능", async () => {
@@ -178,14 +178,14 @@ describe("statistics Api", () => {
     console.log(reviewStatistics);
     // then
     expect(status).toBe(HttpStatusCode.Ok);
-    expect(reviewStatistics.activenessScore / 20).toBe(request.activenessScore);
-    expect(reviewStatistics.communicationScore / 20).toBe(
+    expect(reviewStatistics.activeness / 20).toBe(request.activenessScore);
+    expect(reviewStatistics.communication / 20).toBe(
       request.communicationScore
     );
-    expect(reviewStatistics.professionalismScore / 20).toBe(
+    expect(reviewStatistics.professionalism / 20).toBe(
       request.professionalismScore
     );
-    expect(reviewStatistics.recommendScore / 20).toBe(request.recommendScore);
-    expect(reviewStatistics.togetherScore / 20).toBe(request.togetherScore);
+    expect(reviewStatistics.recommend / 20).toBe(request.recommendScore);
+    expect(reviewStatistics.together / 20).toBe(request.togetherScore);
   });
 });

--- a/src/e2e/dprint.json
+++ b/src/e2e/dprint.json
@@ -1,0 +1,17 @@
+{
+  "typescript": {
+  },
+  "json": {
+  },
+  "biome": {
+  },
+  "excludes": [
+    "**/node_modules",
+    "**/*-lock.json"
+  ],
+  "plugins": [
+    "https://plugins.dprint.dev/typescript-0.91.1.wasm",
+    "https://plugins.dprint.dev/json-0.19.3.wasm",
+    "https://plugins.dprint.dev/biome-0.5.3.wasm"
+  ]
+}

--- a/src/e2e/helpers/review-api-helper.ts
+++ b/src/e2e/helpers/review-api-helper.ts
@@ -13,7 +13,7 @@ export async function writeReview(
     recommendScore,
     revieweeId,
     togetherScore,
-  }: WriteReviewRequest
+  }: WriteReviewRequest,
 ) {
   return apiClient.post<WriteReviewResponse>(`/studies/${studyId}/reviews`, {
     activenessScore,

--- a/src/e2e/helpers/study-api-helper.ts
+++ b/src/e2e/helpers/study-api-helper.ts
@@ -1,6 +1,7 @@
 import { ApiClient } from "../config/api-client";
 import {
   Applicant,
+  ApplicantWithReviewStatistics,
   CreateStudyRequest,
   Participant,
   Study,
@@ -14,7 +15,7 @@ export type CreateStudyResponse = {
 
 export async function createStudy(
   apiClient: ApiClient,
-  body: CreateStudyRequest
+  body: CreateStudyRequest,
 ) {
   return apiClient.post<CreateStudyResponse>("/studies", body);
 }
@@ -25,7 +26,7 @@ export type UpdateStudyResponse = CreateStudyResponse;
 export async function updateStudy(
   apiClient: ApiClient,
   studyId: number,
-  body: UpdateStudyRequest
+  body: UpdateStudyRequest,
 ) {
   return apiClient.put<UpdateStudyResponse>(`/studies/${studyId}`, body);
 }
@@ -39,20 +40,20 @@ export type ParticipantResponse = {
 export async function acceptApplicant(
   apiClient: ApiClient,
   studyId: number,
-  applicantUserId: number
+  applicantUserId: number,
 ) {
   return apiClient.post<ParticipantResponse>(
-    `/studies/${studyId}/apply-accept/${applicantUserId}`
+    `/studies/${studyId}/apply-accept/${applicantUserId}`,
   );
 }
 
 export async function refuseApplicant(
   apiClient: ApiClient,
   studyId: number,
-  applicantUserId: number
+  applicantUserId: number,
 ) {
   return apiClient.post<undefined>(
-    `/studies/${studyId}/apply-refuse/${applicantUserId}`
+    `/studies/${studyId}/apply-refuse/${applicantUserId}`,
   );
 }
 
@@ -62,17 +63,26 @@ export type StudyResponse = { study: Study };
 
 export async function findStudyDetailById(
   apiClient: ApiClient,
-  studyId: number
+  studyId: number,
 ) {
   return apiClient.get<StudyResponse>(`/studies/${studyId}`);
 }
 
 ///
 
-export type ApplicantStudyResponse = Pick<
-  Study,
-  "id" | "owner" | "status" | "participantLimit" | "participantCount"
-> & { applicants: Applicant[] };
+export type ApplicantStudyResponse =
+  & Pick<
+    Study,
+    "id" | "owner" | "status" | "participantLimit" | "participantCount"
+  >
+  & { applicants: Applicant[] };
+
+export type ApplicantStudyWithReviewStatisticsResponse =
+  & Pick<
+    Study,
+    "id" | "owner" | "status" | "participantLimit" | "participantCount"
+  >
+  & { applicants: ApplicantWithReviewStatistics[] };
 //  {
 //   id: number;
 //   owner: User;
@@ -84,12 +94,11 @@ export type ApplicantStudyResponse = Pick<
 // }
 export async function findApplicantsByStudyId(
   apiClient: ApiClient,
-  studyId: number
+  studyId: number,
 ) {
-  return apiClient.post<ApplicantStudyResponse>(
-    `/studies/${studyId}/applicants`
+  return apiClient.get<ApplicantStudyWithReviewStatisticsResponse>(
+    `/studies/${studyId}/applicants`,
   );
 }
 
 ///
-

--- a/src/e2e/types/reviews-types.ts
+++ b/src/e2e/types/reviews-types.ts
@@ -20,3 +20,5 @@ export interface Review {
   togetherScore: number;
   recommendScore: number;
 }
+
+export type ReviewWithUserIds = Omit<Review, "reviewer" | "reviewee"> & { reviewerId: number; revieweeId: number };

--- a/src/e2e/types/statistics-types.ts
+++ b/src/e2e/types/statistics-types.ts
@@ -4,8 +4,8 @@ export type StudyStatistics = {
   id: number;
   user: User;
   totalTeammateCount: number;
+  totalFinishAttendanceStudies: number;
   totalPerfectAttendanceStudies: number;
-  totalRequiredAttendanceStudies: number;
   totalLeftStudyCount: number;
   totalAttendance: number;
   totalValidAttendance: number;
@@ -14,13 +14,13 @@ export type StudyStatistics = {
 
 export type ReviewStatistics = {
   // 적극성
-  activenessScore: number;
+  activeness: number;
   // 전문성
-  professionalismScore: number;
+  professionalism: number;
   // 의사소통
-  communicationScore: number;
+  communication: number;
   // 다시함께
-  togetherScore: number;
+  together: number;
   // 추천
-  recommendScore: number;
+  recommend: number;
 };

--- a/src/e2e/types/study-types.ts
+++ b/src/e2e/types/study-types.ts
@@ -1,4 +1,5 @@
 import { BaseDateTime } from "./base-types";
+import { ReviewStatistics } from "./statistics-types";
 import { User } from "./users-types";
 
 export type UpdateStudyRequest = CreateStudyRequest;
@@ -16,6 +17,7 @@ export interface CreateStudyRequest {
 
 export type Participant = User & { position: Position };
 export type Applicant = User & { position: Position };
+export type ApplicantWithReviewStatistics = Applicant & { reviewStatistics: ReviewStatistics };
 
 export type StudyStatus = "RECRUITING" | "RECRUITED" | "PROGRESS" | "COMPLETED";
 export type Platform = "GATHER" | "GOOGLE_MEET";

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/controller/ReviewStatisticsController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/controller/ReviewStatisticsController.java
@@ -2,7 +2,7 @@ package com.ludo.study.studymatchingplatform.study.controller;
 
 import com.ludo.study.studymatchingplatform.auth.common.AuthUser;
 import com.ludo.study.studymatchingplatform.common.annotation.DataFieldName;
-import com.ludo.study.studymatchingplatform.study.service.dto.response.ReviewStatisticsResponse;
+import com.ludo.study.studymatchingplatform.study.service.dto.response.study.ReviewStatisticsResponse;
 import com.ludo.study.studymatchingplatform.study.service.study.ReviewStatisticsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/controller/StudyController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/controller/StudyController.java
@@ -6,7 +6,7 @@ import com.ludo.study.studymatchingplatform.study.domain.study.StudyStatus;
 import com.ludo.study.studymatchingplatform.study.service.dto.request.recruitment.applicant.StudyApplicantDecisionRequest;
 import com.ludo.study.studymatchingplatform.study.service.dto.request.study.StudyUpdateRequest;
 import com.ludo.study.studymatchingplatform.study.service.dto.request.study.WriteStudyRequest;
-import com.ludo.study.studymatchingplatform.study.service.dto.response.recruitment.applicant.ApplicantResponse;
+import com.ludo.study.studymatchingplatform.study.service.dto.response.recruitment.applicant.ApplicantWithReviewStatisticsResponse;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.study.StudyResponse;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.study.participant.ParticipantUserResponse;
 import com.ludo.study.studymatchingplatform.study.service.recruitment.applicant.StudyApplicantDecisionService;
@@ -115,10 +115,10 @@ public class StudyController {
     @ResponseStatus(HttpStatus.OK)
     @Operation(description = "스터디 지원자 정보")
     @ApiResponse(description = "스터디 지원자 정보 조회 성공", responseCode = "200", useReturnTypeSchema = true, content = @Content(mediaType = "application/json"))
-    public ApplicantResponse findApplicantsInfo(
+    public ApplicantWithReviewStatisticsResponse findApplicantsWithReviewStatistics(
             @Parameter(hidden = true) @AuthUser final User user,
             @PathVariable("studyId") final Long studyId) {
-        return studyService.findApplicantsInfo(user, studyId);
+        return studyService.findApplicantsWithReviewStatistics(user, studyId);
     }
 
     @PutMapping("/{studyId}")

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/ReviewStatistics.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/ReviewStatistics.java
@@ -3,15 +3,13 @@ package com.ludo.study.studymatchingplatform.study.domain.study;
 import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
+@Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -25,7 +23,7 @@ public class ReviewStatistics extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    // review count
+    // reviewStatistics count
     @Builder.Default
     private Long totalActivenessReviewCount = 0L;
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/StudyStatistics.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/StudyStatistics.java
@@ -29,11 +29,11 @@ public class StudyStatistics extends BaseEntity {
 
     // 진행 완료 스터디(진행도 100%)
     @Builder.Default
-    private int totalPerfectAttendanceStudies = 0;
+    private int totalFinishAttendanceStudies = 0;
 
     // 완주 스터디(진행도 80% 이상)
     @Builder.Default
-    private int totalRequiredAttendanceStudies = 0;
+    private int totalPerfectAttendanceStudies = 0;
 
     // 총 무단 탈주 스터디
     @Builder.Default
@@ -68,11 +68,11 @@ public class StudyStatistics extends BaseEntity {
         totalAttendance += participant.getAttendance();
         totalValidAttendance += participant.getValidAttendance();
         totalTeammateCount += study.getParticipantCount() - 1;
+        if (participant.finishAttendance()) {
+            totalFinishAttendanceStudies++;
+        }
         if (participant.perfectAttendance()) {
             totalPerfectAttendanceStudies++;
-        }
-        if (participant.requiredAttendance()) {
-            totalRequiredAttendanceStudies++;
         }
     }
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/participant/Participant.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/participant/Participant.java
@@ -93,14 +93,14 @@ public class Participant extends BaseEntity {
         this.position = position;
     }
 
-    public boolean perfectAttendance() {
-        // TODO: total 스터디 일수를 가져오는 API 필요. 우선 임시 변수로 저장
-        int totalStudyDays = 100;
-        return attendance == totalStudyDays;
+    public boolean finishAttendance() {
+        // TODO:
+        return true;
     }
 
+
     // 출석 80% 이상
-    public boolean requiredAttendance() {
+    public boolean perfectAttendance() {
         // TODO: total 스터디 일수를 가져오는 API 필요. 우선 임시 변수로 저장
         int totalStudyDays = 100;
         return (attendance / totalStudyDays * 100) > 80;

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/recruitment/applicant/ApplicantUserWithReviewStatisticsResponse.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/recruitment/applicant/ApplicantUserWithReviewStatisticsResponse.java
@@ -1,0 +1,32 @@
+package com.ludo.study.studymatchingplatform.study.service.dto.response.recruitment.applicant;
+
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.applicant.Applicant;
+import com.ludo.study.studymatchingplatform.study.domain.study.ReviewStatistics;
+import com.ludo.study.studymatchingplatform.study.service.dto.response.recruitment.position.PositionResponse;
+import com.ludo.study.studymatchingplatform.study.service.dto.response.study.ReviewStatisticsResponse;
+import com.ludo.study.studymatchingplatform.user.domain.user.User;
+import lombok.Builder;
+
+@Builder
+public record ApplicantUserWithReviewStatisticsResponse(
+
+        Long id,
+        String nickname,
+        String email,
+        PositionResponse position,
+        ReviewStatisticsResponse reviewStatistics
+) {
+
+    public static ApplicantUserWithReviewStatisticsResponse from(final Applicant applicant, final ReviewStatistics reviewStatistics) {
+        final User user = applicant.getUser();
+        final PositionResponse response = PositionResponse.from(applicant.getPosition());
+        return ApplicantUserWithReviewStatisticsResponse.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .position(response)
+                .reviewStatistics(ReviewStatisticsResponse.from(reviewStatistics))
+                .build();
+    }
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/recruitment/applicant/ApplicantWithReviewStatisticsResponse.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/recruitment/applicant/ApplicantWithReviewStatisticsResponse.java
@@ -1,0 +1,46 @@
+package com.ludo.study.studymatchingplatform.study.service.dto.response.recruitment.applicant;
+
+import com.ludo.study.studymatchingplatform.study.domain.recruitment.applicant.Applicant;
+import com.ludo.study.studymatchingplatform.study.domain.study.ReviewStatistics;
+import com.ludo.study.studymatchingplatform.study.domain.study.Study;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public record ApplicantWithReviewStatisticsResponse(
+        ApplicantStudyResponse study,
+        List<ApplicantUserWithReviewStatisticsResponse> applicants
+) {
+
+    public static ApplicantWithReviewStatisticsResponse from(final Study study, final List<Applicant> applicants, final List<ReviewStatistics> reviewStatistics) {
+        final ApplicantStudyResponse studyResponse = ApplicantStudyResponse.from(study);
+        final List<ApplicantUserWithReviewStatisticsResponse> applicantsResponse = aggregateReviewStatistics(applicants, reviewStatistics);
+        return new ApplicantWithReviewStatisticsResponse(studyResponse, applicantsResponse);
+    }
+
+    private static List<ApplicantUserWithReviewStatisticsResponse> aggregateReviewStatistics(final List<Applicant> applicants, final List<ReviewStatistics> reviewStatistics) {
+        final Map<Long, Applicant> applicantMap = applicants.stream().collect(Collectors.toMap(
+                applicant -> applicant.getUser().getId(),
+                applicant -> applicant
+        ));
+        final Map<Long, ReviewStatistics> reviewStatisticsMap = reviewStatistics.stream().collect(Collectors.toMap(
+                r -> r.getUser().getId(),
+                r -> r
+        ));
+
+        final List<ApplicantUserWithReviewStatisticsResponse> res = new ArrayList<>();
+        final Stream<Long> userIds = applicants.stream().map(a -> a.getUser().getId());
+        userIds.forEach(userId -> {
+            res.add(
+                    ApplicantUserWithReviewStatisticsResponse.from(
+                            applicantMap.get(userId),
+                            reviewStatisticsMap.get(userId))
+            );
+        });
+
+        return res;
+    }
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/study/PeerReviewsResponse.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/study/PeerReviewsResponse.java
@@ -7,8 +7,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public record PeerReviewsResponse(
-        ReviewResponse selfReview, // self wrote review
-        ReviewResponse peerReview,  // peer wrote review
+        ReviewResponse selfReview, // self wrote reviewStatistics
+        ReviewResponse peerReview,  // peer wrote reviewStatistics
         LocalDateTime updatedDateTime
 ) {
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/study/ReviewStatisticsResponse.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/study/ReviewStatisticsResponse.java
@@ -1,18 +1,18 @@
-package com.ludo.study.studymatchingplatform.study.service.dto.response;
+package com.ludo.study.studymatchingplatform.study.service.dto.response.study;
 
 import com.ludo.study.studymatchingplatform.study.domain.study.ReviewStatistics;
 
 public record ReviewStatisticsResponse(
         // 적극성
-        double activenessScore,
+        double activeness,
         // 전문성
-        double professionalismScore,
+        double professionalism,
         // 의사소통
-        double communicationScore,
+        double communication,
         // 다시함께
-        double togetherScore,
+        double together,
         // 추천
-        double recommendScore
+        double recommend
 ) {
     public static ReviewStatisticsResponse from(final ReviewStatistics statistics) {
         return new ReviewStatisticsResponse(

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewFacade.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewFacade.java
@@ -1,23 +1,21 @@
 package com.ludo.study.studymatchingplatform.study.service.study;
 
-import com.ludo.study.studymatchingplatform.study.repository.study.participant.ParticipantRepositoryImpl;
-import com.ludo.study.studymatchingplatform.study.service.dto.response.study.StudyPeerReviewResponse;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.ludo.study.studymatchingplatform.notification.service.NotificationService;
 import com.ludo.study.studymatchingplatform.common.exception.DataConflictException;
 import com.ludo.study.studymatchingplatform.common.exception.DataNotFoundException;
+import com.ludo.study.studymatchingplatform.notification.service.NotificationService;
 import com.ludo.study.studymatchingplatform.study.domain.study.Review;
 import com.ludo.study.studymatchingplatform.study.domain.study.Study;
 import com.ludo.study.studymatchingplatform.study.repository.study.ReviewRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.repository.study.StudyRepositoryImpl;
+import com.ludo.study.studymatchingplatform.study.repository.study.participant.ParticipantRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.service.dto.request.study.WriteReviewRequest;
+import com.ludo.study.studymatchingplatform.study.service.dto.response.study.StudyPeerReviewResponse;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.study.WriteReviewResponse;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -51,13 +49,13 @@ public class ReviewFacade {
 //    }
 
     public List<StudyPeerReviewResponse> getStudyPeerReviews(final Long selfId) {
-        // 1. 가입한 studyId 모두 찾아온 뒤, 각 study 별 self,peer review 쌍 만들기
-        // 2. 스터디 상관 없이 특정 user에 대한 self, peer review 쌍 만들기
+        // 1. 가입한 studyId 모두 찾아온 뒤, 각 study 별 self,peer reviewStatistics 쌍 만들기
+        // 2. 스터디 상관 없이 특정 user에 대한 self, peer reviewStatistics 쌍 만들기
 
         final List<Review> allSelfReviews = reviewRepository.findAllSelfReviews(selfId);
         final List<Review> allPeerReviews = reviewRepository.findAllPeerReviews(selfId);
 
-        return StudyPeerReviewResponse.listFrom(allSelfReviews,allPeerReviews);
+        return StudyPeerReviewResponse.listFrom(allSelfReviews, allPeerReviews);
     }
 
     public WriteReviewResponse write(final WriteReviewRequest request, final Long studyId, final User reviewer) {

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewStatisticsService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/ReviewStatisticsService.java
@@ -4,12 +4,14 @@ import com.ludo.study.studymatchingplatform.common.exception.DataNotFoundExcepti
 import com.ludo.study.studymatchingplatform.study.domain.study.Review;
 import com.ludo.study.studymatchingplatform.study.domain.study.ReviewStatistics;
 import com.ludo.study.studymatchingplatform.study.repository.study.ReviewStatisticsRepository;
-import com.ludo.study.studymatchingplatform.study.service.dto.response.ReviewStatisticsResponse;
+import com.ludo.study.studymatchingplatform.study.service.dto.response.study.ReviewStatisticsResponse;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -38,5 +40,13 @@ public class ReviewStatisticsService {
     public void updateRevieweeStatistics(final Review review) {
         final ReviewStatistics revieweeStatistics = _findOrCreateByUserId(review.getReviewee().getId());
         revieweeStatistics.update(review);
+    }
+
+    public List<ReviewStatistics> findByUserIdsIn(final List<Long> userIds) {
+        final List<ReviewStatistics> reviewStatistics = new ArrayList<>();
+        for (final Long userId : userIds) {
+            reviewStatistics.add(_findOrCreateByUserId(userId));
+        }
+        return reviewStatistics;
     }
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/StudyService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/StudyService.java
@@ -8,6 +8,7 @@ import com.ludo.study.studymatchingplatform.study.domain.study.participant.Parti
 import com.ludo.study.studymatchingplatform.study.repository.recruitment.applicant.ApplicantRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.repository.study.StudyRepositoryImpl;
 import com.ludo.study.studymatchingplatform.study.service.dto.response.recruitment.applicant.ApplicantResponse;
+import com.ludo.study.studymatchingplatform.study.service.dto.response.recruitment.applicant.ApplicantWithReviewStatisticsResponse;
 import com.ludo.study.studymatchingplatform.study.service.exception.SocialAccountNotFoundException;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ public class StudyService {
     private final StudyRepositoryImpl studyRepository;
     private final ApplicantRepositoryImpl applicantRepository;
     private final UtcDateTimePicker utcDateTimePicker;
+    private final ReviewStatisticsService reviewStatisticsService;
 
     public void leave(final User user, final Long studyId) {
         final Study study = studyRepository.findByIdWithRecruitment(studyId)
@@ -33,6 +35,24 @@ public class StudyService {
         }
         participant.leave(study, utcDateTimePicker.now());
     }
+
+    public ApplicantWithReviewStatisticsResponse findApplicantsWithReviewStatistics(final User user, final Long studyId) {
+        final Study study = findByIdWithRecruitment(studyId);
+        // 스터디 참여자 검증
+        study.getParticipant(user);
+        final Recruitment recruitment = study.getRecruitment();
+        final List<Applicant> applicants =
+                applicantRepository.findStudyApplicantInfoByRecruitmentId(recruitment.getId());
+        final List<Long> applicantsUserIds = applicants.stream()
+                .map(a -> a.getUser().getId()).toList();
+
+        return ApplicantWithReviewStatisticsResponse.from(
+                study,
+                applicants,
+                reviewStatisticsService.findByUserIdsIn(applicantsUserIds)
+        );
+    }
+
 
     public ApplicantResponse findApplicantsInfo(final User user, final Long studyId) {
         final Study study = findByIdWithRecruitment(studyId);

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/StudyStatisticsResponse.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/StudyStatisticsResponse.java
@@ -7,10 +7,10 @@ public record StudyStatisticsResponse(
         Long id,
         UserResponse user,
         int totalTeammateCount,
-        // 진행 완료 스터디(진행도 100%)
-        int totalPerfectAttendanceStudies,
+        // 진행 완료 스터디
+        int totalFinishAttendanceStudies,
         // 완주 스터디(진행도 80% 이상)
-        int totalRequiredAttendanceStudies,
+        int totalPerfectAttendanceStudies,
         // 총 무단 탈주 스터디
         int totalLeftStudyCount,
         // 총 누적 출석
@@ -26,8 +26,8 @@ public record StudyStatisticsResponse(
                 statistics.getId(),
                 UserResponse.from(statistics.getUser()),
                 statistics.getTotalTeammateCount(),
+                statistics.getTotalFinishAttendanceStudies(),
                 statistics.getTotalPerfectAttendanceStudies(),
-                statistics.getTotalRequiredAttendanceStudies(),
                 statistics.getTotalLeftStudyCount(),
                 statistics.getTotalAttendance(),
                 statistics.getTotalValidAttendance(),


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

`/studies/{study-id}/applicants` API를 요구 사항에 맞춰 변경하였습니다.

<img width="470" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/121966058/3916f3db-7cd3-4226-9642-5c5286621aa5">

현재까지 backend test는 이전과 동일하게 1개 제외 모두 통과됩니다.

<img width="1123" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/121966058/78df2f7d-3517-4189-b2fc-dd38f08db22b">

e2e도 1개 제외 통과인데 현재 알림 기능이 진행중이라 터진 것으로 보여집니다. 마무리 되면 저절로 고쳐질 듯 합니다.

<img width="872" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/121966058/3ae1d5e7-bf6f-4e77-9e28-243cfd4da632">


<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- (없다면 이 문항을 지워주세요.)

<br><br>

### 💡 필요한 후속작업이 있어요.

- (없다면 이 문항을 지워주세요.)

<br><br>

### 💡 다음 자료를 참고하면 좋아요.

- (없다면 이 문항을 지워주세요.)

<br><br>

### ✅ 셀프 체크리스트

- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [ ] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
