### PR TITLE
Fix: 모집공고 관련 API specs & Entity specs

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/study/controller/RecruitmentController.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/controller/RecruitmentController.java
@@ -110,7 +110,7 @@ public class RecruitmentController {
 		return recruitmentService.getStudyInfo(user, studyId);
 	}
 
-	@PutMapping("/studies/{studyId}/recruitments")
+	@PutMapping("/studies/{studyId}/recruitments/{recruitmentId}")
 	@ResponseStatus(HttpStatus.OK)
 	@DataFieldName("recruitment")
 	@Operation(description = "모집 공고 수정")

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/recruitment/Recruitment.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/recruitment/Recruitment.java
@@ -1,5 +1,16 @@
 package com.ludo.study.studymatchingplatform.study.domain.recruitment;
 
+import static jakarta.persistence.FetchType.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.data.annotation.CreatedDate;
+
 import com.ludo.study.studymatchingplatform.common.entity.BaseEntity;
 import com.ludo.study.studymatchingplatform.study.domain.id.ApplicantId;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.applicant.Applicant;
@@ -11,18 +22,28 @@ import com.ludo.study.studymatchingplatform.study.domain.recruitment.stack.Stack
 import com.ludo.study.studymatchingplatform.study.domain.study.Study;
 import com.ludo.study.studymatchingplatform.study.domain.study.category.Category;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
-import jakarta.persistence.*;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.annotation.CreatedDate;
-
-import java.time.LocalDateTime;
-import java.util.*;
-
-import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
 @Getter
@@ -35,340 +56,340 @@ import static jakarta.persistence.FetchType.LAZY;
 @Slf4j
 public class Recruitment extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "recruitment_id")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "recruitment_id")
+	private Long id;
 
-    @OneToOne(fetch = LAZY)
-    @JoinColumn(name = "study_id", nullable = false)
-    private Study study;
+	@OneToOne(fetch = LAZY)
+	@JoinColumn(name = "study_id", nullable = false)
+	private Study study;
 
