### PR TITLE
SP-471/Fix-Refactor: 관심키워드 알림 설정 요구사항 만족하도록 기능 수정 및 알림 설정 API 원자성 보장을 위해 트랜잭션 통합

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/service/basic/BasicAuthService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/service/basic/BasicAuthService.java
@@ -1,49 +1,54 @@
 package com.ludo.study.studymatchingplatform.auth.service.basic;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.ludo.study.studymatchingplatform.auth.service.bcrypt.BcryptService;
 import com.ludo.study.studymatchingplatform.auth.service.google.dto.request.BasicLoginRequest;
 import com.ludo.study.studymatchingplatform.auth.service.google.dto.request.BasicSignupRequest;
 import com.ludo.study.studymatchingplatform.common.exception.DataConflictException;
 import com.ludo.study.studymatchingplatform.common.exception.DataNotFoundException;
 import com.ludo.study.studymatchingplatform.common.exception.UnauthorizedUserException;
-import com.ludo.study.studymatchingplatform.notification.repository.notification.StudyNotificationJpaRepository;
+import com.ludo.study.studymatchingplatform.notification.domain.config.GlobalNotificationUserConfig;
+import com.ludo.study.studymatchingplatform.notification.repository.config.GlobalNotificationUserConfigRepositoryImpl;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 import com.ludo.study.studymatchingplatform.user.repository.user.UserRepositoryImpl;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class BasicAuthService {
 
-    private final UserRepositoryImpl userRepository;
-    private final BcryptService bcryptService;
-    // TODO: GlobalNotificationSettings 추가
+	private final UserRepositoryImpl userRepository;
+	private final BcryptService bcryptService;
+	private final GlobalNotificationUserConfigRepositoryImpl notificationUserConfigRepository;
 
-    public User signup(final BasicSignupRequest request) {
-        if (userRepository.findByEmail(request.email()).isPresent()) {
-            throw new DataConflictException("이미 가입된 이메일입니다.");
-        }
+	public User signup(final BasicSignupRequest request) {
+		if (userRepository.findByEmail(request.email()).isPresent()) {
+			throw new DataConflictException("이미 가입된 이메일입니다.");
+		}
 
-        if (userRepository.existsByNickname(request.nickname())) {
-            throw new DataConflictException("이미 존재하는 닉네임입니다.");
-        }
+		if (userRepository.existsByNickname(request.nickname())) {
+			throw new DataConflictException("이미 존재하는 닉네임입니다.");
+		}
 
-        final String hashedPassword = bcryptService.hashPassword(request.password());
-        return userRepository.save(request.toUser(hashedPassword));
-    }
+		final String hashedPassword = bcryptService.hashPassword(request.password());
+		final User user = userRepository.save(request.toUser(hashedPassword));
+		notificationUserConfigRepository.save(GlobalNotificationUserConfig.ofNewSignUpUser(user));
+		return user;
+	}
 
-    public User login(final BasicLoginRequest request) {
-        final User user = userRepository.findByEmail(request.email())
-                .orElseThrow(() -> new DataNotFoundException("가입되지 않은 이메일입니다."));
+	public User login(final BasicLoginRequest request) {
+		final User user = userRepository.findByEmail(request.email())
+				.orElseThrow(() -> new DataNotFoundException("가입되지 않은 이메일입니다."));
 
-        if (!bcryptService.verifyPassword(request.password(), user.getPassword())) {
-            throw new UnauthorizedUserException("비밀번호가 일치하지 않습니다.");
-        }
+		if (!bcryptService.verifyPassword(request.password(), user.getPassword())) {
+			throw new UnauthorizedUserException("비밀번호가 일치하지 않습니다.");
+		}
 
-        return user;
-    }
+		return user;
+	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/config/ServletFilterConfig.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/config/ServletFilterConfig.java
@@ -1,41 +1,44 @@
 package com.ludo.study.studymatchingplatform.config;
 
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
 import com.ludo.study.studymatchingplatform.auth.common.provider.CookieProvider;
 import com.ludo.study.studymatchingplatform.auth.common.provider.JwtTokenProvider;
 import com.ludo.study.studymatchingplatform.auth.common.service.UserDetailsService;
 import com.ludo.study.studymatchingplatform.filter.JwtAuthenticationFilter;
 import com.ludo.study.studymatchingplatform.user.service.UserService;
+
 import jakarta.servlet.Filter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @RequiredArgsConstructor
 public class ServletFilterConfig {
 
-    private final JwtTokenProvider jwtTokenProvider;
-    private final CookieProvider cookieProvider;
-    private final UserDetailsService userDetailsService;
-    private final UserService userService;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final CookieProvider cookieProvider;
+	private final UserDetailsService userDetailsService;
+	private final UserService userService;
 
-    @Bean
-    public FilterRegistrationBean<Filter> jwtAuthenticationFilter() {
-        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+	@Bean
+	public FilterRegistrationBean<Filter> jwtAuthenticationFilter() {
+		FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
 
-        filterRegistrationBean.setFilter(
-                new JwtAuthenticationFilter(jwtTokenProvider, cookieProvider, userDetailsService, userService));
-        filterRegistrationBean.setOrder(1);
-        addAuthenticationEndpoints(filterRegistrationBean);
-        return filterRegistrationBean;
-    }
+		filterRegistrationBean.setFilter(
+				new JwtAuthenticationFilter(jwtTokenProvider, cookieProvider, userDetailsService, userService));
+		filterRegistrationBean.setOrder(1);
+		addAuthenticationEndpoints(filterRegistrationBean);
+		return filterRegistrationBean;
+	}
 
-    private void addAuthenticationEndpoints(FilterRegistrationBean<Filter> filterRegistrationBean) {
-        filterRegistrationBean.addUrlPatterns("/api/users/*");
-        filterRegistrationBean.addUrlPatterns("/api/studies/*");
-        filterRegistrationBean.addUrlPatterns("/api/statistics/*");
-        filterRegistrationBean.addUrlPatterns("/api/reviews/*");
-    }
+	private void addAuthenticationEndpoints(FilterRegistrationBean<Filter> filterRegistrationBean) {
+		filterRegistrationBean.addUrlPatterns("/api/users/*");
+		filterRegistrationBean.addUrlPatterns("/api/studies/*");
+		filterRegistrationBean.addUrlPatterns("/api/statistics/*");
+		filterRegistrationBean.addUrlPatterns("/api/reviews/*");
+		filterRegistrationBean.addUrlPatterns("/api/notifications/*");
+	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/controller/NotificationController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/controller/NotificationController.java
@@ -70,9 +70,7 @@ public class NotificationController {
 	public ResponseEntity<Void> updateNotificationKeywordConfig(@AuthUser final User user,
 																@RequestBody final NotificationKeywordConfigRequest notificationKeywordConfigRequest
 	) {
-		notificationService.configNotificationCategoryKeywords(user, notificationKeywordConfigRequest.categoryIds());
-		notificationService.configNotificationPositionKeywords(user, notificationKeywordConfigRequest.positionIds());
-		notificationService.configNotificationStackKeywords(user, notificationKeywordConfigRequest.stackIds());
+		notificationService.configNotificationKeywords(user, notificationKeywordConfigRequest);
 
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/config/GlobalNotificationUserConfig.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/config/GlobalNotificationUserConfig.java
@@ -68,13 +68,13 @@ public class GlobalNotificationUserConfig {
 	public static GlobalNotificationUserConfig ofNewSignUpUser(final User user) {
 		GlobalNotificationUserConfig globalNotificationUserConfig = new GlobalNotificationUserConfig();
 		globalNotificationUserConfig.user = user;
-		globalNotificationUserConfig.onAllConfig();
+		globalNotificationUserConfig.updateAllConfig(true);
 		return globalNotificationUserConfig;
 	}
 
 	public void updateConfig(final NotificationConfigGroup configGroup, final boolean enabled) {
 		switch (configGroup) {
-			case ALL_CONFIG -> onAllConfig();
+			case ALL_CONFIG -> updateAllConfig(enabled);
 			case RECRUITMENT_CONFIG -> updateRecruitmentConfig(enabled);
 			case STUDY_APPLICANT_CONFIG -> updateStudyApplicantConfig(enabled);
 			case STUDY_APPLICANT_RESULT_CONFIG -> updateStudyApplicantResultConfig(enabled);
@@ -84,14 +84,14 @@ public class GlobalNotificationUserConfig {
 		}
 	}
 
-	private void onAllConfig() {
-		this.allConfig = true;
-		this.recruitmentConfig = true;
-		this.studyApplicantConfig = true;
-		this.studyApplicantResultConfig = true;
-		this.studyEndDateConfig = true;
-		this.studyParticipantLeaveConfig = true;
-		this.reviewConfig = true;
+	private void updateAllConfig(boolean enabled) {
+		this.allConfig = enabled;
+		this.recruitmentConfig = enabled;
+		this.studyApplicantConfig = enabled;
+		this.studyApplicantResultConfig = enabled;
+		this.studyEndDateConfig = enabled;
+		this.studyParticipantLeaveConfig = enabled;
+		this.reviewConfig = enabled;
 	}
 
 	private void updateRecruitmentConfig(boolean enabled) {

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordCategory.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordCategory.java
@@ -3,47 +3,45 @@ package com.ludo.study.studymatchingplatform.notification.domain.keyword;
 import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 
-import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = "id")
 public class NotificationKeywordCategory {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "notification_keyword_category_id")
-	private Long id;
+	@EmbeddedId
+	private NotificationKeywordCategoryId id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@MapsId("userId")
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@MapsId("categoryId")
 	@JoinColumn(name = "category_id")
 	private Category category;
 
-	private NotificationKeywordCategory(final User user, final Category category) {
-		this.user = user;
-		this.category = category;
-	}
-
+	/**
+	 * do not initialize: new NotificationKeywordCategory();
+	 * should use this static method
+	 */
 	public static NotificationKeywordCategory of(final User user, final Category category) {
-		return new NotificationKeywordCategory(user, category);
+		final NotificationKeywordCategoryId id = new NotificationKeywordCategoryId(user.getId(), category.getId());
+		return new NotificationKeywordCategory(id, user, category);
 	}
 
 	public Long getCategoryId() {

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordCategoryId.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordCategoryId.java
@@ -1,0 +1,20 @@
+package com.ludo.study.studymatchingplatform.notification.domain.keyword;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationKeywordCategoryId implements Serializable {
+
+	private Long userId;
+	private Long categoryId;
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordPosition.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordPosition.java
@@ -3,47 +3,45 @@ package com.ludo.study.studymatchingplatform.notification.domain.keyword;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.position.Position;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 
-import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = "id")
 public class NotificationKeywordPosition {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "notification_keyword_position_id")
-	private Long id;
+	@EmbeddedId
+	private NotificationKeywordPositionId id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@MapsId("userId")
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@MapsId("positionId")
 	@JoinColumn(name = "position_id")
 	private Position position;
 
-	private NotificationKeywordPosition(final User user, final Position position) {
-		this.user = user;
-		this.position = position;
-	}
-
+	/**
+	 * do not initialize: new NotificationKeywordPosition();
+	 * should use this static method
+	 */
 	public static NotificationKeywordPosition of(final User user, final Position position) {
-		return new NotificationKeywordPosition(user, position);
+		final NotificationKeywordPositionId id = new NotificationKeywordPositionId(user.getId(), position.getId());
+		return new NotificationKeywordPosition(id, user, position);
 	}
 
 	public Long getPositionId() {

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordPositionId.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordPositionId.java
@@ -1,0 +1,20 @@
+package com.ludo.study.studymatchingplatform.notification.domain.keyword;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationKeywordPositionId implements Serializable {
+
+	private Long userId;
+	private Long positionId;
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordStack.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordStack.java
@@ -3,50 +3,49 @@ package com.ludo.study.studymatchingplatform.notification.domain.keyword;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.Stack;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 
-import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = "id")
 public class NotificationKeywordStack {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "notification_keyword_stack_id")
-	private Long id;
+	@EmbeddedId
+	private NotificationKeywordStackId id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@MapsId("userId")
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@MapsId("stackId")
 	@JoinColumn(name = "stack_id")
 	private Stack stack;
 
-	private NotificationKeywordStack(final User user, final Stack stack) {
-		this.user = user;
-		this.stack = stack;
-	}
-
+	/**
+	 * do not initialize: new NotificationKeywordStack();
+	 * should use this static method
+	 */
 	public static NotificationKeywordStack of(final User user, final Stack stack) {
-		return new NotificationKeywordStack(user, stack);
+		final NotificationKeywordStackId id = new NotificationKeywordStackId(user.getId(), stack.getId());
+		return new NotificationKeywordStack(id, user, stack);
 	}
 
 	public Long getStackId() {
 		return stack.getId();
 	}
+
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordStackId.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/domain/keyword/NotificationKeywordStackId.java
@@ -1,0 +1,20 @@
+package com.ludo.study.studymatchingplatform.notification.domain.keyword;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@EqualsAndHashCode
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationKeywordStackId implements Serializable {
+
+	private Long userId;
+	private Long stackId;
+
+}

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/keyword/NotificationKeywordCategoryRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/keyword/NotificationKeywordCategoryRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.ludo.study.studymatchingplatform.notification.repository.keyword;
 import static com.ludo.study.studymatchingplatform.notification.domain.keyword.QNotificationKeywordCategory.*;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.stereotype.Repository;
 
@@ -25,7 +26,7 @@ public class NotificationKeywordCategoryRepositoryImpl {
 	}
 
 	public List<NotificationKeywordCategory> saveAll(
-			final List<NotificationKeywordCategory> notificationKeywordCategories
+			final Set<NotificationKeywordCategory> notificationKeywordCategories
 	) {
 		return notificationKeywordCategoryJpaRepository.saveAll(notificationKeywordCategories);
 	}
@@ -38,7 +39,15 @@ public class NotificationKeywordCategoryRepositoryImpl {
 
 	public void deleteByUserId(final Long userId) {
 		q.delete(notificationKeywordCategory)
-				.where(notificationKeywordCategory.id.eq(userId))
+				.where(notificationKeywordCategory.user.id.eq(userId))
+				.execute();
+		em.flush();
+		em.clear();
+	}
+
+	public void deleteByIn(final Set<NotificationKeywordCategory> keywordCategories) {
+		q.delete(notificationKeywordCategory)
+				.where(notificationKeywordCategory.in(keywordCategories))
 				.execute();
 		em.flush();
 		em.clear();

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/keyword/NotificationKeywordPositionRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/keyword/NotificationKeywordPositionRepositoryImpl.java
@@ -1,9 +1,9 @@
 package com.ludo.study.studymatchingplatform.notification.repository.keyword;
 
-import static com.ludo.study.studymatchingplatform.notification.domain.keyword.QNotificationKeywordCategory.*;
 import static com.ludo.study.studymatchingplatform.notification.domain.keyword.QNotificationKeywordPosition.*;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.stereotype.Repository;
 
@@ -26,7 +26,7 @@ public class NotificationKeywordPositionRepositoryImpl {
 	}
 
 	public List<NotificationKeywordPosition> saveAll(
-			final List<NotificationKeywordPosition> notificationKeywordPosition
+			final Set<NotificationKeywordPosition> notificationKeywordPosition
 	) {
 		return notificationKeywordPositionJpaRepository.saveAll(notificationKeywordPosition);
 	}
@@ -38,8 +38,16 @@ public class NotificationKeywordPositionRepositoryImpl {
 	}
 
 	public void deleteByUserId(final Long userId) {
-		q.delete(notificationKeywordCategory)
-				.where(notificationKeywordCategory.id.eq(userId))
+		q.delete(notificationKeywordPosition)
+				.where(notificationKeywordPosition.user.id.eq(userId))
+				.execute();
+		em.flush();
+		em.clear();
+	}
+
+	public void deleteByIn(final Set<NotificationKeywordPosition> keywordPositions) {
+		q.delete(notificationKeywordPosition)
+				.where(notificationKeywordPosition.in(keywordPositions))
 				.execute();
 		em.flush();
 		em.clear();

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/keyword/NotificationKeywordStackRepositoryImpl.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/repository/keyword/NotificationKeywordStackRepositoryImpl.java
@@ -1,9 +1,9 @@
 package com.ludo.study.studymatchingplatform.notification.repository.keyword;
 
-import static com.ludo.study.studymatchingplatform.notification.domain.keyword.QNotificationKeywordCategory.*;
 import static com.ludo.study.studymatchingplatform.notification.domain.keyword.QNotificationKeywordStack.*;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.stereotype.Repository;
 
@@ -25,7 +25,7 @@ public class NotificationKeywordStackRepositoryImpl {
 		return notificationKeywordStackJpaRepository.save(notificationKeywordStack);
 	}
 
-	public List<NotificationKeywordStack> saveAll(final List<NotificationKeywordStack> notificationKeywordStacks) {
+	public List<NotificationKeywordStack> saveAll(final Set<NotificationKeywordStack> notificationKeywordStacks) {
 		return notificationKeywordStackJpaRepository.saveAll(notificationKeywordStacks);
 	}
 
@@ -36,8 +36,16 @@ public class NotificationKeywordStackRepositoryImpl {
 	}
 
 	public void deleteByUserId(final Long userId) {
-		q.delete(notificationKeywordCategory)
-				.where(notificationKeywordCategory.id.eq(userId))
+		q.delete(notificationKeywordStack)
+				.where(notificationKeywordStack.user.id.eq(userId))
+				.execute();
+		em.flush();
+		em.clear();
+	}
+
+	public void deleteByIn(final Set<NotificationKeywordStack> keywordStacks) {
+		q.delete(notificationKeywordStack)
+				.where(notificationKeywordStack.in(keywordStacks))
 				.execute();
 		em.flush();
 		em.clear();

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationCommandService.java
@@ -2,6 +2,7 @@ package com.ludo.study.studymatchingplatform.notification.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -98,18 +99,40 @@ public class NotificationCommandService {
 	}
 
 	@Transactional
-	public void saveNotificationKeywordCategory(final NotificationKeywordCategory notificationKeywordCategory) {
-		notificationKeywordCategoryRepository.save(notificationKeywordCategory);
+	public void saveNotificationKeywordCategories(
+			final Set<NotificationKeywordCategory> notificationKeywordCategories) {
+		notificationKeywordCategoryRepository.saveAll(notificationKeywordCategories);
 	}
 
 	@Transactional
-	public void saveNotificationKeywordPosition(final NotificationKeywordPosition notificationKeywordPosition) {
-		notificationKeywordPositionRepository.save(notificationKeywordPosition);
+	public void saveNotificationKeywordPositions(final Set<NotificationKeywordPosition> notificationKeywordPositions) {
+		notificationKeywordPositionRepository.saveAll(notificationKeywordPositions);
 	}
 
 	@Transactional
-	public void saveNotificationKeywordStack(final NotificationKeywordStack notificationKeywordStack) {
-		notificationKeywordStackRepository.save(notificationKeywordStack);
+	public void saveNotificationKeywordStacks(final Set<NotificationKeywordStack> notificationKeywordStacks) {
+		notificationKeywordStackRepository.saveAll(notificationKeywordStacks);
+	}
+
+	@Transactional
+	public void deleteNotificationKeywordCategories(
+			final Set<NotificationKeywordCategory> notificationKeywordCategories
+	) {
+		notificationKeywordCategoryRepository.deleteByIn(notificationKeywordCategories);
+	}
+
+	@Transactional
+	public void deleteNotificationKeywordStacks(
+			final Set<NotificationKeywordStack> notificationKeywordStacks
+	) {
+		notificationKeywordStackRepository.deleteByIn(notificationKeywordStacks);
+	}
+
+	@Transactional
+	public void deleteNotificationKeywordPositions(
+			final Set<NotificationKeywordPosition> notificationKeywordPositions
+	) {
+		notificationKeywordPositionRepository.deleteByIn(notificationKeywordPositions);
 	}
 
 	@Transactional

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationQueryService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationQueryService.java
@@ -5,10 +5,10 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.springframework.stereotype.Service;
@@ -169,8 +169,7 @@ public class NotificationQueryService {
 	}
 
 	public NotificationConfigResponse readNotificationConfigAndKeywords(final User user) {
-		final GlobalNotificationUserConfig userConfig = findNotificationConfig(
-				user);
+		final GlobalNotificationUserConfig userConfig = findNotificationConfig(user);
 
 		final List<NotificationKeywordCategory> notificationKeywordCategories = notificationKeywordCategoryRepository
 				.findByUserId(user.getId());
@@ -194,34 +193,16 @@ public class NotificationQueryService {
 						String.format("id={%d} 사용자의 알림 설정이 등록되지 않았습니다.", user.getId())));
 	}
 
-	public Set<Long> readExistCategoryKeywordCategoryIds(final User user) {
-		final List<NotificationKeywordCategory> notificationKeywordCategories = notificationKeywordCategoryRepository
-				.findByUserId(user.getId());
-
-		return notificationKeywordCategories
-				.stream()
-				.map(NotificationKeywordCategory::getCategoryId)
-				.collect(Collectors.toSet());
+	public Set<NotificationKeywordPosition> readNotificationKeywordPositions(final User user) {
+		return new HashSet<>(notificationKeywordPositionRepository.findByUserId(user.getId()));
 	}
 
-	public Set<Long> readExistPositionKeywordPositionIds(final User user) {
-		final List<NotificationKeywordPosition> notificationKeywordPositions = notificationKeywordPositionRepository
-				.findByUserId(user.getId());
-
-		return notificationKeywordPositions
-				.stream()
-				.map(NotificationKeywordPosition::getPositionId)
-				.collect(Collectors.toSet());
+	public Set<NotificationKeywordStack> readNotificationKeywordStacks(final User user) {
+		return new HashSet<>(notificationKeywordStackRepository.findByUserId(user.getId()));
 	}
 
-	public Set<Long> readExistStackKeywordStackIds(final User user) {
-		final List<NotificationKeywordStack> notificationKeywordStacks = notificationKeywordStackRepository
-				.findByUserId(user.getId());
-
-		return notificationKeywordStacks
-				.stream()
-				.map(NotificationKeywordStack::getStackId)
-				.collect(Collectors.toSet());
+	public Set<NotificationKeywordCategory> readNotificationKeywordCategories(final User user) {
+		return new HashSet<>(notificationKeywordCategoryRepository.findByUserId(user.getId()));
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationService.java
@@ -222,6 +222,10 @@ public class NotificationService {
 
 	@Transactional
 	public void configNotificationKeywords(final User user, final NotificationKeywordConfigRequest configRequest) {
+		if (validateKeywordConfigUpdatable(user)) {
+			return;
+		}
+
 		configNotificationCategoryKeywords(user, configRequest.categoryIds());
 		configNotificationPositionKeywords(user, configRequest.positionIds());
 		configNotificationStackKeywords(user, configRequest.stackIds());
@@ -230,10 +234,6 @@ public class NotificationService {
 	private void configNotificationCategoryKeywords(final User user,
 													final List<Long> categoryIds
 	) {
-		if (validateKeywordConfigUpdatable(user)) {
-			return;
-		}
-
 		final Set<NotificationKeywordCategory> requestedKeywordCategory =
 				createRequestedKeywordCategories(user, categoryIds);
 
@@ -252,10 +252,6 @@ public class NotificationService {
 	private void configNotificationPositionKeywords(final User user,
 													final List<Long> positionIds
 	) {
-		if (validateKeywordConfigUpdatable(user)) {
-			return;
-		}
-
 		final Set<NotificationKeywordPosition> requestedKeywordPositions =
 				createRequestedKeywordPositions(user, positionIds);
 
@@ -274,10 +270,6 @@ public class NotificationService {
 	private void configNotificationStackKeywords(final User user,
 												 final List<Long> stackIds
 	) {
-		if (validateKeywordConfigUpdatable(user)) {
-			return;
-		}
-
 		final Set<NotificationKeywordStack> requestedKeywordStacks =
 				createRequestedKeywordStacks(user, stackIds);
 

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationService.java
@@ -10,6 +10,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.ludo.study.studymatchingplatform.notification.controller.dto.request.NotificationKeywordConfigRequest;
 import com.ludo.study.studymatchingplatform.notification.domain.config.GlobalNotificationUserConfig;
 import com.ludo.study.studymatchingplatform.notification.domain.config.NotificationConfigGroup;
 import com.ludo.study.studymatchingplatform.notification.domain.keyword.NotificationKeywordCategory;
@@ -220,8 +221,14 @@ public class NotificationService {
 	}
 
 	@Transactional
-	public void configNotificationCategoryKeywords(final User user,
-												   final List<Long> categoryIds
+	public void configNotificationKeywords(final User user, final NotificationKeywordConfigRequest configRequest) {
+		configNotificationCategoryKeywords(user, configRequest.categoryIds());
+		configNotificationPositionKeywords(user, configRequest.positionIds());
+		configNotificationStackKeywords(user, configRequest.stackIds());
+	}
+
+	private void configNotificationCategoryKeywords(final User user,
+													final List<Long> categoryIds
 	) {
 		if (validateKeywordConfigUpdatable(user)) {
 			return;
@@ -242,9 +249,8 @@ public class NotificationService {
 		saveAndDeleteKeywordCategories(keywordCategoriesToSave, keywordCategoriesToDelete);
 	}
 
-	@Transactional
-	public void configNotificationPositionKeywords(final User user,
-												   final List<Long> positionIds
+	private void configNotificationPositionKeywords(final User user,
+													final List<Long> positionIds
 	) {
 		if (validateKeywordConfigUpdatable(user)) {
 			return;
@@ -265,9 +271,8 @@ public class NotificationService {
 		saveAndDeleteKeywordPositions(keywordPositionsToSave, keywordPositionsToDelete);
 	}
 
-	@Transactional
-	public void configNotificationStackKeywords(final User user,
-												final List<Long> stackIds
+	private void configNotificationStackKeywords(final User user,
+												 final List<Long> stackIds
 	) {
 		if (validateKeywordConfigUpdatable(user)) {
 			return;

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/NotificationService.java
@@ -4,6 +4,7 @@ import static com.ludo.study.studymatchingplatform.notification.domain.notificat
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -222,56 +223,137 @@ public class NotificationService {
 	public void configNotificationCategoryKeywords(final User user,
 												   final List<Long> categoryIds
 	) {
-		// 이미 존재하는 카테고리 찾기
-		final Set<Long> existCategoryIds = notificationQueryService.readExistCategoryKeywordCategoryIds(user);
-
-		// 존재하지 않는 카테고리만 필터링
-		final List<Long> notExistCategoryIds = filterNotExistIds(categoryIds, existCategoryIds);
-
-		// 필터링된 카테고리에 대해 키워드 생성
-		for (Long newCategoryId : notExistCategoryIds) {
-			final Category category = categoryQueryService.readCategory(newCategoryId);
-			notificationCommandService.saveNotificationKeywordCategory(NotificationKeywordCategory.of(user, category));
+		if (validateKeywordConfigUpdatable(user)) {
+			return;
 		}
+
+		final Set<NotificationKeywordCategory> requestedKeywordCategory =
+				createRequestedKeywordCategories(user, categoryIds);
+
+		final Set<NotificationKeywordCategory> savedKeywordCategories =
+				notificationQueryService.readNotificationKeywordCategories(user);
+
+		final Set<NotificationKeywordCategory> keywordCategoriesToSave =
+				filterKeywordsToSave(requestedKeywordCategory, savedKeywordCategories);
+
+		final Set<NotificationKeywordCategory> keywordCategoriesToDelete =
+				filterKeywordsToDelete(savedKeywordCategories, requestedKeywordCategory);
+
+		saveAndDeleteKeywordCategories(keywordCategoriesToSave, keywordCategoriesToDelete);
 	}
 
 	@Transactional
 	public void configNotificationPositionKeywords(final User user,
 												   final List<Long> positionIds
 	) {
-		// 이미 존재하는 포지션 찾기
-		final Set<Long> existPositionIds = notificationQueryService.readExistPositionKeywordPositionIds(user);
-
-		// 존재하지 않는 포지션만 필터링
-		final List<Long> notExistPositionIds = filterNotExistIds(positionIds, existPositionIds);
-
-		for (Long notExistPositionId : notExistPositionIds) {
-			final Position position = positionQueryService.readPosition(notExistPositionId);
-			notificationCommandService.saveNotificationKeywordPosition(NotificationKeywordPosition.of(user, position));
+		if (validateKeywordConfigUpdatable(user)) {
+			return;
 		}
+
+		final Set<NotificationKeywordPosition> requestedKeywordPositions =
+				createRequestedKeywordPositions(user, positionIds);
+
+		final Set<NotificationKeywordPosition> savedKeywordPositions =
+				notificationQueryService.readNotificationKeywordPositions(user);
+
+		final Set<NotificationKeywordPosition> keywordPositionsToSave =
+				filterKeywordsToSave(requestedKeywordPositions, savedKeywordPositions);
+
+		final Set<NotificationKeywordPosition> keywordPositionsToDelete =
+				filterKeywordsToDelete(savedKeywordPositions, requestedKeywordPositions);
+
+		saveAndDeleteKeywordPositions(keywordPositionsToSave, keywordPositionsToDelete);
 	}
 
 	@Transactional
 	public void configNotificationStackKeywords(final User user,
-												final List<Long> positionIds
+												final List<Long> stackIds
 	) {
-		// 이미 존재하는 스택 찾기
-		final Set<Long> existStackIds = notificationQueryService.readExistStackKeywordStackIds(user);
-
-		// 존재하지 않는 스택만 필터링
-		final List<Long> notExistStackIds = filterNotExistIds(positionIds, existStackIds);
-
-		for (Long notExistStackId : notExistStackIds) {
-			final Stack stack = stackQueryService.readStack(notExistStackId);
-			notificationCommandService.saveNotificationKeywordStack(NotificationKeywordStack.of(user, stack));
+		if (validateKeywordConfigUpdatable(user)) {
+			return;
 		}
+
+		final Set<NotificationKeywordStack> requestedKeywordStacks =
+				createRequestedKeywordStacks(user, stackIds);
+
+		final Set<NotificationKeywordStack> savedKeywordStacks =
+				notificationQueryService.readNotificationKeywordStacks(user);
+
+		final Set<NotificationKeywordStack> keywordStacksToSave =
+				filterKeywordsToSave(requestedKeywordStacks, savedKeywordStacks);
+
+		final Set<NotificationKeywordStack> keywordStacksToDelete =
+				filterKeywordsToDelete(savedKeywordStacks, requestedKeywordStacks);
+
+		saveAndDeleteKeywordStacks(keywordStacksToSave, keywordStacksToDelete);
 	}
 
-	private List<Long> filterNotExistIds(final List<Long> target, final Set<Long> compare) {
-		return target
-				.stream()
-				.filter(categoryId -> !compare.contains(categoryId))
-				.toList();
+	private boolean validateKeywordConfigUpdatable(final User user) {
+		return !notificationQueryService.isNotificationConfigTrue(user, NotificationConfigGroup.RECRUITMENT_CONFIG);
+	}
+
+	private Set<NotificationKeywordCategory> createRequestedKeywordCategories(final User user,
+																			  final List<Long> categoryIds
+	) {
+		return categoryIds.stream()
+				.map(categoryId -> {
+					final Category category = categoryQueryService.readCategory(categoryId);
+					return NotificationKeywordCategory.of(user, category);
+				})
+				.collect(Collectors.toSet());
+	}
+
+	private Set<NotificationKeywordPosition> createRequestedKeywordPositions(final User user,
+																			 final List<Long> positionIds
+	) {
+		return positionIds.stream()
+				.map(positionId -> {
+					final Position position = positionQueryService.readPosition(positionId);
+					return NotificationKeywordPosition.of(user, position);
+				})
+				.collect(Collectors.toSet());
+	}
+
+	private Set<NotificationKeywordStack> createRequestedKeywordStacks(final User user, final List<Long> stackIds) {
+		return stackIds.stream()
+				.map(stackId -> {
+					final Stack stack = stackQueryService.readStack(stackId);
+					return NotificationKeywordStack.of(user, stack);
+				})
+				.collect(Collectors.toSet());
+	}
+
+	private <T> Set<T> filterKeywordsToDelete(final Set<T> savedKeywords, final Set<T> requestedKeywords) {
+		return savedKeywords.stream()
+				.filter(saved -> !requestedKeywords.contains(saved))
+				.collect(Collectors.toSet());
+	}
+
+	private <T> Set<T> filterKeywordsToSave(final Set<T> requestedKeywords, final Set<T> savedKeywords) {
+		return requestedKeywords.stream()
+				.filter(requested -> !savedKeywords.contains(requested))
+				.collect(Collectors.toSet());
+	}
+
+	private void saveAndDeleteKeywordCategories(final Set<NotificationKeywordCategory> keywordCategoriesToSave,
+												final Set<NotificationKeywordCategory> keywordCategoriesToDelete
+	) {
+		notificationCommandService.saveNotificationKeywordCategories(keywordCategoriesToSave);
+		notificationCommandService.deleteNotificationKeywordCategories(keywordCategoriesToDelete);
+	}
+
+	private void saveAndDeleteKeywordPositions(final Set<NotificationKeywordPosition> keywordPositionsToSave,
+											   final Set<NotificationKeywordPosition> keywordPositionsToDelete
+	) {
+		notificationCommandService.saveNotificationKeywordPositions(keywordPositionsToSave);
+		notificationCommandService.deleteNotificationKeywordPositions(keywordPositionsToDelete);
+	}
+
+	private void saveAndDeleteKeywordStacks(final Set<NotificationKeywordStack> keywordStacksToSave,
+											final Set<NotificationKeywordStack> keywordStacksToDelete
+	) {
+		notificationCommandService.saveNotificationKeywordStacks(keywordStacksToSave);
+		notificationCommandService.deleteNotificationKeywordStacks(keywordStacksToDelete);
 	}
 
 	public NotificationConfigResponse findNotificationConfig(final User user) {

--- a/src/main/java/com/ludo/study/studymatchingplatform/notification/service/dto/response/config/NotificationConfigResponse.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/notification/service/dto/response/config/NotificationConfigResponse.java
@@ -33,20 +33,38 @@ public record NotificationConfigResponse(AllConfigResponse allConfig,
 															final List<NotificationKeywordStack> notificationKeywordStacks
 	) {
 
+		final AllConfigResponse allConfigResponse = new AllConfigResponse(
+				ALL_CONFIG.name(), userConfig.getAllConfig());
+
+		final StudyApplicantConfigResponse studyApplicantConfigResponse = new StudyApplicantConfigResponse(
+				STUDY_APPLICANT_CONFIG.name(), userConfig.getStudyApplicantConfig());
+
+		final StudyApplicantResultConfigResponse studyApplicantResultConfigResponse = new StudyApplicantResultConfigResponse(
+				STUDY_APPLICANT_RESULT_CONFIG.name(), userConfig.getStudyApplicantResultConfig());
+
+		final StudyEndDateConfigResponse studyEndDateConfig = new StudyEndDateConfigResponse(
+				STUDY_END_DATE_CONFIG.name(), userConfig.getStudyEndDateConfig());
+
+		final StudyParticipantLeaveConfigResponse studyParticipantLeaveConfig = new StudyParticipantLeaveConfigResponse(
+				STUDY_PARTICIPANT_LEAVE_CONFIG.name(), userConfig.getStudyParticipantLeaveConfig());
+
+		final ReviewConfigResponse reviewConfig = new ReviewConfigResponse(
+				REVIEW_CONFIG.name(), userConfig.getReviewConfig());
+
+		final RecruitmentConfigResponse recruitmentConfig = new RecruitmentConfigResponse(
+				RECRUITMENT_CONFIG.name(), userConfig.getRecruitmentConfig(),
+				mapToCategoryKeyword(notificationKeywordCategories),
+				mapToPositionKeyword(notificationKeywordPositions),
+				mapToStackKeyword(notificationKeywordStacks));
+
 		return new NotificationConfigResponse(
-				new AllConfigResponse(ALL_CONFIG.name(), userConfig.getAllConfig()),
-				new StudyApplicantConfigResponse(STUDY_APPLICANT_CONFIG.name(), userConfig.getStudyApplicantConfig()),
-				new StudyApplicantResultConfigResponse(STUDY_APPLICANT_CONFIG.name(),
-						userConfig.getStudyApplicantConfig()),
-				new StudyEndDateConfigResponse(STUDY_END_DATE_CONFIG.name(), userConfig.getStudyEndDateConfig()),
-				new StudyParticipantLeaveConfigResponse(STUDY_PARTICIPANT_LEAVE_CONFIG.name(),
-						userConfig.getStudyParticipantLeaveConfig()),
-				new ReviewConfigResponse(REVIEW_CONFIG.name(), userConfig.getReviewConfig()),
-				new RecruitmentConfigResponse(RECRUITMENT_CONFIG.name(),
-						userConfig.getRecruitmentConfig(),
-						mapToCategoryKeyword(notificationKeywordCategories),
-						mapToPositionKeyword(notificationKeywordPositions),
-						mapToStackKeyword(notificationKeywordStacks)));
+				allConfigResponse,
+				studyApplicantConfigResponse,
+				studyApplicantResultConfigResponse,
+				studyEndDateConfig,
+				studyParticipantLeaveConfig,
+				reviewConfig,
+				recruitmentConfig);
 	}
 
 	private static List<RecruitmentConfigResponse.CategoryKeyword> mapToCategoryKeyword(

--- a/src/test/java/com/ludo/study/studymatchingplatform/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/notification/service/NotificationServiceTest.java
@@ -1,0 +1,33 @@
+package com.ludo.study.studymatchingplatform.notification.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class NotificationServiceTest {
+
+	@Nested
+	@DisplayName("모집공고 관심 키워드를 업데이트하는 기능은")
+	class Describe_ConfigNotificationKeywords {
+
+		@Test
+		@DisplayName("저장되지 않은 관심 키워드만 새로 저장된다.")
+		void test() {
+			// given
+
+			// when
+
+			// then
+		}
+
+		@Test
+		@DisplayName("저장되어 있는 관심 키워드가 요청 받은 관심 키워드에 없으면 삭제된다.")
+		void test2() {
+			// given
+
+			// when
+
+			// then
+		}
+	}
+}


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

- [x] 관심키워드 알림 설정 요구사항 만족하도록 기능 수정
  - 요구사항1: 관심 키워드 `기술 스택`, `포지션`, `카테고리`를 설정할 때, 현재 등록되지 않은 관심 키워드만 새로 생성된다.
  - 요구사항2: 관심 키워드 `기술 스택`, `포지션`, `카테고리`를 설정할 때, 기존에 등록한 키워드가 설정값에 없는 경우 기존에 등록한 키워드는 삭제된다.

- [x] 관심키워드 알림 설정 API 원자성 보장을 위해 트랜잭션 통합

<br><br>

## 💡 이슈를 처리하면서 추가된 코드가 있어요.
### 모집공고 관심 키워드 엔티티 스펙 변경

- 모집공고 관심 키워드 엔티티:
  - `NotificationKeywordStack`
  - `NotificationKeywordCategory`
  - `NotificationKeywordPosition`
- **기본키를 조합키로 변경**했습니다.


<br><br>

## 💡 필요한 후속작업이 있어요.

- 프로덕션 DB에 엔티티 수정사항 반영

<br><br>

### ✅ 셀프 체크리스트

- [o] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [o] 커밋 메세지를 컨벤션에 맞추었습니다.
- [o] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [o] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [o] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
