### PR TITLE
hotfix: `/api/reviews` API Score suffix 일관성 위해 제거

### DIFF
--- a/src/e2e/__tests__/review.test.ts
+++ b/src/e2e/__tests__/review.test.ts
@@ -126,19 +126,19 @@ describe("리뷰 작성", () => {
     // then
     expect(status).toBe(HttpStatusCode.Ok);
     expect(reviews.length).toBeGreaterThan(0);
-    expect(reviews[0].selfReview.activenessScore).toEqual(
+    expect(reviews[0].selfReview.activeness).toEqual(
       request.activenessScore,
     );
-    expect(reviews[0].selfReview.communicationScore).toEqual(
+    expect(reviews[0].selfReview.communication).toEqual(
       request.communicationScore,
     );
-    expect(reviews[0].selfReview.professionalismScore).toEqual(
+    expect(reviews[0].selfReview.professionalism).toEqual(
       request.professionalismScore,
     );
-    expect(reviews[0].selfReview.recommendScore).toEqual(
+    expect(reviews[0].selfReview.recommend).toEqual(
       request.recommendScore,
     );
-    expect(reviews[0].selfReview.togetherScore).toEqual(request.togetherScore);
+    expect(reviews[0].selfReview.together).toEqual(request.togetherScore);
     expect(reviews[0].selfReview.reviewerId).toEqual(ownerId);
     expect(reviews[0].selfReview.revieweeId).toEqual(request.revieweeId);
     expect(reviews[0].peerReview).toBeNull();
@@ -208,19 +208,19 @@ describe("리뷰 작성", () => {
     // then
     expect(status).toBe(HttpStatusCode.Ok);
     expect(reviews.length).toBeGreaterThan(0);
-    expect(reviews[0].peerReview.activenessScore).toEqual(
+    expect(reviews[0].peerReview.activeness).toEqual(
       request.activenessScore,
     );
-    expect(reviews[0].peerReview.communicationScore).toEqual(
+    expect(reviews[0].peerReview.communication).toEqual(
       request.communicationScore,
     );
-    expect(reviews[0].peerReview.professionalismScore).toEqual(
+    expect(reviews[0].peerReview.professionalism).toEqual(
       request.professionalismScore,
     );
-    expect(reviews[0].peerReview.recommendScore).toEqual(
+    expect(reviews[0].peerReview.recommend).toEqual(
       request.recommendScore,
     );
-    expect(reviews[0].peerReview.togetherScore).toEqual(request.togetherScore);
+    expect(reviews[0].peerReview.together).toEqual(request.togetherScore);
     expect(reviews[0].peerReview.reviewerId).toEqual(applicantUserId);
     expect(reviews[0].peerReview.revieweeId).toEqual(request.revieweeId);
     expect(reviews[0].selfReview).toBeNull();
@@ -320,19 +320,19 @@ describe("리뷰 작성", () => {
     // // then
     expect(status).toBe(HttpStatusCode.Ok);
     expect(latestReviews.length).toBe(1);
-    expect(latestReviews[0].selfReview.activenessScore).toEqual(
+    expect(latestReviews[0].selfReview.activeness).toEqual(
       lastestRequest.activenessScore,
     );
-    expect(latestReviews[0].selfReview.communicationScore).toEqual(
+    expect(latestReviews[0].selfReview.communication).toEqual(
       lastestRequest.communicationScore,
     );
-    expect(latestReviews[0].selfReview.professionalismScore).toEqual(
+    expect(latestReviews[0].selfReview.professionalism).toEqual(
       lastestRequest.professionalismScore,
     );
-    expect(latestReviews[0].selfReview.recommendScore).toEqual(
+    expect(latestReviews[0].selfReview.recommend).toEqual(
       lastestRequest.recommendScore,
     );
-    expect(latestReviews[0].selfReview.togetherScore).toEqual(
+    expect(latestReviews[0].selfReview.together).toEqual(
       lastestRequest.togetherScore,
     );
     expect(latestReviews[0].selfReview.reviewerId).toEqual(applicantUserId);
@@ -341,19 +341,19 @@ describe("리뷰 작성", () => {
     );
     expect(latestReviews[0].peerReview).toBeNull();
 
-    expect(prevReviews[0].selfReview.activenessScore).toEqual(
+    expect(prevReviews[0].selfReview.activeness).toEqual(
       prevRequest.activenessScore,
     );
-    expect(prevReviews[0].selfReview.communicationScore).toEqual(
+    expect(prevReviews[0].selfReview.communication).toEqual(
       prevRequest.communicationScore,
     );
-    expect(prevReviews[0].selfReview.professionalismScore).toEqual(
+    expect(prevReviews[0].selfReview.professionalism).toEqual(
       prevRequest.professionalismScore,
     );
-    expect(prevReviews[0].selfReview.recommendScore).toEqual(
+    expect(prevReviews[0].selfReview.recommend).toEqual(
       prevRequest.recommendScore,
     );
-    expect(prevReviews[0].selfReview.togetherScore).toEqual(
+    expect(prevReviews[0].selfReview.together).toEqual(
       prevRequest.togetherScore,
     );
     expect(prevReviews[0].selfReview.reviewerId).toEqual(applicantUserId);
@@ -462,23 +462,23 @@ describe("리뷰 작성", () => {
     const latestReview = studies[0].reviews;
     const prevReview = studies[1].reviews;
 
-    console.log(latestReview[0].selfReview);
     // // then
+
     expect(status).toBe(HttpStatusCode.Ok);
     expect(latestReview.length).toBe(1);
-    expect(latestReview[0].peerReview.activenessScore).toEqual(
+    expect(latestReview[0].peerReview.activeness).toEqual(
       lastestRequest.activenessScore,
     );
-    expect(latestReview[0].peerReview.communicationScore).toEqual(
+    expect(latestReview[0].peerReview.communication).toEqual(
       lastestRequest.communicationScore,
     );
-    expect(latestReview[0].peerReview.professionalismScore).toEqual(
+    expect(latestReview[0].peerReview.professionalism).toEqual(
       lastestRequest.professionalismScore,
     );
-    expect(latestReview[0].peerReview.recommendScore).toEqual(
+    expect(latestReview[0].peerReview.recommend).toEqual(
       lastestRequest.recommendScore,
     );
-    expect(latestReview[0].peerReview.togetherScore).toEqual(
+    expect(latestReview[0].peerReview.together).toEqual(
       lastestRequest.togetherScore,
     );
     expect(latestReview[0].peerReview.reviewerId).toEqual(owner2Id);
@@ -487,19 +487,19 @@ describe("리뷰 작성", () => {
     );
     expect(latestReview[0].selfReview).toBeNull();
 
-    expect(prevReview[0].peerReview.activenessScore).toEqual(
+    expect(prevReview[0].peerReview.activeness).toEqual(
       prevRequest.activenessScore,
     );
-    expect(prevReview[0].peerReview.communicationScore).toEqual(
+    expect(prevReview[0].peerReview.communication).toEqual(
       prevRequest.communicationScore,
     );
-    expect(prevReview[0].peerReview.professionalismScore).toEqual(
+    expect(prevReview[0].peerReview.professionalism).toEqual(
       prevRequest.professionalismScore,
     );
-    expect(prevReview[0].peerReview.recommendScore).toEqual(
+    expect(prevReview[0].peerReview.recommend).toEqual(
       prevRequest.recommendScore,
     );
-    expect(prevReview[0].peerReview.togetherScore).toEqual(
+    expect(prevReview[0].peerReview.together).toEqual(
       prevRequest.togetherScore,
     );
     expect(prevReview[0].peerReview.reviewerId).toEqual(ownerId);
@@ -616,7 +616,6 @@ describe("리뷰 작성", () => {
     const prevPeerReview = prevReview[0].peerReview;
     const prevMyReview = prevReview[0].selfReview;
 
-    console.log(studies);
     // // then
     expect(status).toBe(HttpStatusCode.Ok);
 
@@ -624,70 +623,70 @@ describe("리뷰 작성", () => {
     expect(latestReviews.length).toBe(1);
 
     // latesty Study peer review
-    expect(latestPeerReview.activenessScore).toEqual(
+    expect(latestPeerReview.activeness).toEqual(
       lastestPeerRequest.activenessScore,
     );
-    expect(latestPeerReview.communicationScore).toEqual(
+    expect(latestPeerReview.communication).toEqual(
       lastestPeerRequest.communicationScore,
     );
-    expect(latestPeerReview.professionalismScore).toEqual(
+    expect(latestPeerReview.professionalism).toEqual(
       lastestPeerRequest.professionalismScore,
     );
-    expect(latestPeerReview.recommendScore).toEqual(
+    expect(latestPeerReview.recommend).toEqual(
       lastestPeerRequest.recommendScore,
     );
-    expect(latestPeerReview.togetherScore).toEqual(
+    expect(latestPeerReview.together).toEqual(
       lastestPeerRequest.togetherScore,
     );
     expect(latestPeerReview.reviewerId).toEqual(owner2Id);
     expect(latestPeerReview.revieweeId).toEqual(applicantUserId);
 
     // latest study my review
-    expect(latestMyReview.activenessScore).toEqual(
+    expect(latestMyReview.activeness).toEqual(
       lastestMyRequest.activenessScore,
     );
-    expect(latestMyReview.communicationScore).toEqual(
+    expect(latestMyReview.communication).toEqual(
       lastestMyRequest.communicationScore,
     );
-    expect(latestMyReview.professionalismScore).toEqual(
+    expect(latestMyReview.professionalism).toEqual(
       lastestMyRequest.professionalismScore,
     );
-    expect(latestMyReview.recommendScore).toEqual(
+    expect(latestMyReview.recommend).toEqual(
       lastestMyRequest.recommendScore,
     );
-    expect(latestMyReview.togetherScore).toEqual(
+    expect(latestMyReview.together).toEqual(
       lastestMyRequest.togetherScore,
     );
     expect(latestMyReview.reviewerId).toEqual(applicantUserId);
     expect(latestMyReview.revieweeId).toEqual(owner2Id);
 
     // prev study peer review
-    expect(prevPeerReview.activenessScore).toEqual(
+    expect(prevPeerReview.activeness).toEqual(
       prevPeerRequest.activenessScore,
     );
-    expect(prevPeerReview.communicationScore).toEqual(
+    expect(prevPeerReview.communication).toEqual(
       prevPeerRequest.communicationScore,
     );
-    expect(prevPeerReview.professionalismScore).toEqual(
+    expect(prevPeerReview.professionalism).toEqual(
       prevPeerRequest.professionalismScore,
     );
-    expect(prevPeerReview.recommendScore).toEqual(
+    expect(prevPeerReview.recommend).toEqual(
       prevPeerRequest.recommendScore,
     );
-    expect(prevPeerReview.togetherScore).toEqual(prevPeerRequest.togetherScore);
+    expect(prevPeerReview.together).toEqual(prevPeerRequest.togetherScore);
     expect(prevPeerReview.reviewerId).toEqual(ownerId);
     expect(prevPeerReview.revieweeId).toEqual(applicantUserId);
 
     // prev study my review
-    expect(prevMyReview.activenessScore).toEqual(prevMyRequest.activenessScore);
-    expect(prevMyReview.communicationScore).toEqual(
+    expect(prevMyReview.activeness).toEqual(prevMyRequest.activenessScore);
+    expect(prevMyReview.communication).toEqual(
       prevMyRequest.communicationScore,
     );
-    expect(prevMyReview.professionalismScore).toEqual(
+    expect(prevMyReview.professionalism).toEqual(
       prevMyRequest.professionalismScore,
     );
-    expect(prevMyReview.recommendScore).toEqual(prevMyRequest.recommendScore);
-    expect(prevMyReview.togetherScore).toEqual(prevMyRequest.togetherScore);
+    expect(prevMyReview.recommend).toEqual(prevMyRequest.recommendScore);
+    expect(prevMyReview.together).toEqual(prevMyRequest.togetherScore);
     expect(prevMyReview.reviewerId).toEqual(applicantUserId);
     expect(prevMyReview.revieweeId).toEqual(ownerId);
   });

--- a/src/e2e/__tests__/statistics.test.ts
+++ b/src/e2e/__tests__/statistics.test.ts
@@ -1,6 +1,5 @@
 import { HttpStatusCode } from "axios";
 import { subDays } from "date-fns";
-import { Knex } from "knex";
 import dns from "node:dns";
 import { describe } from "node:test";
 import { ApiClient } from "../config/api-client";
@@ -11,20 +10,13 @@ import { fakeWriteReviewRequest } from "../fixtures/review-fixture";
 import { fakeCreateStudyRequest } from "../fixtures/study-fixture";
 import { login, signup } from "../helpers/auth-api-helper";
 import { utcNow } from "../helpers/datetime-helper";
-import {
-    applyRecruitment,
-    writeRecruitment,
-} from "../helpers/recruitment-api-helper";
+import { applyRecruitment, writeRecruitment } from "../helpers/recruitment-api-helper";
 import { getPeerReviews, writeReview } from "../helpers/review-api-helper";
-import {
-    getMyReviewStatistics,
-    getMyStudyStatistics,
-} from "../helpers/statistics-api-helper";
+import { getMyReviewStatistics, getMyStudyStatistics } from "../helpers/statistics-api-helper";
 import { acceptApplicant, createStudy } from "../helpers/study-api-helper";
 import { updateStudyEndDateTime } from "../helpers/study-db-helper";
 dns.setDefaultResultOrder("ipv4first");
 
-let tx: Knex.Transaction<any, any[]>;
 
 describe("statistics Api", () => {
   it("[200 OK] 사용자 스터디 통계 조회 가능", async () => {
@@ -118,7 +110,7 @@ describe("statistics Api", () => {
     expect(study.status).toEqual("RECRUITING");
   });
 
-  test.only("[200 OK] review 작성 시, review 통계 확인 시 반영", async () => {
+  test("[200 OK] review 작성 시, review 통계 확인 시 반영", async () => {
     // given
     const client = ApiClient.default();
     const owner = fakeSignupBody();
@@ -175,15 +167,15 @@ describe("statistics Api", () => {
       },
     } = await getMyReviewStatistics(client);
 
-    console.log(reviewStatistics);
+    console.log(reviewStatistics)
     // then
     expect(status).toBe(HttpStatusCode.Ok);
     expect(reviewStatistics.activeness / 20).toBe(request.activenessScore);
     expect(reviewStatistics.communication / 20).toBe(
-      request.communicationScore
+      request.communicationScore,
     );
     expect(reviewStatistics.professionalism / 20).toBe(
-      request.professionalismScore
+      request.professionalismScore,
     );
     expect(reviewStatistics.recommend / 20).toBe(request.recommendScore);
     expect(reviewStatistics.together / 20).toBe(request.togetherScore);

--- a/src/e2e/helpers/review-api-helper.ts
+++ b/src/e2e/helpers/review-api-helper.ts
@@ -28,11 +28,11 @@ export async function writeReview(
 export type ReviewResponse = {
   reviewerId: number;
   revieweeId: number;
-  activenessScore: number;
-  professionalismScore: number;
-  communicationScore: number;
-  togetherScore: number;
-  recommendScore: number;
+  activeness: number;
+  professionalism: number;
+  communication: number;
+  together: number;
+  recommend: number;
 };
 
 export type PeerReview = {

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/study/ReviewResponse.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/study/ReviewResponse.java
@@ -7,11 +7,11 @@ import java.time.LocalDateTime;
 public record ReviewResponse(
         Long reviewerId,
         Long revieweeId,
-        Long activenessScore,
-        Long professionalismScore,
-        Long communicationScore,
-        Long togetherScore,
-        Long recommendScore,
+        Long activeness,
+        Long professionalism,
+        Long communication,
+        Long together,
+        Long recommend,
         LocalDateTime createdDateTime
 ) {
     public static ReviewResponse from(final Review review) {


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

<img width="811" alt="image" src="https://github.com/Ludo-SMP/ludo-backend/assets/121966058/2b5229c1-760d-4326-a9dc-fe5a875c4d5f">

<br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- (없다면 이 문항을 지워주세요.)

<br><br>

### 💡 필요한 후속작업이 있어요.

- (없다면 이 문항을 지워주세요.)

<br><br>

### 💡 다음 자료를 참고하면 좋아요.

- (없다면 이 문항을 지워주세요.)

<br><br>

### ✅ 셀프 체크리스트

- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [ ] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