-    @OneToMany(fetch = LAZY, mappedBy = "recruitment", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Builder.Default
-    private List<Applicant> applicants = new ArrayList<>();
+	@OneToMany(fetch = LAZY, mappedBy = "recruitment", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Builder.Default
+	private List<Applicant> applicants = new ArrayList<>();
 
-    @OneToMany(fetch = LAZY, mappedBy = "recruitment", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Builder.Default
-    private List<RecruitmentStack> recruitmentStacks = new ArrayList<>();
+	@OneToMany(fetch = LAZY, mappedBy = "recruitment", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Builder.Default
+	private List<RecruitmentStack> recruitmentStacks = new ArrayList<>();
 
-    @OneToMany(fetch = LAZY, mappedBy = "recruitment", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Builder.Default
-    private List<RecruitmentPosition> recruitmentPositions = new ArrayList<>();
+	@OneToMany(fetch = LAZY, mappedBy = "recruitment", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Builder.Default
+	private List<RecruitmentPosition> recruitmentPositions = new ArrayList<>();
 
-    @CreatedDate
-    @Column(nullable = false)
-    private LocalDateTime modifiedDateTime;
+	@CreatedDate
+	@Column(nullable = false)
+	private LocalDateTime modifiedDateTime;
 
-    // contact 추가 (연결 방법)
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, columnDefinition = "char(20)")
-    private Contact contact;
+	// contact 추가 (연결 방법)
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, columnDefinition = "char(20)")
+	private Contact contact;
 
-    @Column(nullable = false, length = 2048)
-    @Size(max = 2048)
-    private String callUrl;
+	@Column(nullable = false, length = 2048)
+	@Size(max = 2048)
+	private String callUrl;
 
-    @Column(nullable = false, length = 50)
-    @Size(max = 50)
-    private String title;
+	@Column(nullable = false, length = 50)
+	@Size(max = 50)
+	private String title;
 
-    @Column(nullable = false, length = 2000)
-    @Size(max = 2000)
-    private String content;
+	@Column(nullable = false, length = 2000)
+	@Size(max = 2000)
+	private String content;
 
-    @Column(nullable = false)
-    @PositiveOrZero
-    @Builder.Default
-    private Integer hits = 0;
+	@Column(nullable = false)
+	@PositiveOrZero
+	@Builder.Default
+	private Integer hits = 0;
 
-    @Column(nullable = false)
-    private LocalDateTime recruitmentEndDateTime;
+	@Column(nullable = false)
+	private LocalDateTime recruitmentEndDateTime;
 
-    @Column(nullable = false)
-    @PositiveOrZero
-    private Integer applicantCount;
+	@Column(nullable = false)
+	@PositiveOrZero
+	private Integer applicantLimit;
 
-    public static Recruitment of(
-            final String title,
-            final String content,
-            final Contact contact,
-            final String callUrl,
-            final Integer hits,
-            final Integer applicantLimit,
-            final LocalDateTime recruitmentEndDateTime,
-            final Study study
-    ) {
-        return Recruitment.builder()
-                .title(title)
-                .content(content)
-                .contact(contact)
-                .callUrl(callUrl)
-                .hits(hits)
-                .applicantCount(applicantLimit)
-                .recruitmentEndDateTime(recruitmentEndDateTime)
-                .study(study)
-                .build();
-    }
+	public static Recruitment of(
+			final String title,
+			final String content,
+			final Contact contact,
+			final String callUrl,
+			final Integer hits,
+			final Integer applicantLimit,
+			final LocalDateTime recruitmentEndDateTime,
+			final Study study
+	) {
+		return Recruitment.builder()
+				.title(title)
+				.content(content)
+				.contact(contact)
+				.callUrl(callUrl)
+				.hits(hits)
+				.applicantLimit(applicantLimit)
+				.recruitmentEndDateTime(recruitmentEndDateTime)
+				.study(study)
+				.build();
+	}
 
-    @Deprecated
-    public void connectToStudy(Study study) {
-        this.study = study;
-    }
+	@Deprecated
+	public void connectToStudy(Study study) {
+		this.study = study;
+	}
 
-    /***
-     *
-     * @param recruitmentStack
-     * 어플리케이션 레벨에서 데이터 정합성 유지
-     */
-    public void addRecruitmentStack(RecruitmentStack recruitmentStack) {
-        this.recruitmentStacks
-                .add(recruitmentStack);
-    }
+	/***
+	 *
+	 * @param recruitmentStack
+	 * 어플리케이션 레벨에서 데이터 정합성 유지
+	 */
+	public void addRecruitmentStack(RecruitmentStack recruitmentStack) {
+		this.recruitmentStacks
+				.add(recruitmentStack);
+	}
 
-    public void addPosition(RecruitmentPosition recruitmentPosition) {
-        this.recruitmentPositions
-                .add(recruitmentPosition);
-    }
+	public void addPosition(RecruitmentPosition recruitmentPosition) {
+		this.recruitmentPositions
+				.add(recruitmentPosition);
+	}
 
-    public void upHit() {
-        hits++;
-    }
+	public void upHit() {
+		hits++;
+	}
 
-    public List<String> getStackNames() {
-        return recruitmentStacks.stream()
-                .map(recruitmentStack -> recruitmentStack.getStack().getName())
-                .toList();
-    }
+	public List<String> getStackNames() {
+		return recruitmentStacks.stream()
+				.map(recruitmentStack -> recruitmentStack.getStack().getName())
+				.toList();
+	}
 
-    public List<String> getPositionNames() {
-        return recruitmentPositions.stream()
-                .map(recruitmentPosition -> recruitmentPosition.getPosition().getName())
-                .toList();
-    }
+	public List<String> getPositionNames() {
+		return recruitmentPositions.stream()
+				.map(recruitmentPosition -> recruitmentPosition.getPosition().getName())
+				.toList();
+	}
 
-    public void addRecruitmentStacks(final List<RecruitmentStack> recruitmentStacks) {
-        this.recruitmentStacks.addAll(recruitmentStacks);
-    }
+	public void addRecruitmentStacks(final List<RecruitmentStack> recruitmentStacks) {
+		this.recruitmentStacks.addAll(recruitmentStacks);
+	}
 
-    public void addRecruitmentPositions(final List<RecruitmentPosition> recruitmentPositions) {
-        this.recruitmentPositions.addAll(recruitmentPositions);
-    }
+	public void addRecruitmentPositions(final List<RecruitmentPosition> recruitmentPositions) {
+		this.recruitmentPositions.addAll(recruitmentPositions);
+	}
 
-    public void edit(
-            final String title,
-            final Contact contact,
-            final String callUrl,
-            final Integer applicantCount,
-            final LocalDateTime recruitmentEndDateTime,
-            final String content
-    ) {
-        if (title != null) {
-            this.title = title;
-        }
-        if (contact != null) {
-            this.contact = contact;
-        }
-        if (callUrl != null) {
-            this.callUrl = callUrl;
-        }
-        if (applicantCount != null) {
-            this.applicantCount = applicantCount;
-        }
-        if (recruitmentEndDateTime != null) {
-            this.recruitmentEndDateTime = recruitmentEndDateTime;
-        }
-        if (content != null) {
-            this.content = content;
-        }
-        if (modifiedDateTime != null) {
-            this.modifiedDateTime = LocalDateTime.now();
-        }
-    }
+	public void edit(
+			final String title,
+			final Contact contact,
+			final String callUrl,
+			final Integer applicantCount,
+			final LocalDateTime recruitmentEndDateTime,
+			final String content
+	) {
+		if (title != null) {
+			this.title = title;
+		}
+		if (contact != null) {
+			this.contact = contact;
+		}
+		if (callUrl != null) {
+			this.callUrl = callUrl;
+		}
+		if (applicantCount != null) {
+			this.applicantLimit = applicantCount;
+		}
+		if (recruitmentEndDateTime != null) {
+			this.recruitmentEndDateTime = recruitmentEndDateTime;
+		}
+		if (content != null) {
+			this.content = content;
+		}
+		if (modifiedDateTime != null) {
+			this.modifiedDateTime = LocalDateTime.now();
+		}
+	}
 
-    public Optional<RecruitmentStack> getRecruitmentStack(final Stack stack) {
-        return recruitmentStacks.stream()
-                .filter(r -> r.getStack().equals(stack))
-                .findFirst();
-    }
+	public Optional<RecruitmentStack> getRecruitmentStack(final Stack stack) {
+		return recruitmentStacks.stream()
+				.filter(r -> r.getStack().equals(stack))
+				.findFirst();
+	}
 
-    public Optional<RecruitmentPosition> getRecruitmentPosition(final Position position) {
-        return recruitmentPositions.stream()
-                .filter(r -> r.getPosition().equals(position))
-                .findFirst();
-    }
+	public Optional<RecruitmentPosition> getRecruitmentPosition(final Position position) {
+		return recruitmentPositions.stream()
+				.filter(r -> r.getPosition().equals(position))
+				.findFirst();
+	}
 
-    public void removeRecruitmentStack(final RecruitmentStack recruitmentStack) {
-        recruitmentStacks.remove(recruitmentStack);
-    }
+	public void removeRecruitmentStack(final RecruitmentStack recruitmentStack) {
+		recruitmentStacks.remove(recruitmentStack);
+	}
 
-    public void removeRecruitmentPosition(final RecruitmentPosition recruitmentPosition) {
-        recruitmentPositions.remove(recruitmentPosition);
-    }
+	public void removeRecruitmentPosition(final RecruitmentPosition recruitmentPosition) {
+		recruitmentPositions.remove(recruitmentPosition);
+	}
 
-    public boolean hasStacks(final Stack stack) {
-        return recruitmentStacks.stream()
-                .anyMatch(r -> r.getStack().equals(stack));
-    }
+	public boolean hasStacks(final Stack stack) {
+		return recruitmentStacks.stream()
+				.anyMatch(r -> r.getStack().equals(stack));
+	}
 
-    public boolean hasPosition(final Position position) {
-        return recruitmentPositions.stream()
-                .anyMatch(r -> r.getPosition().equals(position));
-    }
+	public boolean hasPosition(final Position position) {
+		return recruitmentPositions.stream()
+				.anyMatch(r -> r.getPosition().equals(position));
+	}
 
-    public void ensureEditable(final User user) {
-        if (!isOwner(user)) {
-            throw new IllegalArgumentException("모집 공고를 작성할 권한이 없습니다.");
-        }
-    }
+	public void ensureEditable(final User user) {
+		if (!isOwner(user)) {
+			throw new IllegalArgumentException("모집 공고를 작성할 권한이 없습니다.");
+		}
+	}
 
-    public void ensureApplicable(final User user) {
-        if (study.isOwner(user)) {
-            throw new IllegalArgumentException("스터디장은 자신의 스터디에 지원할 수 없습니다.");
-        }
-        applicants.stream()
-                .filter(a -> a.equals(user))
-                .findFirst()
-                .ifPresent(Applicant::ensureApplicable);
-    }
+	public void ensureApplicable(final User user) {
+		if (study.isOwner(user)) {
+			throw new IllegalArgumentException("스터디장은 자신의 스터디에 지원할 수 없습니다.");
+		}
+		applicants.stream()
+				.filter(a -> a.equals(user))
+				.findFirst()
+				.ifPresent(Applicant::ensureApplicable);
+	}
 
-    public Optional<Applicant> findApplicant(final User user) {
-        return applicants.stream()
-                .filter(a -> a.getUser().equals(user))
-                .findFirst();
-    }
+	public Optional<Applicant> findApplicant(final User user) {
+		return applicants.stream()
+				.filter(a -> a.getUser().equals(user))
+				.findFirst();
+	}
 
-    public boolean isOwner(final User user) {
-        return study.isOwner(user);
-    }
+	public boolean isOwner(final User user) {
+		return study.isOwner(user);
+	}
 
-    /**
-     * helper method
-     */
-    public void addApplicant(final Applicant applicant) {
-        applicant.connectToRecruitment(this);
-        applicants.add(applicant);
-    }
+	/**
+	 * helper method
+	 */
+	public void addApplicant(final Applicant applicant) {
+		applicant.connectToRecruitment(this);
+		applicants.add(applicant);
+	}
 
-    public void ensureRecruiting() {
-        study.ensureRecruiting();
-    }
+	public void ensureRecruiting() {
+		study.ensureRecruiting();
+	}
 
-    public List<Stack> getAddedStacks(final Set<Stack> nextStacks) {
-        final List<Stack> stacks = getStacks();
+	public List<Stack> getAddedStacks(final Set<Stack> nextStacks) {
+		final List<Stack> stacks = getStacks();
 
-        return nextStacks.stream()
-                .filter(nextStack -> !stacks.contains(nextStack))
-                .toList();
-    }
+		return nextStacks.stream()
+				.filter(nextStack -> !stacks.contains(nextStack))
+				.toList();
+	}
 
-    public List<Position> getAddedPositions(final Set<Position> nextPositions) {
-        final List<Position> prevPositions = getPositions();
+	public List<Position> getAddedPositions(final Set<Position> nextPositions) {
+		final List<Position> prevPositions = getPositions();
 
-        return nextPositions.stream()
-                .filter(nextPosition -> !prevPositions.contains(nextPosition))
-                .toList();
-    }
+		return nextPositions.stream()
+				.filter(nextPosition -> !prevPositions.contains(nextPosition))
+				.toList();
+	}
 
-    public List<Position> getPositions() {
-        return recruitmentPositions.stream()
-                .map(RecruitmentPosition::getPosition)
-                .toList();
-    }
+	public List<Position> getPositions() {
+		return recruitmentPositions.stream()
+				.map(RecruitmentPosition::getPosition)
+				.toList();
+	}
 
-    public void removeRecruitmentPositionsNotIn(final Set<Position> nextPositions) {
-        final List<Position> prevPositions = getPositions();
+	public void removeRecruitmentPositionsNotIn(final Set<Position> nextPositions) {
+		final List<Position> prevPositions = getPositions();
 
-        for (final Position prevPosition : prevPositions) {
-            if (!nextPositions.contains(prevPosition)) {
-                recruitmentPositions.removeIf(recruitmentPosition -> recruitmentPosition.hasPosition(prevPosition));
-            }
-        }
-    }
+		for (final Position prevPosition : prevPositions) {
+			if (!nextPositions.contains(prevPosition)) {
+				recruitmentPositions.removeIf(recruitmentPosition -> recruitmentPosition.hasPosition(prevPosition));
+			}
+		}
+	}
 
-    public void removeRecruitmentStacksNotIn(final Set<Stack> nextStacks) {
-        final List<Stack> prevStacks = getStacks();
+	public void removeRecruitmentStacksNotIn(final Set<Stack> nextStacks) {
+		final List<Stack> prevStacks = getStacks();
 
-        for (final Stack prevStack : prevStacks) {
-            if (!nextStacks.contains(prevStack)) {
-                recruitmentStacks.removeIf(recruitmentStack -> recruitmentStack.hasStack(prevStack));
-            }
-        }
-    }
+		for (final Stack prevStack : prevStacks) {
+			if (!nextStacks.contains(prevStack)) {
+				recruitmentStacks.removeIf(recruitmentStack -> recruitmentStack.hasStack(prevStack));
+			}
+		}
+	}
 
-    // public List<Stack> removeRecruitmentStacksNotIn(final Set<Stack> nextStacks) {
-    // 	final List<Stack> prevStacks = getStacks();
-    //
-    // 	return prevStacks.stream()
-    // 			.filter(nextStacks::contains)
-    // 			.toList();
-    // }
+	// public List<Stack> removeRecruitmentStacksNotIn(final Set<Stack> nextStacks) {
+	// 	final List<Stack> prevStacks = getStacks();
+	//
+	// 	return prevStacks.stream()
+	// 			.filter(nextStacks::contains)
+	// 			.toList();
+	// }
 
-    public List<Stack> getStacks() {
-        return recruitmentStacks.stream()
-                .map(RecruitmentStack::getStack)
-                .toList();
-    }
+	public List<Stack> getStacks() {
+		return recruitmentStacks.stream()
+				.map(RecruitmentStack::getStack)
+				.toList();
+	}
 
-    public void ensureCorrectApplicantUser(final User applicantUser) {
-        if (!containsApplicantUser(applicantUser)) {
-            throw new IllegalStateException("지원자 목록에 존재하지 않는 사용자입니다.");
-        }
-    }
+	public void ensureCorrectApplicantUser(final User applicantUser) {
+		if (!containsApplicantUser(applicantUser)) {
+			throw new IllegalStateException("지원자 목록에 존재하지 않는 사용자입니다.");
+		}
+	}
 
-    private boolean containsApplicantUser(final User applicantUser) {
-        return applicants.stream()
-                .anyMatch(applicant -> applicant.getUser().equals(applicantUser));
-    }
+	private boolean containsApplicantUser(final User applicantUser) {
+		return applicants.stream()
+				.anyMatch(applicant -> applicant.getUser().equals(applicantUser));
+	}
 
-    public void acceptApplicant(final User applicantUser, final LocalDateTime deletedDateTime) {
-        final Applicant applicant = getApplicant(applicantUser);
-        applicant.changeStatus(ApplicantStatus.ACCEPTED);
-        // 지원자 수락시 소프트 딜리트 추가
-        applicant.softDelete(deletedDateTime);
-    }
+	public void acceptApplicant(final User applicantUser, final LocalDateTime deletedDateTime) {
+		final Applicant applicant = getApplicant(applicantUser);
+		applicant.changeStatus(ApplicantStatus.ACCEPTED);
+		// 지원자 수락시 소프트 딜리트 추가
+		applicant.softDelete(deletedDateTime);
+	}
 
-    public void rejectApplicant(final User applicantUser) {
-        final Applicant applicant = getApplicant(applicantUser);
-        applicant.changeStatus(ApplicantStatus.REFUSED);
-        // 지원자 거절시 소프트 딜리트 제거
-        // applicant.softDelete();
-    }
+	public void rejectApplicant(final User applicantUser) {
+		final Applicant applicant = getApplicant(applicantUser);
+		applicant.changeStatus(ApplicantStatus.REFUSED);
+		// 지원자 거절시 소프트 딜리트 제거
+		// applicant.softDelete();
+	}
 
-    public Applicant getApplicant(final User applicantUser) {
-        ApplicantId applicantId = new ApplicantId(id, applicantUser.getId());
+	public Applicant getApplicant(final User applicantUser) {
+		ApplicantId applicantId = new ApplicantId(id, applicantUser.getId());
 
-        return applicants.stream()
-                .filter(applicant -> applicant.getId().equals(applicantId))
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException("지원하지 않은 사용자입니다."));
-    }
+		return applicants.stream()
+				.filter(applicant -> applicant.getId().equals(applicantId))
+				.findFirst()
+				.orElseThrow(() -> new IllegalStateException("지원하지 않은 사용자입니다."));
+	}
 
-    public boolean isIdEquals(final Long recruitmentId) {
-        return Objects.equals(this.id, recruitmentId);
-    }
+	public boolean isIdEquals(final Long recruitmentId) {
+		return Objects.equals(this.id, recruitmentId);
+	}
 
-    public void validateDuplicatePositions(final List<Position> positions) {
-        final boolean isDuplicatePosition = this.recruitmentPositions.stream()
-                .anyMatch(r -> positions.contains(r.getPosition()));
-        if (isDuplicatePosition) {
-            throw new IllegalArgumentException("이미 존재하는 포지션입니다.");
-        }
-    }
+	public void validateDuplicatePositions(final List<Position> positions) {
+		final boolean isDuplicatePosition = this.recruitmentPositions.stream()
+				.anyMatch(r -> positions.contains(r.getPosition()));
+		if (isDuplicatePosition) {
+			throw new IllegalArgumentException("이미 존재하는 포지션입니다.");
+		}
+	}
 
-    public void validateDuplicateStacks(final List<Stack> stacks) {
-        final boolean isDuplicateStack = this.recruitmentStacks.stream()
-                .anyMatch(r -> stacks.contains(r.getStack()));
-        if (isDuplicateStack) {
-            throw new IllegalArgumentException("이미 존재하는 스택입니다.");
-        }
-    }
+	public void validateDuplicateStacks(final List<Stack> stacks) {
+		final boolean isDuplicateStack = this.recruitmentStacks.stream()
+				.anyMatch(r -> stacks.contains(r.getStack()));
+		if (isDuplicateStack) {
+			throw new IllegalArgumentException("이미 존재하는 스택입니다.");
+		}
+	}
 
-    public int getApplicantsCount() {
-        return (int) applicants.stream()
-                .filter(Applicant::isActive)
-                .count();
-    }
+	public int getApplicantsCount() {
+		return (int)applicants.stream()
+				.filter(Applicant::isActive)
+				.count();
+	}
 
 	public Category getCategory() {
 		return this.study.getCategory();

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/StudyStatistics.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/domain/study/StudyStatistics.java
@@ -11,6 +11,7 @@ import com.ludo.study.studymatchingplatform.study.domain.study.attendance.Calend
 import com.ludo.study.studymatchingplatform.study.domain.study.participant.Participant;
 import com.ludo.study.studymatchingplatform.user.domain.user.User;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -32,6 +33,7 @@ import lombok.experimental.SuperBuilder;
 public class StudyStatistics extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "study_statistics_id")
 	private Long id;
 
 	@OneToOne(fetch = LAZY)

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/request/recruitment/EditRecruitmentRequest.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/request/recruitment/EditRecruitmentRequest.java
@@ -30,7 +30,7 @@ public final class EditRecruitmentRequest {
 	private final Set<Long> positionIds;
 
 	@Schema(description = "수정할 모집 최대 인원", requiredMode = REQUIRED)
-	private final Integer applicantCount;
+	private final Integer applicantLimit;
 
 	@Schema(description = "수정할 모집 공고 마감 날짜", requiredMode = REQUIRED)
 	private final LocalDateTime recruitmentEndDateTime;

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/request/recruitment/WriteRecruitmentRequest.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/request/recruitment/WriteRecruitmentRequest.java
@@ -27,7 +27,7 @@ public final class WriteRecruitmentRequest {
 	private final Set<Long> positionIds;
 
 	@Schema(description = "모집 공고 최대 인원", requiredMode = REQUIRED)
-	private final Integer applicantCount;
+	private final Integer applicantLimit;
 
 	@Schema(description = "모집 공고 마감 ISOString", requiredMode = REQUIRED)
 	private final LocalDateTime recruitmentEndDateTime;
@@ -44,7 +44,7 @@ public final class WriteRecruitmentRequest {
 		return Recruitment.builder()
 				.title(title)
 				.content(content)
-				.applicantCount(applicantCount)
+				.applicantLimit(applicantLimit)
 				.recruitmentEndDateTime(recruitmentEndDateTime)
 				.study(study)
 				.contact(contact)

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/recruitment/RecruitmentDetailsResponse.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/recruitment/RecruitmentDetailsResponse.java
@@ -12,7 +12,7 @@ public record RecruitmentDetailsResponse(RecruitmentDetail recruitment,
 										 StudyDetail study
 ) {
 
-	public record RecruitmentDetail(Long id, Integer applicantCount,
+	public record RecruitmentDetail(Long id, Integer applicantCount, Integer applicantLimit,
 									List<PositionDetail> positions, List<StackDetail> stacks,
 									Contact contact, String callUrl, String title, String content,
 									LocalDateTime endDateTime,
@@ -39,9 +39,11 @@ public record RecruitmentDetailsResponse(RecruitmentDetail recruitment,
 	public RecruitmentDetailsResponse(final Recruitment recruitment, final Study study) {
 		this(new RecruitmentDetail(
 						recruitment.getId(),
-						recruitment.getApplicantsCount(), recruitment.getPositions().stream()
-						.map(position -> new PositionDetail(position.getId(), position.getName()))
-						.toList(),
+						recruitment.getApplicantsCount(),
+						recruitment.getApplicantLimit(),
+						recruitment.getPositions().stream()
+								.map(position -> new PositionDetail(position.getId(), position.getName()))
+								.toList(),
 						recruitment.getStacks().stream()
 								.map(stack -> new StackDetail(stack.getId(), stack.getName(),
 										ResourcePath.STACK_IMAGE.getPath() + stack.getImageUrl()))

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/study/StudyResponse.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/dto/response/study/StudyResponse.java
@@ -50,7 +50,7 @@ public record StudyResponse(
 		Integer applicantCount = 0; // 지원자 수
 		if (Boolean.TRUE.equals(study.ensureHasRecruitment())) {
 			final Recruitment recruitment = study.getRecruitment();
-			applicantCount = recruitment.getApplicantCount();
+			applicantCount = recruitment.getApplicantsCount();
 		}
 
 		return StudyResponse.builder()

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentService.java
@@ -98,7 +98,7 @@ public class RecruitmentService {
 				request.getTitle(),
 				request.getContact(),
 				request.getCallUrl(),
-				request.getApplicantCount(),
+				request.getApplicantLimit(),
 				request.getRecruitmentEndDateTime(),
 				request.getContent()
 		);

--- a/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/StudyService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/study/service/study/StudyService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ludo.study.studymatchingplatform.common.utils.UtcDateTimePicker;
 import com.ludo.study.studymatchingplatform.study.domain.recruitment.Recruitment;
@@ -28,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class StudyService {
 
 	private final StudyRepositoryImpl studyRepository;

--- a/src/test/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentServiceTest.java
+++ b/src/test/java/com/ludo/study/studymatchingplatform/study/service/recruitment/RecruitmentServiceTest.java
@@ -973,7 +973,7 @@ class RecruitmentServiceTest {
 				.title("edited text")
 				.contact(Contact.KAKAO)
 				.callUrl("edited callUrl")
-				.applicantCount(3)
+				.applicantLimit(3)
 				.recruitmentEndDateTime(editedRecruitmentEndDateTime)
 				.content("edited content")
 				.build();
@@ -1001,7 +1001,7 @@ class RecruitmentServiceTest {
 				.title("edited text")
 				.contact(Contact.KAKAO)
 				.callUrl("edited callUrl")
-				.applicantCount(3)
+				.applicantLimit(3)
 				.recruitmentEndDateTime(editedRecruitmentEndDateTime)
 				.content("edited content")
 				.build();


### PR DESCRIPTION
## 💡 다음 이슈를 해결했어요.

- [x] 모집공고 Recruitment에서 **모집 인원을 의미**했던 `applicantCount` 변수명을 `applicantLimit` 으로 변경했습니다.
  - [x] 이에 따라, 프로덕션 DB의 컬럼명도 업데이트 하였습니다.
- [x] `모집 공고 상세 조회 API`, `모집 공고 생성 API`, `모집 공고 수정 API` 에서 `applicantCount`가 **현재 지원한 지원자 수**로 혼재되어 사용되는 문제가 있었고, 변수명의 혼동이 있다고 판단하여 변수명을 수정 및 해당 API에 반영했습니다.
- 결론적으로
- `applicantLimit` : 모집 인원
- `applicantCount` : 현재 지원자 수
- 를 의미합니다.

- [x] 스터디 서비스의 @Transactional 누락으로 인해 no-session Lazy Loading Fail 에러 해결 (OSIV - false)
- [x] 모집 공고 수정 엔드포인트의 Path-Variable과 컨트롤러 메서드 파라미터의 Path-Variable이 매핑되어 있지 않아서 발생하는 500 에러 해결 

<br><br>

### ✅ 셀프 체크리스트

- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [ ] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
