### PR TITLE
Fix: Client IP, User Agent 기반 사용자 세부 인증 로직 주석 처리

### DIFF
--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/common/redis/UserDetails.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/common/redis/UserDetails.java
@@ -8,11 +8,13 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @RedisHash(value = "user_details")
+@ToString
 public class UserDetails {
 
 	@Id

--- a/src/main/java/com/ludo/study/studymatchingplatform/auth/common/service/UserDetailsService.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/auth/common/service/UserDetailsService.java
@@ -30,7 +30,9 @@ public class UserDetailsService {
 		final String clientIp = WebUtils.getClientIp(request);
 		final UserDetails userDetails =
 				new UserDetails(user.getId(), userAgent, clientIp, Long.parseLong(refreshExpiresIn));
+		log.info("userDetails = {}", userDetails);
 		userDetailsRepository.save(userDetails);
+		log.info("UserDetailsService.createUserDetails start");
 	}
 
 	public void verifyUserDetails(final Long userId, final HttpServletRequest request) {
@@ -39,10 +41,18 @@ public class UserDetailsService {
 		final String clientIp = WebUtils.getClientIp(request);
 		final UserDetails userDetails = userDetailsRepository.findById(userId)
 				.orElseThrow(() -> new SocialAccountNotFoundException("만료된 사용자 정보 입니다."));
+		log.info("saved userAgent = {}", userDetails.getUserAgent());
+		log.info("saved clientIp = {}", userDetails.getClientIp());
+		log.info("requested userAgent = {}", userAgent);
+		log.info("requested clientIp = {}", clientIp);
+		validateUserDetails(userDetails, userAgent, clientIp);
+		log.info("UserDetailsService.verifyUserDetails end");
+	}
+
+	private void validateUserDetails(UserDetails userDetails, String userAgent, String clientIp) {
 		if (!userDetails.getUserAgent().equals(userAgent) || !userDetails.getClientIp().equals(clientIp)) {
 			throw new AuthenticationException("검증되지 않은 사용자 입니다.");
 		}
-		log.info("UserDetailsService.verifyUserDetails end");
 	}
 
 }

--- a/src/main/java/com/ludo/study/studymatchingplatform/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ludo/study/studymatchingplatform/filter/JwtAuthenticationFilter.java
@@ -51,7 +51,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				Claims claims = jwtTokenProvider.verifyAuthTokenOrThrow(authToken.get());
 				final AuthUserPayload payload = AuthUserPayload.from(claims);
 				// 사용자 agent / ip 검증
-				userDetailsService.verifyUserDetails(payload.getId(), request);
+				// TODO: CloudFlare DNS 로 변경함에 따라, IP 기반 사용자 세부 인증이 힘든 구조임
+				//  CloudFlare 는 CDN 을 분산하여 여러대로 관리하기 때문
+				//  이에 대한 사용자 세부 인증 논의 필요
+				// userDetailsService.verifyUserDetails(payload.getId(), request);
 				request.setAttribute(AUTH_USER_PAYLOAD, payload);
 				// 토큰 갱신
 				accessTokenRefresh(payload.getId(), response);


### PR DESCRIPTION
DNS 호스팅 서비스를 CloudFlare로 이전함에 따라, **IP 기반 사용자 세부 인증이 힘든 구조**입니다.
CloudFlare는 ***CDN을 분산하여 여러대로 관리*** 하고, 이로 인해 ***Client IP가 매 번 달라지기 때문*** 입니다.
이러한 현상은 아래 로그로 확인할 수 있습니다.

**Backend UserDetails Validation Log**
![image](https://github.com/Ludo-SMP/ludo-backend/assets/68291395/a6c15af4-d173-4793-8960-3e0a1998a74e)


**Nginx Access Log**
![image](https://github.com/Ludo-SMP/ludo-backend/assets/68291395/86b35648-9f09-406b-8b3d-006624b533a6)

이를 그림으로 표현하면 아래와 같습니다.
![image](https://github.com/Ludo-SMP/ludo-backend/assets/68291395/b911f52a-07ee-4a28-a96c-5902156bf8b5)

![image](https://github.com/Ludo-SMP/ludo-backend/assets/68291395/6238adce-2ad7-41d1-96f4-b7307caa145a)

따라서, 임시방편으로 Filter 로직의 사용자 세부 인증에 대한 로직을 주석처리하였으며, 이에 대한 사용자 세부 인증 논의가 필요합니다.


<br><br>

## ✅ 셀프 체크리스트

- [O] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [O] 커밋 메세지를 컨벤션에 맞추었습니다.
- [O] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [O] 변경 후 코드는 기존의 테스트를 통과합니다.
- [O] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [O] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
